### PR TITLE
Log background task errors and notify users

### DIFF
--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -963,14 +963,7 @@ async def send_manual_email(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         clear_recent_sent_cache()
         disable_force_send(chat_id)
 
-    async def _run_long_job():
-        try:
-            await long_job()
-        except Exception as e:
-            log_error(f"send_manual_email: {e}")
-            await query.message.reply_text(f"❌ Ошибка: {e}")
-
-    asyncio.create_task(_run_long_job())
+    messaging.create_task_with_logging(long_job(), query.message.reply_text)
 
 
 async def send_all(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -1076,14 +1069,7 @@ async def send_all(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         clear_recent_sent_cache()
         disable_force_send(chat_id)
 
-    async def _run_long_job():
-        try:
-            await long_job()
-        except Exception as e:
-            log_error(f"send_all: {e}")
-            await query.message.reply_text(f"❌ Ошибка: {e}")
-
-    asyncio.create_task(_run_long_job())
+    messaging.create_task_with_logging(long_job(), query.message.reply_text)
 
 
 async def autosync_imap_with_message(query: CallbackQuery) -> None:


### PR DESCRIPTION
## Summary
- wrap background tasks in a helper that logs exceptions and sends a short error message
- use the helper for sending operations to avoid swallowing exceptions
- log asynchronous send failures

## Testing
- `pytest`
- simulated failing background task shows traceback and user notification

------
https://chatgpt.com/codex/tasks/task_e_68b441853b38832690f3267fd1560d38