### PR TITLE
Add suppress list and bounce logging

### DIFF
--- a/emailbot/messaging_utils.py
+++ b/emailbot/messaging_utils.py
@@ -1,0 +1,136 @@
+import csv
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List
+
+from .messaging import was_sent_within as was_sent_within, log_sent_email as log_sent
+
+SUPPRESS_PATH = Path("/mnt/data/suppress_list.csv")  # e-mail, code, reason, first_seen, last_seen, hits
+BOUNCE_LOG_PATH = Path("/mnt/data/bounce_log.csv")   # ts, email, code, msg, phase
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _ensure_headers(p: Path, headers: List[str]):
+    new = not p.exists()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    f = p.open("a", newline="", encoding="utf-8")
+    w = csv.DictWriter(f, fieldnames=headers)
+    if new:
+        w.writeheader()
+    return f, w
+
+
+def add_bounce(email: str, code: int | None, msg: str, phase: str) -> None:
+    f, w = _ensure_headers(BOUNCE_LOG_PATH, ["ts", "email", "code", "msg", "phase"])
+    with f:
+        w.writerow(
+            {
+                "ts": _now(),
+                "email": (email or "").lower().strip(),
+                "code": code or "",
+                "msg": (msg or "")[:500],
+                "phase": phase,
+            }
+        )
+
+
+def is_hard_bounce(code: int | None, msg: str | bytes | None) -> bool:
+    """Return True for permanent delivery failures."""
+    if code is not None:
+        try:
+            icode = int(code)
+        except Exception:
+            icode = None
+        if icode is not None:
+            if 500 <= icode < 600:
+                return True
+            if 400 <= icode < 500:
+                return False
+    m = (
+        (msg or b"")
+        .decode("utf-8", "ignore")
+        if isinstance(msg, (bytes, bytearray))
+        else (msg or "")
+    ).lower()
+    patterns = [
+        "user not found",
+        "invalid mailbox",
+        "no such user",
+        "unknown user",
+        "non-local recipient verification failed",
+        "recipient address rejected",
+        "user is terminated",
+        "mailbox unavailable",
+        "mailbox disabled",
+    ]
+    return any(p in m for p in patterns)
+
+
+def suppress_add(email: str, code: int | None, reason: str) -> None:
+    email = (email or "").lower().strip()
+    rows: dict[str, dict] = {}
+    if SUPPRESS_PATH.exists():
+        with SUPPRESS_PATH.open("r", newline="", encoding="utf-8") as f:
+            for r in csv.DictReader(f):
+                rows[r["email"].lower()] = r
+    rec = rows.get(email)
+    if rec:
+        rec["last_seen"] = _now()
+        rec["hits"] = str(int(rec.get("hits", "1")) + 1)
+        rec["code"] = str(code or rec.get("code", ""))
+        rec["reason"] = reason or rec.get("reason", "")
+    else:
+        rec = {
+            "email": email,
+            "code": str(code or ""),
+            "reason": reason or "hard bounce",
+            "first_seen": _now(),
+            "last_seen": _now(),
+            "hits": "1",
+        }
+    rows[email] = rec
+    SUPPRESS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with SUPPRESS_PATH.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(
+            f,
+            fieldnames=["email", "code", "reason", "first_seen", "last_seen", "hits"],
+        )
+        w.writeheader()
+        w.writerows(rows.values())
+
+
+def is_suppressed(email: str) -> bool:
+    email = (email or "").lower().strip()
+    if not email or not SUPPRESS_PATH.exists():
+        return False
+    with SUPPRESS_PATH.open("r", newline="", encoding="utf-8") as f:
+        for r in csv.DictReader(f):
+            if r.get("email", "").lower().strip() == email:
+                return True
+    return False
+
+
+_ALLOWED_TLDS = {"ru", "com"}
+
+def is_foreign(email: str) -> bool:
+    """Return True if the e-mail has a TLD outside the allowed set."""
+    if not email:
+        return True
+    tld = email.rsplit(".", 1)[-1].lower()
+    return tld not in _ALLOWED_TLDS
+
+
+__all__ = [
+    "SUPPRESS_PATH",
+    "BOUNCE_LOG_PATH",
+    "add_bounce",
+    "is_hard_bounce",
+    "suppress_add",
+    "is_suppressed",
+    "is_foreign",
+    "was_sent_within",
+    "log_sent",
+]

--- a/tests/test_messaging_utils.py
+++ b/tests/test_messaging_utils.py
@@ -1,0 +1,37 @@
+import csv
+from emailbot import messaging_utils as mu
+
+
+def setup_paths(tmp_path, monkeypatch):
+    suppress = tmp_path / "s.csv"
+    bounce = tmp_path / "b.csv"
+    monkeypatch.setattr(mu, "SUPPRESS_PATH", suppress)
+    monkeypatch.setattr(mu, "BOUNCE_LOG_PATH", bounce)
+    return suppress, bounce
+
+
+def test_suppress_add_and_is_suppressed(tmp_path, monkeypatch):
+    s, _ = setup_paths(tmp_path, monkeypatch)
+    mu.suppress_add("user@example.com", 550, "hard")
+    mu.suppress_add("user@example.com", 550, "hard")
+    assert mu.is_suppressed("user@example.com") is True
+    with s.open() as f:
+        rows = list(csv.DictReader(f))
+    assert rows[0]["hits"] == "2"
+
+
+def test_add_bounce_writes_log(tmp_path, monkeypatch):
+    _, b = setup_paths(tmp_path, monkeypatch)
+    mu.add_bounce("a@b.com", 550, "user unknown", "send")
+    with b.open() as f:
+        rows = list(csv.DictReader(f))
+    assert rows[0]["email"] == "a@b.com"
+    assert rows[0]["code"] == "550"
+    assert rows[0]["phase"] == "send"
+
+
+def test_is_hard_bounce():
+    assert mu.is_hard_bounce(550, "err")
+    assert not mu.is_hard_bounce(450, "err")
+    assert mu.is_hard_bounce(None, "User Not Found")
+    assert not mu.is_hard_bounce(None, "temporary failure")


### PR DESCRIPTION
## Summary
- track hard bounces and suppress invalid emails
- skip suppressed addresses and recent contacts in mass mailings
- log bounces without blocking addresses for manual sends

## Testing
- `pre-commit run --files emailbot/messaging_utils.py emailbot/bot_handlers.py tests/test_messaging_utils.py` *(fails: CONNECT tunnel failed)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5addd42b48326b9553149ed452e5a