### PR TITLE
Fix HTML alternative attachment

### DIFF
--- a/emailbot/messaging.py
+++ b/emailbot/messaging.py
@@ -144,7 +144,7 @@ def build_message(
     msg["List-Unsubscribe-Post"] = "List-Unsubscribe=One-Click"
     msg.set_content(text_body)
     # Attach the HTML version explicitly as ``text/html``.
-    msg.add_alternative(html_body, maintype="text", subtype="html")
+    msg.add_alternative(html_body, subtype="html")
     logo_path = SCRIPT_DIR / "Logo.png"
     if logo_path.exists():
         try:

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -77,3 +77,15 @@ def test_log_sent_email_records_entries(temp_files):
     assert len(rows) == 2
     assert rows[0][1:4] == ["user@example.com", "group1", "ok"]
     assert rows[1][3] == "error" and rows[1][6] == "boom"
+
+
+def test_build_message_adds_html_alternative(tmp_path, monkeypatch):
+    html_file = tmp_path / "template.html"
+    html_file.write_text("<html><body>Hello</body></html>", encoding="utf-8")
+    monkeypatch.setattr(messaging, "EMAIL_ADDRESS", "sender@example.com")
+    msg = messaging.build_message(
+        "recipient@example.com", str(html_file), "Subject"
+    )
+    html_part = msg.get_body("html")
+    assert html_part is not None
+    assert "Hello" in html_part.get_content()


### PR DESCRIPTION
## Summary
- drop unsupported `maintype` argument when attaching HTML alternative
- add regression test to ensure HTML part is included in built messages

## Testing
- `pre-commit run --files emailbot/messaging.py tests/test_messaging.py` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b364b2cfa08326a6c7b3ff56051028