### PR TITLE
Add soft bounce retry command

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -36,6 +36,7 @@ def main() -> None:
     app = ApplicationBuilder().token(token).build()
 
     app.add_handler(CommandHandler("start", bot_handlers.start))
+    app.add_handler(CommandHandler("retry_last", bot_handlers.retry_last_command))
 
     app.add_handler(
         MessageHandler(filters.TEXT & filters.Regex("^📤"), bot_handlers.prompt_upload)

--- a/tests/test_messaging_utils.py
+++ b/tests/test_messaging_utils.py
@@ -35,3 +35,10 @@ def test_is_hard_bounce():
     assert not mu.is_hard_bounce(450, "err")
     assert mu.is_hard_bounce(None, "User Not Found")
     assert not mu.is_hard_bounce(None, "temporary failure")
+
+
+def test_is_soft_bounce():
+    assert mu.is_soft_bounce(450, "temporary failure")
+    assert mu.is_soft_bounce(None, "greylisted")
+    assert not mu.is_soft_bounce(550, "User not found")
+    assert not mu.is_soft_bounce(None, "permanent error")

--- a/tests/test_retry_last.py
+++ b/tests/test_retry_last.py
@@ -1,0 +1,95 @@
+import asyncio
+import csv
+import types
+
+import emailbot.bot_handlers as bh
+from emailbot import messaging_utils as mu, messaging
+
+
+class DummyMessage:
+    def __init__(self):
+        self.replies: list[str] = []
+
+    async def reply_text(self, text, reply_markup=None):
+        self.replies.append(text)
+        return self
+
+
+class DummyUpdate:
+    def __init__(self):
+        self.message = DummyMessage()
+        self.effective_chat = types.SimpleNamespace(id=123)
+
+
+class DummyContext:
+    def __init__(self):
+        self.chat_data = {}
+        self.user_data = {}
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def setup_paths(tmp_path, monkeypatch):
+    bounce = tmp_path / "b.csv"
+    sent = tmp_path / "s.csv"
+    suppress = tmp_path / "sup.csv"
+    monkeypatch.setattr(mu, "BOUNCE_LOG_PATH", bounce)
+    monkeypatch.setattr(mu, "SUPPRESS_PATH", suppress)
+    monkeypatch.setattr(bh, "BOUNCE_LOG_PATH", bounce)
+    monkeypatch.setattr(messaging, "LOG_FILE", sent)
+    monkeypatch.setattr(bh.messaging, "LOG_FILE", sent)
+    return bounce, sent, suppress
+
+
+def write_bounce(path, rows):
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["ts", "email", "code", "msg", "phase"])
+        for r in rows:
+            w.writerow(r)
+
+
+def test_retry_last_only_soft(monkeypatch, tmp_path):
+    bounce, sent, suppress = setup_paths(tmp_path, monkeypatch)
+    write_bounce(
+        bounce,
+        [
+            ["2023-01-01", "old@example.com", "450", "temporary", "send"],
+            ["2023-01-02", "soft@example.com", "450", "temporary", "send"],
+            ["2023-01-02", "hard@example.com", "550", "user not found", "send"],
+        ],
+    )
+    suppress.write_text(
+        "email,code,reason,first_seen,last_seen,hits\nfoo@example.com,550,hard,1,1,1\n"
+    )
+    before = suppress.read_text()
+    sent_addrs = []
+    monkeypatch.setattr(
+        bh.messaging, "send_raw_smtp_with_retry", lambda m, a, max_tries=3: sent_addrs.append(a)
+    )
+    update = DummyUpdate()
+    ctx = DummyContext()
+    run(bh.retry_last_command(update, ctx))
+    assert sent_addrs == ["soft@example.com"]
+    with open(sent, encoding="utf-8") as f:
+        data = f.read()
+    assert "soft@example.com" in data
+    assert suppress.read_text() == before
+    assert update.message.replies[-1] == "Повторно отправлено: 1"
+
+
+def test_retry_last_no_soft(monkeypatch, tmp_path):
+    bounce, sent, suppress = setup_paths(tmp_path, monkeypatch)
+    write_bounce(bounce, [["2023-01-02", "hard@example.com", "550", "user not found", "send"]])
+    sent_addrs = []
+    monkeypatch.setattr(
+        bh.messaging, "send_raw_smtp_with_retry", lambda m, a, max_tries=3: sent_addrs.append(a)
+    )
+    update = DummyUpdate()
+    ctx = DummyContext()
+    run(bh.retry_last_command(update, ctx))
+    assert sent_addrs == []
+    assert not sent.exists()
+    assert update.message.replies[-1] == "Нет писем для ретрая"


### PR DESCRIPTION
## Summary
- detect soft bounces like SMTP 4xx, timeouts and greylisting
- add `/retry_last` command to resend only soft-bounced addresses
- register new command and cover with tests

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5da283b3c83268a2c9555428e6b38