### PR TITLE
Hide blocked email sections from mass mailing report

### DIFF
--- a/emailbot/__init__.py
+++ b/emailbot/__init__.py
@@ -1,6 +1,6 @@
 """Helpers for the email bot."""
 
-from . import bot_handlers, extraction, messaging, unsubscribe
+from . import bot_handlers, extraction, messaging, unsubscribe, reporting
 from .smtp_client import SmtpClient
 from .utils import load_env, log_error, setup_logging
 
@@ -13,4 +13,5 @@ __all__ = [
     "messaging",
     "bot_handlers",
     "unsubscribe",
+    "reporting",
 ]

--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -26,6 +26,7 @@ from telegram.ext import ContextTypes
 
 from . import messaging
 from .extraction import normalize_email, smart_extract_emails, extract_emails_manual
+from .reporting import build_mass_report_text
 
 
 def _preclean_text_for_emails(text: str) -> str:
@@ -1244,20 +1245,14 @@ async def send_all(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                     )
         imap.logout()
 
-        summary_lines: List[str] = []
+        report_text = build_mass_report_text(
+            sent_ok,
+            skipped_recent,
+            blocked_foreign,
+            blocked_invalid,
+        )
 
-        def _fmt(title: str, items: List[str]) -> str:
-            line = f"{title}: {len(items)}"
-            if items:
-                line += "\n" + "\n".join(items)
-            return line
-
-        summary_lines.append(_fmt("🔒 В блок (иностранные)", blocked_foreign))
-        summary_lines.append(_fmt("⛔ В блок (неработающие)", blocked_invalid))
-        summary_lines.append(_fmt(f"⏳ Пропущены (<{lookup_days} дней)", skipped_recent))
-        summary_lines.append(f"✅ Отправлено: {len(sent_ok)}")
-
-        await query.message.reply_text("\n\n".join(summary_lines))
+        await query.message.reply_text(report_text)
         if errors:
             await query.message.reply_text("Ошибки:\n" + "\n".join(errors))
 

--- a/emailbot/reporting.py
+++ b/emailbot/reporting.py
@@ -1,0 +1,36 @@
+"""Utilities for composing user-facing reports."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Optional
+
+
+def build_mass_report_text(
+    sent_ok: Iterable[str],
+    skipped_recent: Iterable[str],
+    blocked_foreign: Optional[Iterable[str]] = None,
+    blocked_invalid: Optional[Iterable[str]] = None,
+) -> str:
+    """Build summary text for mass mailing.
+
+    Only the ``sent_ok`` and ``skipped_recent`` sections are returned to the user.
+    ``blocked_foreign`` and ``blocked_invalid`` are accepted for compatibility but
+    ignored in the output so that calling code does not need to change its
+    interface.
+    """
+
+    def lines(title: str, items: Iterable[str]) -> str:
+        items_list = list(items)
+        if not items_list:
+            return f"{title}: 0\n"
+        unique_sorted = sorted(set(items_list))
+        return (
+            f"{title}: {len(items_list)}\n" +
+            "\n".join(f"• {e}" for e in unique_sorted) +
+            "\n"
+        )
+
+    text: List[str] = []
+    text.append(lines("✅ Отправлено", sent_ok))
+    text.append(lines("⏳ Пропущены (<180 дней)", skipped_recent))
+    return "\n".join(text).strip()

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,19 @@
+from emailbot.reporting import build_mass_report_text
+
+
+def test_build_mass_report_text_ignores_blocked():
+    sent_ok = ["a@example.com", "b@example.com"]
+    skipped = ["c@example.com"]
+    blocked_foreign = ["foreign@example.de"]
+    blocked_invalid = ["invalid@example.com"]
+
+    text = build_mass_report_text(sent_ok, skipped, blocked_foreign, blocked_invalid)
+
+    assert "В блок" not in text
+    assert "иностранные" not in text
+    assert "неработающие" not in text
+    assert "✅ Отправлено: 2" in text
+    assert "⏳ Пропущены (<180 дней): 1" in text
+    # ensure addresses listed with bullets
+    assert "• a@example.com" in text
+    assert "• c@example.com" in text


### PR DESCRIPTION
## Summary
- show only sent and skipped-recent sections in mass mailing reports
- use new reporting helper to build mass mailing summaries
- add tests to ensure blocked categories are hidden

## Testing
- `pre-commit run --files emailbot/__init__.py emailbot/bot_handlers.py emailbot/reporting.py tests/test_reporting.py` (failed: `fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403`)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5cc04b1a08326b838020e02543a0a