### PR TITLE
Improve email extraction accuracy with contextual filtering and footnote dedupe

### DIFF
--- a/emailbot/dedupe.py
+++ b/emailbot/dedupe.py
@@ -1,0 +1,80 @@
+"""Helpers for deduplication of e-mail hits."""
+
+from __future__ import annotations
+
+import unicodedata
+from typing import Dict, List, Tuple
+
+from . import settings
+from .extraction_url import EmailHit
+
+
+def _is_superscript(ch: str) -> bool:
+    return "SUPERSCRIPT" in unicodedata.name(ch, "")
+
+
+def _last_visible(s: str) -> str:
+    for c in reversed(s):
+        if not c.isspace():
+            return c
+    return ""
+
+
+def _split_ref(ref: str) -> Tuple[str, int]:
+    parts = ref.split("|")
+    try:
+        page = int(parts[-1])
+        base = "|".join(parts[:-1])
+    except ValueError:
+        base, page = ref, 0
+    return base, page
+
+
+def merge_footnote_prefix_variants(hits: List[EmailHit], stats: Dict[str, int] | None = None) -> List[EmailHit]:
+    """Merge footnote-trimmed variants of the same e-mail within one source."""
+
+    if stats is None:
+        stats = {}
+
+    grouped: Dict[str, List[Tuple[int, EmailHit, int]]] = {}
+    for idx, h in enumerate(hits):
+        base, page = _split_ref(h.source_ref)
+        grouped.setdefault(base, []).append((idx, h, page))
+
+    removed: set[int] = set()
+
+    for base, lst in grouped.items():
+        for i, (idx_long, long, page_long) in enumerate(lst):
+            loc_long, dom_long = long.email.split("@", 1)
+            for j, (idx_short, short, page_short) in enumerate(lst):
+                if i == j or idx_short in removed or idx_long in removed:
+                    continue
+                if abs(page_long - page_short) > settings.FOOTNOTE_RADIUS_PAGES:
+                    continue
+                loc_short, dom_short = short.email.split("@", 1)
+                if dom_long != dom_short:
+                    continue
+                if len(loc_long) != len(loc_short) + 1:
+                    continue
+                if not loc_long.endswith(loc_short):
+                    continue
+                added = loc_long[0]
+                if not (added.isalnum() or _is_superscript(added)):
+                    continue
+                prev_short = _last_visible(short.pre)
+                prev_long = _last_visible(long.pre)
+                cond = False
+                if prev_short and (prev_short.isdigit() or _is_superscript(prev_short)):
+                    cond = True
+                if prev_long and (prev_long.isdigit() or _is_superscript(prev_long)):
+                    cond = True
+                if not cond:
+                    continue
+                removed.add(idx_short)
+                stats["footnote_trimmed_merged"] = stats.get("footnote_trimmed_merged", 0) + 1
+
+    return [h for idx, h in enumerate(hits) if idx not in removed]
+
+
+__all__ = ["merge_footnote_prefix_variants"]
+

--- a/emailbot/extraction_url.py
+++ b/emailbot/extraction_url.py
@@ -1,0 +1,62 @@
+"""Helpers for extracting e-mail hits from URLs."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class EmailHit:
+    """Single e-mail occurrence with some context information.
+
+    Parameters
+    ----------
+    email:
+        Normalised e-mail address.
+    source_ref:
+        Identifier of the source (file, url, page).
+    origin:
+        Extraction origin, e.g. ``mailto`` or ``obfuscation``.
+    pre:
+        Text preceding the hit (up to ~40 characters).
+    post:
+        Text following the hit (up to ~40 characters).
+    """
+
+    email: str
+    source_ref: str
+    origin: str
+    pre: str
+    post: str
+
+
+# Patterns for popular "obfuscated" e-mail formats such as
+# ``name [at] host [dot] com``.
+_OBFUSCATION_PATTERNS = [
+    r"([\w.+-]+)\s*\[at\]\s*([\w.-]+)\s*\[dot\]\s*([A-Za-z]{2,})",
+    r"([\w.+-]+)\s*\(at\)\s*([\w.-]+)\s*\(dot\)\s*([A-Za-z]{2,})",
+    r"([\w.+-]+)\s+at\s+([\w.-]+)\s+dot\s+([A-Za-z]{2,})",
+    r"([\w.+-]+)\s+собака\s+([\w.-]+)\s+точка\s+([A-Za-z]{2,})",
+]
+
+
+def extract_obfuscated_hits(text: str, source_ref: str) -> List[EmailHit]:
+    """Return all ``EmailHit`` objects found via obfuscation patterns."""
+
+    hits: List[EmailHit] = []
+    for pat in _OBFUSCATION_PATTERNS:
+        for m in re.finditer(pat, text, flags=re.I):
+            start, end = m.span()
+            pre = text[max(0, start - 40) : start]
+            post = text[end : end + 40]
+            email = f"{m.group(1)}@{m.group(2)}.{m.group(3)}".lower()
+            hits.append(
+                EmailHit(email=email, source_ref=source_ref, origin="obfuscation", pre=pre, post=post)
+            )
+    return hits
+
+
+__all__ = ["EmailHit", "extract_obfuscated_hits"]
+

--- a/emailbot/settings.py
+++ b/emailbot/settings.py
@@ -1,0 +1,49 @@
+"""Runtime configurable settings for the bot."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+SETTINGS_PATH = Path("/mnt/data/settings.json")
+
+# Default values
+STRICT_OBFUSCATION: bool = True
+FOOTNOTE_RADIUS_PAGES: int = 1
+
+
+def load() -> None:
+    """Load configuration from :data:`SETTINGS_PATH`."""
+
+    global STRICT_OBFUSCATION, FOOTNOTE_RADIUS_PAGES
+    try:
+        data = json.loads(SETTINGS_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        data = {}
+    STRICT_OBFUSCATION = bool(data.get("STRICT_OBFUSCATION", STRICT_OBFUSCATION))
+    FOOTNOTE_RADIUS_PAGES = int(data.get("FOOTNOTE_RADIUS_PAGES", FOOTNOTE_RADIUS_PAGES))
+
+
+def save() -> None:
+    """Persist current configuration."""
+
+    try:
+        SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        with SETTINGS_PATH.open("w", encoding="utf-8") as f:
+            json.dump(
+                {
+                    "STRICT_OBFUSCATION": STRICT_OBFUSCATION,
+                    "FOOTNOTE_RADIUS_PAGES": FOOTNOTE_RADIUS_PAGES,
+                },
+                f,
+            )
+    except Exception:
+        pass
+
+
+# Load settings on module import.
+load()
+
+
+__all__ = ["STRICT_OBFUSCATION", "FOOTNOTE_RADIUS_PAGES", "load", "save"]
+

--- a/tests/test_dedupe_footnotes.py
+++ b/tests/test_dedupe_footnotes.py
@@ -1,0 +1,25 @@
+from emailbot.dedupe import merge_footnote_prefix_variants
+from emailbot.extraction_url import EmailHit
+
+
+def make_hit(email: str, pre: str, source: str = "doc.pdf|1") -> EmailHit:
+    return EmailHit(email=email, source_ref=source, origin="direct_at", pre=pre, post="")
+
+
+def test_trimmed_variant_removed():
+    long = make_hit("959536_vorobeva@mail.ru", pre="")
+    short = make_hit("59536_vorobeva@mail.ru", pre="9")
+    stats = {}
+    res = merge_footnote_prefix_variants([long, short], stats)
+    assert res == [long]
+    assert stats.get("footnote_trimmed_merged") == 1
+
+
+def test_different_addresses_not_merged():
+    a = make_hit("1abc@mail.ru", pre="1")
+    b = make_hit("xabc@mail.ru", pre="")
+    stats = {}
+    res = merge_footnote_prefix_variants([a, b], stats)
+    assert {h.email for h in res} == {a.email, b.email}
+    assert stats.get("footnote_trimmed_merged", 0) == 0
+

--- a/tests/test_url_obfuscation.py
+++ b/tests/test_url_obfuscation.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from emailbot.extraction import extract_from_url
+
+
+def _write_html(tmp_path: Path, name: str, content: str) -> str:
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    return "file://" + str(p)
+
+
+def test_numeric_obfuscation_dropped(tmp_path):
+    html = (
+        "<html><body>121536 [at] gmail [dot] com and 2 [at] mail [dot] ru" "</body></html>"
+    )
+    url = _write_html(tmp_path, "70.html", html)
+    emails, stats = extract_from_url(url)
+    assert "121536@gmail.com" not in emails
+    assert "2@mail.ru" not in emails
+    assert stats["numeric_from_obfuscation_dropped"] >= 2
+
+
+def test_numeric_mailto_and_direct_kept(tmp_path):
+    html = (
+        "<html><body><a href='mailto:12345@mail.ru'>m</a> 67890@mail.ru" "</body></html>"
+    )
+    url = _write_html(tmp_path, "71.html", html)
+    emails, _ = extract_from_url(url)
+    assert "12345@mail.ru" in emails
+    assert "67890@mail.ru" in emails
+


### PR DESCRIPTION
## Summary
- track email occurrences with new `EmailHit` structure and obfuscation pattern extraction
- filter numeric logins from obfuscated text and expose runtime strictness and footnote radius settings
- merge footnote-trimmed variants by source and report potential duplicates
- add regression tests for obfuscation handling and footnote dedupe

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b61442b12c8326bf3bf4123a9fa7e2