### PR TITLE
Clear stale manual emails when prompting again

### DIFF
--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -587,6 +587,7 @@ async def prompt_manual_email(update: Update, context: ContextTypes.DEFAULT_TYPE
     """Ask the user to enter e-mail addresses manually."""
 
     clear_all_awaiting(context)
+    context.user_data.pop("manual_emails", None)
     await update.message.reply_text(
         "Введите email или список email-адресов (через запятую/пробел/с новой строки):"
     )

--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -125,6 +125,19 @@ def test_handle_text_manual_emails():
     assert "К отправке: 1test@site.com, user@example.com" in update.message.replies[0]
 
 
+def test_prompt_manual_email_clears_previous_list():
+    update = DummyUpdate(text="/manual")
+    ctx = DummyContext()
+    ctx.user_data["manual_emails"] = ["old@example.com"]
+    ctx.user_data["awaiting_block_email"] = True
+
+    run(bh.prompt_manual_email(update, ctx))
+
+    assert "manual_emails" not in ctx.user_data
+    assert ctx.user_data["awaiting_manual_email"] is True
+    assert ctx.user_data.get("awaiting_block_email") is False
+
+
 def test_select_group_sets_html_template():
     update = DummyUpdate(callback_data="group_спорт")
     ctx = DummyContext()


### PR DESCRIPTION
## Summary
- Reset any previously stored manual addresses when prompting for manual email entry
- Add regression test for manual prompt clearing

## Testing
- `pre-commit run --files emailbot/bot_handlers.py tests/test_bot_handlers.py` *(fails: CONNECT tunnel failed, response 403)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b32f1870d483268f5b7e67faa3a6d7