### PR TITLE
Use root templates and expand manual email parsing

### DIFF
--- a/emailbot/messaging.py
+++ b/emailbot/messaging.py
@@ -23,12 +23,15 @@ from .extraction import normalize_email, strip_html
 
 logger = logging.getLogger(__name__)
 
-SCRIPT_DIR = Path(__file__).resolve().parent
+# Resolve the project root (one level above this file) and use shared
+# directories located at the repository root.
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
 DOWNLOAD_DIR = str(SCRIPT_DIR / "downloads")
 LOG_FILE = str(SCRIPT_DIR / "sent_log.csv")
 BLOCKED_FILE = str(SCRIPT_DIR / "blocked_emails.txt")
 MAX_EMAILS_PER_DAY = 200
 
+# HTML templates are stored at the root-level ``templates`` directory.
 TEMPLATES_DIR = str(SCRIPT_DIR / "templates")
 TEMPLATE_MAP = {
     "спорт": os.path.join(TEMPLATES_DIR, "sport.htm"),
@@ -121,7 +124,8 @@ def build_message(
     msg["List-Unsubscribe"] = f"<mailto:{EMAIL_ADDRESS}?subject=unsubscribe>"
     msg["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
     msg.set_content(text_body)
-    msg.add_alternative(html_body, subtype="html")
+    # Attach the HTML version explicitly as ``text/html``.
+    msg.add_alternative(html_body, maintype="text", subtype="html")
     logo_path = SCRIPT_DIR / "Logo.png"
     if logo_path.exists():
         try:

--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -105,7 +105,6 @@ def test_handle_text_manual_emails():
 
     run(handle_text(update, ctx))
 
-    state = ctx.chat_data[SESSION_KEY]
-    assert state.manual_emails == ["1test@site.com", "user@example.com"]
+    assert ctx.user_data["manual_emails"] == ["1test@site.com", "user@example.com"]
     assert ctx.user_data["awaiting_manual_email"] is False
     assert "К отправке: 1test@site.com, user@example.com" in update.message.replies[0]


### PR DESCRIPTION
## Summary
- Load sport, tourism and medicine templates from the root-level `templates/` directory and attach the HTML part as `text/html`
- Relax manual email entry parsing: extract with `extract_emails_loose`, allow only `.ru`/`.com` domains, store normalized addresses in `context.user_data`
- Remove `manual_emails` from session state and clear user-provided emails on reset

## Testing
- `python -m py_compile email_bot.py emailbot/bot_handlers.py emailbot/messaging.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2d9fbb51c832699b3929081cde7e2