### PR TITLE
feat: add remove invisibles helper

### DIFF
--- a/emailbot/extraction.py
+++ b/emailbot/extraction.py
@@ -55,15 +55,26 @@ def sample_preview(items, k: int) -> list[str]:
     return random.sample(lst, k)
 
 
+def remove_invisibles(text: str) -> str:
+    """Remove zero-width and similar invisible characters.
+
+    Currently strips soft hyphens (\u00ad), non-breaking hyphens (\u2011),
+    zero-width spaces (\u200b) and converts non-breaking spaces (\xa0) to
+    regular spaces.
+    """
+    if not text:
+        return ""
+    s = text
+    s = s.replace("\u00ad", "").replace("\u2011", "").replace("\u200b", "")
+    s = s.replace("\xa0", " ")
+    return s
+
+
 # ---------------- Предобработка текста ----------------
 def _preclean_text_for_emails(text: str) -> str:
     if not text:
         return ""
-    s = text
-
-    # убираем невидимые
-    s = s.replace("\u00ad", "").replace("\u2011", "").replace("\u200b", "")
-    s = s.replace("\xa0", " ")
+    s = remove_invisibles(text)
 
     # защита от прилипания односимвольных маркеров перед email
     s = re.sub(
@@ -282,10 +293,7 @@ async def async_extract_emails_from_url(
 def _remove_invisibles_keep_newlines(text: str) -> str:
     if not text:
         return ""
-    s = text
-    s = s.replace("\u00ad", "").replace("\u2011", "").replace("\u200b", "")
-    s = s.replace("\xa0", " ")
-    return s
+    return remove_invisibles(text)
 
 
 def find_prefix_repairs(raw_text: str) -> List[tuple[str, str]]:

--- a/tests/test_email_functions.py
+++ b/tests/test_email_functions.py
@@ -5,12 +5,12 @@ import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-import email_bot
+import emailbot.extraction as extraction
 
 
 def test_preclean_merges_hyphen_newlines_and_spaces():
     raw = "user-\nname @ example. c o m"
-    assert email_bot._preclean_text_for_emails(raw) == "username@example.com"
+    assert extraction._preclean_text_for_emails(raw) == "username@example.com"
 
 
 def test_extract_clean_emails_handles_variants_and_truncations():
@@ -21,7 +21,7 @@ def test_extract_clean_emails_handles_variants_and_truncations():
         "Vilena\n33 @mail. r u"
     )
     expected = {"username@example.com", "john@example.com", "vilena33@mail.ru"}
-    assert email_bot.extract_clean_emails_from_text(text) == expected
+    assert extraction.extract_clean_emails_from_text(text) == expected
 
 
 @pytest.mark.parametrize(
@@ -33,13 +33,18 @@ def test_extract_clean_emails_handles_variants_and_truncations():
     ],
 )
 def test_detect_numeric_truncations(candidates, expected):
-    assert sorted(email_bot.detect_numeric_truncations(candidates)) == sorted(expected)
+    assert sorted(extraction.detect_numeric_truncations(candidates)) == sorted(expected)
 
 
 def test_find_prefix_repairs_detects_cases():
     raw = "M\norgachov-ilya@yandex.ru\nVilena\n33 @mail.ru"
-    pairs = email_bot.find_prefix_repairs(raw)
+    pairs = extraction.find_prefix_repairs(raw)
     assert set(pairs) == {
         ("orgachov-ilya@yandex.ru", "morgachov-ilya@yandex.ru"),
         ("33@mail.ru", "vilena33@mail.ru"),
     }
+
+
+def test_remove_invisibles_strips_zero_width_and_nbsp():
+    raw = "a\u00adb\u2011c\u200b\xa0d"
+    assert extraction.remove_invisibles(raw) == "abc d"


### PR DESCRIPTION
## Summary
- add `remove_invisibles` helper
- use helper in text pre-cleaning routines
- update email extraction tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b207c6a7ac8326893a2e2838c33969