### PR TITLE
Improve IMAP robustness and blocked list handling

### DIFF
--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -963,7 +963,14 @@ async def send_manual_email(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         clear_recent_sent_cache()
         disable_force_send(chat_id)
 
-    asyncio.create_task(long_job())
+    async def _run_long_job():
+        try:
+            await long_job()
+        except Exception as e:
+            log_error(f"send_manual_email: {e}")
+            await query.message.reply_text(f"❌ Ошибка: {e}")
+
+    asyncio.create_task(_run_long_job())
 
 
 async def send_all(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -1069,12 +1076,19 @@ async def send_all(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         clear_recent_sent_cache()
         disable_force_send(chat_id)
 
-    asyncio.create_task(long_job())
+    async def _run_long_job():
+        try:
+            await long_job()
+        except Exception as e:
+            log_error(f"send_all: {e}")
+            await query.message.reply_text(f"❌ Ошибка: {e}")
+
+    asyncio.create_task(_run_long_job())
 
 
 async def autosync_imap_with_message(query: CallbackQuery) -> None:
     """Synchronize IMAP logs and notify the user via message."""
-
+    await query.answer()
     await query.message.reply_text(
         "🔄 Синхронизация истории отправки с сервером..."
     )


### PR DESCRIPTION
## Summary
- validate and select IMAP sent folder with fallback
- guard background tasks and log errors
- normalize and dedupe blocked emails

## Testing
- `pre-commit run --files emailbot/messaging.py emailbot/bot_handlers.py` *(failed: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b40d592a6c8326a2b0427445bd5a1e