### PR TITLE
feat: allow manual emails despite recent history

### DIFF
--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -817,7 +817,6 @@ async def send_manual_email(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         await query.message.reply_text("❗ Список email пуст.")
         return
 
-    lookup_days = int(os.getenv("EMAIL_LOOKBACK_DAYS", "180"))
     blocked = get_blocked_emails()
     sent_today = get_sent_today()
 
@@ -835,13 +834,11 @@ async def send_manual_email(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     for e in emails:
         if e in blocked or e in sent_today:
             continue
-        if was_emailed_recently(e, lookup_days, imap=imap, folder=sent_folder):
-            continue
         to_send.append(e)
 
     if not to_send:
         await query.message.reply_text(
-            "❗ Все адреса уже есть в истории за 6 мес. или в блок-листе."
+            "❗ Все адреса уже есть в блок-листе или отправлены сегодня."
         )
         context.user_data["manual_emails"] = []
         imap.logout()


### PR DESCRIPTION
## Summary
- allow manual emails to bypass 6‑month history check

## Testing
- `pytest`
- `pre-commit run --files emailbot/bot_handlers.py` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*


------
https://chatgpt.com/codex/tasks/task_e_68b352e3c4f48326939ab274b6eeda2f