### PR TITLE
style: auto-format and lint fixes (isort, black, ruff)

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -15,8 +15,8 @@ from telegram.ext import (
     filters,
 )
 
+from emailbot import bot_handlers, messaging
 from emailbot.utils import load_env, setup_logging
-from emailbot import messaging, bot_handlers
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 
@@ -41,34 +41,50 @@ def main() -> None:
         MessageHandler(filters.TEXT & filters.Regex("^📤"), bot_handlers.prompt_upload)
     )
     app.add_handler(
-        MessageHandler(filters.TEXT & filters.Regex("^🧹"), bot_handlers.reset_email_list)
+        MessageHandler(
+            filters.TEXT & filters.Regex("^🧹"), bot_handlers.reset_email_list
+        )
     )
     app.add_handler(
         MessageHandler(filters.TEXT & filters.Regex("^🧾"), bot_handlers.about_bot)
     )
     app.add_handler(
-        MessageHandler(filters.TEXT & filters.Regex("^🚫"), bot_handlers.add_block_prompt)
+        MessageHandler(
+            filters.TEXT & filters.Regex("^🚫"), bot_handlers.add_block_prompt
+        )
     )
     app.add_handler(
-        MessageHandler(filters.TEXT & filters.Regex("^📄"), bot_handlers.show_blocked_list)
+        MessageHandler(
+            filters.TEXT & filters.Regex("^📄"), bot_handlers.show_blocked_list
+        )
     )
     app.add_handler(
-        MessageHandler(filters.TEXT & filters.Regex("^✉️"), bot_handlers.prompt_manual_email)
+        MessageHandler(
+            filters.TEXT & filters.Regex("^✉️"), bot_handlers.prompt_manual_email
+        )
     )
     app.add_handler(
-        MessageHandler(filters.TEXT & filters.Regex("^🧭"), bot_handlers.prompt_change_group)
+        MessageHandler(
+            filters.TEXT & filters.Regex("^🧭"), bot_handlers.prompt_change_group
+        )
     )
     app.add_handler(
         MessageHandler(filters.TEXT & filters.Regex("^📈"), bot_handlers.report_command)
     )
     app.add_handler(
-        MessageHandler(filters.TEXT & filters.Regex("^📁"), bot_handlers.imap_folders_command)
+        MessageHandler(
+            filters.TEXT & filters.Regex("^📁"), bot_handlers.imap_folders_command
+        )
     )
     app.add_handler(
-        MessageHandler(filters.TEXT & filters.Regex("^🔄"), bot_handlers.sync_imap_command)
+        MessageHandler(
+            filters.TEXT & filters.Regex("^🔄"), bot_handlers.sync_imap_command
+        )
     )
     app.add_handler(
-        MessageHandler(filters.TEXT & filters.Regex("^🚀"), bot_handlers.force_send_command)
+        MessageHandler(
+            filters.TEXT & filters.Regex("^🚀"), bot_handlers.force_send_command
+        )
     )
 
     app.add_handler(MessageHandler(filters.Document.ALL, bot_handlers.handle_document))
@@ -82,11 +98,13 @@ def main() -> None:
     app.add_handler(
         CallbackQueryHandler(bot_handlers.proceed_to_group, pattern="^proceed_group$")
     )
+    app.add_handler(CallbackQueryHandler(bot_handlers.select_group, pattern="^group_"))
     app.add_handler(
-        CallbackQueryHandler(bot_handlers.select_group, pattern="^group_")
+        CallbackQueryHandler(bot_handlers.send_all, pattern="^start_sending")
     )
-    app.add_handler(CallbackQueryHandler(bot_handlers.send_all, pattern="^start_sending"))
-    app.add_handler(CallbackQueryHandler(bot_handlers.report_callback, pattern="^report_"))
+    app.add_handler(
+        CallbackQueryHandler(bot_handlers.report_callback, pattern="^report_")
+    )
     app.add_handler(
         CallbackQueryHandler(bot_handlers.show_numeric_list, pattern="^show_numeric$")
     )

--- a/emailbot/__init__.py
+++ b/emailbot/__init__.py
@@ -1,8 +1,8 @@
 """Helpers for the email bot."""
 
-from .utils import load_env, setup_logging, log_error
+from . import bot_handlers, extraction, messaging
 from .smtp_client import SmtpClient
-from . import extraction, messaging, bot_handlers
+from .utils import load_env, log_error, setup_logging
 
 __all__ = [
     "load_env",

--- a/emailbot/smtp_client.py
+++ b/emailbot/smtp_client.py
@@ -1,12 +1,14 @@
-import ssl
 import smtplib
+import ssl
 from typing import Optional
 
 
 class SmtpClient:
     """Simple SMTP client with context manager support."""
 
-    def __init__(self, host: str, port: int, username: str, password: str, use_ssl: bool = True):
+    def __init__(
+        self, host: str, port: int, username: str, password: str, use_ssl: bool = True
+    ):
         self.host = host
         self.port = port
         self.username = username

--- a/emailbot/utils.py
+++ b/emailbot/utils.py
@@ -1,6 +1,6 @@
 import logging
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 
 from dotenv import load_dotenv
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203
+exclude = .git,__pycache__,venv,env

--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -1,16 +1,21 @@
-import sys
-from pathlib import Path
-import types
 import asyncio
 import logging
+import sys
+import types
+from pathlib import Path
 
-import pytest
 from telegram import InlineKeyboardMarkup
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import emailbot.bot_handlers as bh
-from emailbot.bot_handlers import start, handle_document, handle_text, SESSION_KEY, SessionState
+from emailbot.bot_handlers import (
+    SESSION_KEY,
+    SessionState,
+    handle_document,
+    handle_text,
+    start,
+)
 
 
 class DummyFile:
@@ -50,6 +55,7 @@ class DummyUpdate:
         self.message = DummyMessage(text=text, document=document, chat_id=chat_id)
         self.effective_chat = types.SimpleNamespace(id=chat_id)
         if callback_data is not None:
+
             class DummyQuery:
                 def __init__(self, data, chat_id):
                     self.data = data
@@ -90,8 +96,14 @@ def test_handle_document_processes_file(monkeypatch, tmp_path):
         "extract_from_uploaded_file",
         lambda path: ({"good@example.com", "123@site.com"}, {"foreign@example.de"}),
     )
-    monkeypatch.setattr(bh, "collect_repairs_from_files", lambda files: [("bad@example.com", "good@example.com")])
-    monkeypatch.setattr(bh, "apply_numeric_truncation_removal", lambda allowed: (allowed, []))
+    monkeypatch.setattr(
+        bh,
+        "collect_repairs_from_files",
+        lambda files: [("bad@example.com", "good@example.com")],
+    )
+    monkeypatch.setattr(
+        bh, "apply_numeric_truncation_removal", lambda allowed: (allowed, [])
+    )
     monkeypatch.setattr(bh, "sample_preview", lambda items, k: list(items)[:k])
 
     run(handle_document(update, ctx))
@@ -120,7 +132,9 @@ def test_handle_text_add_block(monkeypatch):
 
 
 def test_handle_text_manual_emails():
-    update = DummyUpdate(text="User@example.com support@support.com 123@site.com 1test@site.com")
+    update = DummyUpdate(
+        text="User@example.com support@support.com 123@site.com 1test@site.com"
+    )
     ctx = DummyContext()
     ctx.user_data["awaiting_manual_email"] = True
 
@@ -186,7 +200,9 @@ def test_send_manual_email_uses_html_template(monkeypatch):
             return False
 
     monkeypatch.setattr(bh, "SmtpClient", lambda *a, **k: DummyClient())
-    monkeypatch.setattr(bh, "imaplib", types.SimpleNamespace(IMAP4_SSL=lambda *a, **k: DummyImap()))
+    monkeypatch.setattr(
+        bh, "imaplib", types.SimpleNamespace(IMAP4_SSL=lambda *a, **k: DummyImap())
+    )
     monkeypatch.setattr(bh, "send_email_with_sessions", fake_send)
     monkeypatch.setattr(bh, "get_blocked_emails", lambda: set())
     monkeypatch.setattr(bh, "get_sent_today", lambda: set())

--- a/tests/test_email_functions.py
+++ b/tests/test_email_functions.py
@@ -1,10 +1,10 @@
+import asyncio
 import sys
 from pathlib import Path
 
-import asyncio
 import aiohttp
-from aiohttp import web
 import pytest
+from aiohttp import web
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -67,7 +67,7 @@ def test_is_allowed_tld_accepts_com_and_subdomain():
     expected = "com" in extraction.ALLOWED_TLDS
     assert extraction.is_allowed_tld("user@mail.google.com") == expected
     assert extraction.is_allowed_tld("user@domain.com,") == expected
-    assert extraction.is_allowed_tld("user@domain.com\u00A0") == expected
+    assert extraction.is_allowed_tld("user@domain.com\u00a0") == expected
 
 
 def _run_async(coro):

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -1,7 +1,7 @@
 import csv
 import sys
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 
 import pytest
 
@@ -16,12 +16,16 @@ def fake_smtp(monkeypatch):
     class DummySmtp:
         def __init__(self, *a, **kw):
             pass
+
         def __enter__(self):
             return self
+
         def __exit__(self, exc_type, exc, tb):
             pass
+
         def send(self, *a, **kw):
             pass
+
     monkeypatch.setattr(messaging, "SmtpClient", DummySmtp)
 
 
@@ -56,14 +60,16 @@ def test_add_blocked_email_handles_duplicates_and_invalid(temp_files):
 def test_dedupe_blocked_file_removes_duplicates_and_variants(temp_files):
     blocked, _ = temp_files
     blocked.write_text(
-        "\n".join([
-            "john@example.com",
-            "John@example.com",
-            "1john@example.com",
-            "2john@example.com",
-            "1jane@example.com",
-            "1john@example.com",
-        ])
+        "\n".join(
+            [
+                "john@example.com",
+                "John@example.com",
+                "1john@example.com",
+                "2john@example.com",
+                "1jane@example.com",
+                "1john@example.com",
+            ]
+        )
         + "\n"
     )
     messaging.dedupe_blocked_file()
@@ -91,9 +97,7 @@ def test_build_message_adds_html_alternative(tmp_path, monkeypatch):
     html_file = tmp_path / "template.html"
     html_file.write_text("<html><body>Hello</body></html>", encoding="utf-8")
     monkeypatch.setattr(messaging, "EMAIL_ADDRESS", "sender@example.com")
-    msg = messaging.build_message(
-        "recipient@example.com", str(html_file), "Subject"
-    )
+    msg = messaging.build_message("recipient@example.com", str(html_file), "Subject")
     html_part = msg.get_body("html")
     assert html_part is not None
     assert "Hello" in html_part.get_content()


### PR DESCRIPTION
## Summary
- run isort and black across project
- drop unused imports flagged by ruff
- add flake8 config for line length 88 and ignore E203

## Testing
- `ruff check .`
- `flake8 .` *(fails: command not found)*
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b46022c5c88326b5ddca1d1f769726