### PR TITLE
Fix provider email normalization

### DIFF
--- a/emailbot/extraction.py
+++ b/emailbot/extraction.py
@@ -136,9 +136,9 @@ def _preclean_text_for_emails(text: str) -> str:
     s = _RX_DOT_COM.sub(".com", s)
     s = _RX_DOT_RU.sub(".ru", s)
 
-    # '@gmail.co' → '.com' (и др. провайдеры)
-    s = _RX_PROV1.sub(r"@\1.com", s)
-    s = _RX_PROV2.sub(r"@\1.com", s)
+    # '@gmail.co' → '@gmail.com' (и др. провайдеры)
+    s = _RX_PROV1.sub(r"\1m", s)
+    s = _RX_PROV2.sub(r"\1m", s)
 
     # разделим «слипшийся хвост» после .ru/.com
     s = _RX_SUFFIX.sub(r"\1 ", s)

--- a/tests/test_email_functions.py
+++ b/tests/test_email_functions.py
@@ -16,6 +16,10 @@ def test_preclean_merges_hyphen_newlines_and_spaces():
     assert extraction._preclean_text_for_emails(raw) == "username@example.com"
 
 
+def test_preclean_keeps_common_provider_email():
+    assert extraction._preclean_text_for_emails("user@gmail.com") == "user@gmail.com"
+
+
 def test_extract_clean_emails_handles_variants_and_truncations():
     text = (
         "user-\nname @ example. c o m\n"
@@ -25,6 +29,12 @@ def test_extract_clean_emails_handles_variants_and_truncations():
     )
     expected = {"username@example.com", "john@example.com", "vilena33@mail.ru"}
     assert extraction.extract_clean_emails_from_text(text) == expected
+
+
+def test_extract_clean_emails_from_text_allows_provider_email():
+    assert extraction.extract_clean_emails_from_text("Contact: user@gmail.com") == {
+        "user@gmail.com"
+    }
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- fix cleanup of common email providers to avoid duplicating `@` and `.com`
- test pre-cleaning and extraction for provider addresses like gmail

## Testing
- `pre-commit run --files emailbot/extraction.py tests/test_email_functions.py` *(fails: `fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403`)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b3047bed2083268bf013d6b34bf4f6