### PR TITLE
feat: unify email hit representation and tighten obfuscation parsing

### DIFF
--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -40,8 +40,8 @@ def apply_numeric_truncation_removal(allowed):
 
 
 async def async_extract_emails_from_url(url: str, session, chat_id=None):
-    emails, _stats = await asyncio.to_thread(_extraction.extract_from_url, url)
-    emails = set(e.lower().strip() for e in emails)
+    hits, _stats = await asyncio.to_thread(_extraction.extract_from_url, url)
+    emails = set(h.email.lower().strip() for h in hits)
     foreign = {e for e in emails if not is_allowed_tld(e)}
     return url, emails, foreign, []
 
@@ -55,10 +55,10 @@ def collect_repairs_from_files(files):
 
 
 async def extract_emails_from_zip(path: str, *_, **__):
-    emails, _stats = await asyncio.to_thread(
+    hits, _stats = await asyncio.to_thread(
         _extraction.extract_emails_from_zip, path
     )
-    emails = set(e.lower().strip() for e in emails)
+    emails = set(h.email.lower().strip() for h in hits)
     extracted_files = [path]
     return emails, extracted_files, set(emails)
 
@@ -68,8 +68,8 @@ def extract_emails_loose(text):
 
 
 def extract_from_uploaded_file(path: str):
-    emails, _stats = _extraction.extract_any(path)
-    emails = set(e.lower().strip() for e in emails)
+    hits, _stats = _extraction.extract_any(path)
+    emails = set(h.email.lower().strip() for h in hits)
     return emails, set(emails)
 
 

--- a/emailbot/dedupe.py
+++ b/emailbot/dedupe.py
@@ -6,7 +6,7 @@ import unicodedata
 from typing import Dict, List, Tuple
 
 from . import settings
-from .extraction_url import EmailHit
+from .extraction import EmailHit
 
 
 def _is_superscript(ch: str) -> bool:

--- a/emailbot/extraction_url.py
+++ b/emailbot/extraction_url.py
@@ -3,60 +3,47 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
-from typing import List
+from typing import Dict, List, Optional
+
+from .extraction import EmailHit, _valid_local, _valid_domain
+
+_OBFUSCATED_RE = re.compile(
+    r"(?P<local>[\w.+-]+)\s*(?P<at>@|\(at\)|\[at\]|at|собака)\s*(?P<domain>[\w-]+(?:\s*(?:\.|dot|\(dot\)|\[dot\]|точка)\s*[\w-]+)+)",
+    re.I,
+)
+
+_DOT_SPLIT_RE = re.compile(r"\s*(?:\.|dot|\(dot\)|\[dot\]|точка)\s*", re.I)
 
 
-@dataclass
-class EmailHit:
-    """Single e-mail occurrence with some context information.
-
-    Parameters
-    ----------
-    email:
-        Normalised e-mail address.
-    source_ref:
-        Identifier of the source (file, url, page).
-    origin:
-        Extraction origin, e.g. ``mailto`` or ``obfuscation``.
-    pre:
-        Text preceding the hit (up to ~40 characters).
-    post:
-        Text following the hit (up to ~40 characters).
-    """
-
-    email: str
-    source_ref: str
-    origin: str
-    pre: str
-    post: str
-
-
-# Patterns for popular "obfuscated" e-mail formats such as
-# ``name [at] host [dot] com``.
-_OBFUSCATION_PATTERNS = [
-    r"([\w.+-]+)\s*\[at\]\s*([\w.-]+)\s*\[dot\]\s*([A-Za-z]{2,})",
-    r"([\w.+-]+)\s*\(at\)\s*([\w.-]+)\s*\(dot\)\s*([A-Za-z]{2,})",
-    r"([\w.+-]+)\s+at\s+([\w.-]+)\s+dot\s+([A-Za-z]{2,})",
-    r"([\w.+-]+)\s+собака\s+([\w.-]+)\s+точка\s+([A-Za-z]{2,})",
-]
-
-
-def extract_obfuscated_hits(text: str, source_ref: str) -> List[EmailHit]:
+def extract_obfuscated_hits(
+    text: str, source_ref: str, stats: Optional[Dict[str, int]] = None
+) -> List[EmailHit]:
     """Return all ``EmailHit`` objects found via obfuscation patterns."""
 
     hits: List[EmailHit] = []
-    for pat in _OBFUSCATION_PATTERNS:
-        for m in re.finditer(pat, text, flags=re.I):
-            start, end = m.span()
-            pre = text[max(0, start - 40) : start]
-            post = text[end : end + 40]
-            email = f"{m.group(1)}@{m.group(2)}.{m.group(3)}".lower()
-            hits.append(
-                EmailHit(email=email, source_ref=source_ref, origin="obfuscation", pre=pre, post=post)
-            )
+    for m in _OBFUSCATED_RE.finditer(text):
+        local = m.group("local")
+        at_token = m.group("at")
+        domain_raw = m.group("domain")
+        parts = [p for p in _DOT_SPLIT_RE.split(domain_raw) if p]
+        domain = ".".join(parts)
+        email = f"{local}@{domain}".lower()
+        if not (_valid_local(local) and _valid_domain(domain)):
+            continue
+        if local.isdigit() and at_token != "@":
+            if stats is not None:
+                stats["numeric_from_obfuscation_dropped"] = stats.get(
+                    "numeric_from_obfuscation_dropped", 0
+                ) + 1
+            continue
+        start, end = m.span()
+        pre = text[max(0, start - 16) : start]
+        post = text[end : end + 16]
+        hits.append(
+            EmailHit(email=email, source_ref=source_ref, origin="obfuscation", pre=pre, post=post)
+        )
     return hits
 
 
-__all__ = ["EmailHit", "extract_obfuscated_hits"]
+__all__ = ["extract_obfuscated_hits"]
 

--- a/tests/test_dedupe_footnotes.py
+++ b/tests/test_dedupe_footnotes.py
@@ -1,5 +1,5 @@
 from emailbot.dedupe import merge_footnote_prefix_variants
-from emailbot.extraction_url import EmailHit
+from emailbot.extraction import EmailHit
 
 
 def make_hit(email: str, pre: str, source: str = "doc.pdf|1") -> EmailHit:

--- a/tests/test_url_obfuscation.py
+++ b/tests/test_url_obfuscation.py
@@ -14,7 +14,8 @@ def test_numeric_obfuscation_dropped(tmp_path):
         "<html><body>121536 [at] gmail [dot] com and 2 [at] mail [dot] ru" "</body></html>"
     )
     url = _write_html(tmp_path, "70.html", html)
-    emails, stats = extract_from_url(url)
+    hits, stats = extract_from_url(url)
+    emails = [h.email for h in hits]
     assert "121536@gmail.com" not in emails
     assert "2@mail.ru" not in emails
     assert stats["numeric_from_obfuscation_dropped"] >= 2
@@ -25,7 +26,8 @@ def test_numeric_mailto_and_direct_kept(tmp_path):
         "<html><body><a href='mailto:12345@mail.ru'>m</a> 67890@mail.ru" "</body></html>"
     )
     url = _write_html(tmp_path, "71.html", html)
-    emails, _ = extract_from_url(url)
+    hits, _ = extract_from_url(url)
+    emails = [h.email for h in hits]
     assert "12345@mail.ru" in emails
     assert "67890@mail.ru" in emails
 


### PR DESCRIPTION
## Summary
- add immutable `EmailHit` with source context
- implement strict token-based obfuscation parsing
- return `EmailHit` objects across extraction helpers and update callers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b811e7d6dc83269f8ebe6b9fd708f9