### PR TITLE
feat: improve url extraction safety

### DIFF
--- a/tests/test_url_obfuscation.py
+++ b/tests/test_url_obfuscation.py
@@ -1,34 +1,71 @@
-from pathlib import Path
+from __future__ import annotations
+
+import http.server
+import socket
+import threading
 
 from emailbot.extraction import extract_from_url
 
 
-def _write_html(tmp_path: Path, name: str, content: str) -> str:
-    p = tmp_path / name
-    p.write_text(content, encoding="utf-8")
-    return "file://" + str(p)
+def _run_server(pages: dict[str, str]):
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            body = pages.get(self.path, "").encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *a):  # noqa: D401, override
+            return
+
+    sock = socket.socket()
+    sock.bind(("localhost", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    server = http.server.ThreadingHTTPServer(("localhost", port), Handler)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    return server, port
 
 
-def test_requires_at_token(tmp_path):
+def _serve(html: str):
+    pages = {"/": html}
+    server, port = _run_server(pages)
+    return server, f"http://localhost:{port}/"
+
+
+def test_requires_at_token():
     html = "<html><body>121536 gmail dot com</body></html>"
-    url = _write_html(tmp_path, "70.html", html)
-    hits, _ = extract_from_url(url)
+    server, url = _serve(html)
+    try:
+        hits, _ = extract_from_url(url)
+    finally:
+        server.shutdown()
     emails = [h.email for h in hits]
     assert "121536@gmail.com" not in emails
 
 
-def test_obfuscation_with_at(tmp_path):
+def test_obfuscation_with_at():
     html = "<html><body>121536 at gmail dot com</body></html>"
-    url = _write_html(tmp_path, "71.html", html)
-    hits, _ = extract_from_url(url)
+    server, url = _serve(html)
+    try:
+        hits, _ = extract_from_url(url)
+    finally:
+        server.shutdown()
     emails = [h.email for h in hits]
     assert "121536@gmail.com" in emails
 
 
-def test_numeric_local_kept(tmp_path):
+def test_numeric_local_kept():
     html = "<html><body>2@mail.ru and 2 at mail dot ru</body></html>"
-    url = _write_html(tmp_path, "72.html", html)
-    hits, stats = extract_from_url(url)
+    server, url = _serve(html)
+    try:
+        hits, stats = extract_from_url(url)
+    finally:
+        server.shutdown()
     emails = [h.email for h in hits]
     assert "2@mail.ru" in emails
     assert stats["obfuscated_hits"] >= 1


### PR DESCRIPTION
## Summary
- add safe URL fetcher with caching, size/time limits, and Cloudflare cfemail decoder
- restrict crawler depth and enforce same-domain policy
- update URL obfuscation tests to use local HTTP server

## Testing
- `pre-commit run --files emailbot/extraction_url.py emailbot/extraction.py tests/test_url_obfuscation.py` (failed: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b833fee9488326a76a9661d21f320a