### PR TITLE
Add diagnostics and secure structured logging

### DIFF
--- a/emailbot/messaging.py
+++ b/emailbot/messaging.py
@@ -152,7 +152,7 @@ def send_raw_smtp_with_retry(raw_message: str, recipient: str, max_tries=3):
                 "smtp.mail.ru", 465, EMAIL_ADDRESS, EMAIL_PASSWORD
             ) as client:
                 client.send(EMAIL_ADDRESS, recipient, raw_message)
-            logger.info("Email sent to %s", recipient)
+            logger.info("Email sent", extra={"event": "send", "email": recipient})
             return
         except smtplib.SMTPResponseException as e:
             code = getattr(e, "smtp_code", None)


### PR DESCRIPTION
## Summary
- mask secrets in logs and log bounce events
- use JSON logging with size and time rotation
- add admin-only /diag command with counters and versions

## Testing
- `pre-commit run --files emailbot/messaging_utils.py email_bot.py emailbot/bot_handlers.py emailbot/messaging.py` *(fails: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8531409c4832685678995f97f4595