### PR TITLE
Center logo block above email headings

### DIFF
--- a/templates/medicine.html
+++ b/templates/medicine.html
@@ -11,14 +11,17 @@
   </style>
 </head>
 <body style="margin:0; padding:0; background:#fff;">
-  <!-- Логотип строго над заголовком -->
-  <div style="padding:30px 40px 0 0;">
-    <img src="cid:logo" alt="Логотип Лань" style="float:right; max-width:200px; height:auto;">
+  <!-- Логотип: всегда сверху, центрирован, адаптивный -->
+  <div style="text-align:center; margin: 12px 0 18px;">
+    <img id="lan-logo"
+         src="cid:logo"
+         alt="Издательство Лань"
+         style="display:block; margin:0 auto; max-width:160px; width:25%; height:auto; border:0; line-height:1;" />
   </div>
 
   <!-- Заголовок по центру -->
   <div style="padding: 0 40px;">
-    <h1 style="text-align:center; font-size:28px; font-weight:bold; margin: 16px 0 32px 0; font-family: Arial, sans-serif;">
+    <h1 style="text-align:center; font-size:28px; font-weight:bold; margin:0 0 32px 0; font-family: Arial, sans-serif; line-height:1.2;">
       Издательство Лань разыскивает авторов!
     </h1>
   </div>

--- a/templates/sport.html
+++ b/templates/sport.html
@@ -11,14 +11,17 @@
   </style>
 </head>
 <body style="margin:0; padding:0; background:#fff;">
-  <!-- Логотип -->
-  <div style="padding:30px 40px 0 0;">
-    <img src="cid:logo" alt="Логотип Лань" style="float:right; max-width:200px; height:auto;">
+  <!-- Логотип: всегда сверху, центрирован, адаптивный -->
+  <div style="text-align:center; margin: 12px 0 18px;">
+    <img id="lan-logo"
+         src="cid:logo"
+         alt="Издательство Лань"
+         style="display:block; margin:0 auto; max-width:160px; width:25%; height:auto; border:0; line-height:1;" />
   </div>
 
   <!-- Заголовок по центру -->
   <div style="padding: 0 40px;">
-    <h1 style="text-align:center; font-size:28px; font-weight:bold; margin: 16px 0 32px 0; font-family: Arial, sans-serif;">
+    <h1 style="text-align:center; font-size:28px; font-weight:bold; margin:0 0 32px 0; font-family: Arial, sans-serif; line-height:1.2;">
       Издательство Лань разыскивает авторов!
     </h1>
   </div>

--- a/templates/tourism.html
+++ b/templates/tourism.html
@@ -11,14 +11,17 @@
   </style>
 </head>
 <body style="margin:0; padding:0; background:#fff;">
-  <!-- Логотип -->
-  <div style="padding:30px 40px 0 0;">
-    <img src="cid:logo" alt="Логотип Лань" style="float:right; max-width:200px; height:auto;">
+  <!-- Логотип: всегда сверху, центрирован, адаптивный -->
+  <div style="text-align:center; margin: 12px 0 18px;">
+    <img id="lan-logo"
+         src="cid:logo"
+         alt="Издательство Лань"
+         style="display:block; margin:0 auto; max-width:160px; width:25%; height:auto; border:0; line-height:1;" />
   </div>
 
   <!-- Заголовок по центру -->
   <div style="padding: 0 40px;">
-    <h1 style="text-align:center; font-size:28px; font-weight:bold; margin: 16px 0 32px 0; font-family: Arial, sans-serif;">
+    <h1 style="text-align:center; font-size:28px; font-weight:bold; margin:0 0 32px 0; font-family: Arial, sans-serif; line-height:1.2;">
       Издательство Лань разыскивает авторов!
     </h1>
   </div>


### PR DESCRIPTION
## Summary
- place the inline logo in its own centered block above the main title in all email templates
- ensure titles start immediately after the logo block without floating
- add regression test for repository templates honoring INLINE_LOGO toggle

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4acd979108326822f8f73bc83e5c4