### PR TITLE
Add signature and unsubscribe flow

### DIFF
--- a/emailbot/__init__.py
+++ b/emailbot/__init__.py
@@ -1,6 +1,6 @@
 """Helpers for the email bot."""
 
-from . import bot_handlers, extraction, messaging
+from . import bot_handlers, extraction, messaging, unsubscribe
 from .smtp_client import SmtpClient
 from .utils import load_env, log_error, setup_logging
 
@@ -12,4 +12,5 @@ __all__ = [
     "extraction",
     "messaging",
     "bot_handlers",
+    "unsubscribe",
 ]

--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -1010,10 +1010,17 @@ async def send_manual_email(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         ) as client:
             for email_addr in to_send:
                 try:
-                    send_email_with_sessions(
+                    token = send_email_with_sessions(
                         client, imap, sent_folder, email_addr, template_path
                     )
-                    log_sent_email(email_addr, group_code, "ok", chat_id, template_path)
+                    log_sent_email(
+                        email_addr,
+                        group_code,
+                        "ok",
+                        chat_id,
+                        template_path,
+                        unsubscribe_token=token,
+                    )
                     sent_count += 1
                     await asyncio.sleep(1.5)
                 except Exception as e:
@@ -1121,10 +1128,17 @@ async def send_all(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         ) as client:
             for email_addr in emails_to_send:
                 try:
-                    send_email_with_sessions(
+                    token = send_email_with_sessions(
                         client, imap, sent_folder, email_addr, template_path
                     )
-                    log_sent_email(email_addr, group_code, "ok", chat_id, template_path)
+                    log_sent_email(
+                        email_addr,
+                        group_code,
+                        "ok",
+                        chat_id,
+                        template_path,
+                        unsubscribe_token=token,
+                    )
                     sent_count += 1
                     await asyncio.sleep(1.5)
                 except Exception as e:

--- a/emailbot/unsubscribe.py
+++ b/emailbot/unsubscribe.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from aiohttp import web
+
+from .messaging import verify_unsubscribe_token, mark_unsubscribed
+
+
+async def handle(request: web.Request) -> web.Response:
+    email = request.query.get("email", "")
+    token = request.query.get("token", "")
+    if request.method == "POST":
+        data = await request.post()
+        email = data.get("email", "")
+        token = data.get("token", "")
+        if verify_unsubscribe_token(email, token):
+            mark_unsubscribed(email, token)
+            return web.Response(
+                text="Вы отписаны. Вопросы: med@lanbook.ru",
+                content_type="text/html",
+            )
+        return web.Response(
+            text="Если хотите отписаться — ответьте Unsubscribe или свяжитесь по med@lanbook.ru",
+            content_type="text/html",
+        )
+    if verify_unsubscribe_token(email, token):
+        html = f"""<html><body style='font-family:Arial,sans-serif;'>
+<p>Нажмите кнопку, чтобы подтвердить отписку.</p>
+<form method='post'>
+<input type='hidden' name='email' value='{email}'>
+<input type='hidden' name='token' value='{token}'>
+<button type='submit'>Подтвердить отписку</button>
+</form>
+<p>Вопросы: <a href='mailto:med@lanbook.ru'>med@lanbook.ru</a></p>
+</body></html>"""
+        return web.Response(text=html, content_type="text/html")
+    return web.Response(
+        text="Если хотите отписаться — ответьте Unsubscribe или свяжитесь по med@lanbook.ru",
+        content_type="text/html",
+    )
+
+
+def create_app() -> web.Application:
+    app = web.Application()
+    app.router.add_get("/unsubscribe", handle)
+    app.router.add_post("/unsubscribe", handle)
+    return app

--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -174,6 +174,7 @@ def test_send_manual_email_uses_html_template(monkeypatch):
 
     def fake_send(client, imap, folder, addr, path, *a, **kw):
         sent_paths.append(path)
+        return "tok"
 
     class DummyImap:
         def login(self, *a, **k):


### PR DESCRIPTION
## Summary
- append human-provided signature with inline logo and unsubscribe button
- generate and log unsubscribe tokens and minimal endpoint for confirmations
- track unsubscribe status in logs and handle reply-based unsubscriptions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b47c8f32188326b20d257f332805c4