### PR TITLE
Right-align logo above email headings

### DIFF
--- a/templates/medicine.html
+++ b/templates/medicine.html
@@ -11,14 +11,17 @@
   </style>
 </head>
 <body style="margin:0; padding:0; background:#fff;">
-  <!-- Логотип строго над заголовком -->
-  <div style="padding:30px 40px 0 0;">
-    <img src="cid:logo" alt="Логотип Лань" style="float:right; max-width:200px; height:auto;">
+  <!-- Логотип: сверху справа, адаптивный -->
+  <div style="margin: 12px 0 18px;">
+    <img id="lan-logo"
+         src="cid:logo"
+         alt="Издательство Лань"
+         style="display:block; margin:0 0 0 auto; max-width:160px; width:25%; height:auto; border:0; line-height:1;" />
   </div>
 
   <!-- Заголовок по центру -->
   <div style="padding: 0 40px;">
-    <h1 style="text-align:center; font-size:28px; font-weight:bold; margin: 16px 0 32px 0; font-family: Arial, sans-serif;">
+    <h1 style="text-align:center; font-size:28px; font-weight:bold; margin:0 0 32px 0; font-family: Arial, sans-serif; line-height:1.2;">
       Издательство Лань разыскивает авторов!
     </h1>
   </div>

--- a/templates/sport.html
+++ b/templates/sport.html
@@ -11,27 +11,30 @@
   </style>
 </head>
 <body style="margin:0; padding:0; background:#fff;">
-  <!-- Логотип -->
-  <div style="padding:30px 40px 0 0;">
-    <img src="cid:logo" alt="Логотип Лань" style="float:right; max-width:200px; height:auto;">
+  <!-- Логотип: сверху справа, адаптивный -->
+  <div style="margin: 12px 0 18px;">
+    <img id="lan-logo"
+         src="cid:logo"
+         alt="Издательство Лань"
+         style="display:block; margin:0 0 0 auto; max-width:160px; width:25%; height:auto; border:0; line-height:1;" />
   </div>
 
   <!-- Заголовок по центру -->
   <div style="padding: 0 40px;">
-    <h1 style="text-align:center; font-size:28px; font-weight:bold; margin: 16px 0 32px 0; font-family: Arial, sans-serif;">
+    <h1 style="text-align:center; font-size:28px; font-weight:bold; margin:0 0 32px 0; font-family: Arial, sans-serif; line-height:1.2;">
       Издательство Лань разыскивает авторов!
     </h1>
   </div>
 
-  <div style="padding: 0 40px 32px 40px;">
-    <div style="font-size:17px; margin-bottom: 0;">
-      Приглашаем к сотрудничеству талантливых авторов-преподавателей, которые хотят учить студентов по своим учебникам и учебным пособиям!
-    </div>
-    <div style="font-size:17px; margin-bottom: 18px;">
-      В настоящее время мы заинтересованы в издании учебников, учебных пособий и практикумов для вузов и колледжей по следующим дисциплинам:
-    </div>
+    <div style="padding: 0 40px 32px 40px;">
+      <div style="font-size:17px; margin-bottom: 0;">
+        <span>Приглашаем к сотрудничеству талантливых авторов-преподавателей, которые хотят учить студентов по своим учебникам и учебным пособиям!</span>
+      </div>
+      <div style="font-size:17px; margin-bottom: 18px;">
+        <span>В настоящее время мы заинтересованы в издании учебников, учебных пособий и практикумов для вузов и колледжей по следующим дисциплинам:</span>
+      </div>
 
-    <!-- Новый блок направлений и дисциплин -->
+      <!-- Новый блок направлений и дисциплин -->
     <div style="margin-bottom:24px;">
       <div style="font-size:18px; font-weight:bold; margin-top:18px; margin-bottom:6px;">
         49.03.01 Физическая культура 49.03.02 Физическая культура для лиц с отклонениями в состоянии здоровья 49.03.03 Рекреация и спортивно-оздоровительный туризм 49.03.04 Спорт

--- a/templates/tourism.html
+++ b/templates/tourism.html
@@ -11,14 +11,17 @@
   </style>
 </head>
 <body style="margin:0; padding:0; background:#fff;">
-  <!-- Логотип -->
-  <div style="padding:30px 40px 0 0;">
-    <img src="cid:logo" alt="Логотип Лань" style="float:right; max-width:200px; height:auto;">
+  <!-- Логотип: сверху справа, адаптивный -->
+  <div style="margin: 12px 0 18px;">
+    <img id="lan-logo"
+         src="cid:logo"
+         alt="Издательство Лань"
+         style="display:block; margin:0 0 0 auto; max-width:160px; width:25%; height:auto; border:0; line-height:1;" />
   </div>
 
   <!-- Заголовок по центру -->
   <div style="padding: 0 40px;">
-    <h1 style="text-align:center; font-size:28px; font-weight:bold; margin: 16px 0 32px 0; font-family: Arial, sans-serif;">
+    <h1 style="text-align:center; font-size:28px; font-weight:bold; margin:0 0 32px 0; font-family: Arial, sans-serif; line-height:1.2;">
       Издательство Лань разыскивает авторов!
     </h1>
   </div>


### PR DESCRIPTION
## Summary
- place the inline logo in a right-aligned block above the main title in all email templates
- standardize the sport template header to match medicine and tourism variants
- keep regression test confirming templates honor the `INLINE_LOGO` toggle

## Testing
- `pre-commit run --files templates/sport.html` *(fails: fatal unable to access 'https://github.com/pre-commit/pre-commit-hooks/' CONNECT tunnel failed)*
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4acd979108326822f8f73bc83e5c4