### PR TITLE
Add offline regression tests and remove binary fixtures

### DIFF
--- a/tests/fixtures/html/footnotes.html
+++ b/tests/fixtures/html/footnotes.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+<p>Contact: ¹john.doe@example.com</p>
+<p>Another: ²jane.doe@example.org</p>
+</body>
+</html>

--- a/tests/test_gold_dataset.py
+++ b/tests/test_gold_dataset.py
@@ -1,0 +1,11 @@
+import pathlib
+
+from emailbot.extraction import strip_html, smart_extract_emails
+
+
+def test_html_fixture_numbers():
+    html_path = pathlib.Path('tests/fixtures/html/footnotes.html')
+    html = html_path.read_text(encoding='utf-8')
+    text = strip_html(html)
+    emails = smart_extract_emails(text)
+    assert emails == ['john.doe@example.com', 'jane.doe@example.org']

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -1,0 +1,71 @@
+import types
+import urllib.request
+
+from emailbot import extraction_url
+
+
+class DummyHeaders:
+    def get_content_charset(self):
+        return 'utf-8'
+
+
+class DummyResp:
+    def __init__(self, data: bytes):
+        self.data = data
+        self.pos = 0
+        self.read_calls = 0
+
+    def geturl(self):
+        return 'http://example.com'
+
+    @property
+    def headers(self):
+        return DummyHeaders()
+
+    def read(self, n: int) -> bytes:
+        self.read_calls += 1
+        if self.pos >= len(self.data):
+            return b''
+        chunk = self.data[self.pos:self.pos + n]
+        self.pos += n
+        return chunk
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_http_timeout(monkeypatch):
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured['timeout'] = timeout
+        raise TimeoutError
+
+    monkeypatch.setattr(urllib.request, 'urlopen', fake_urlopen)
+    assert extraction_url.fetch_url('http://example.com', timeout=1) is None
+    assert captured['timeout'] == 1
+
+
+def test_max_size_limit(monkeypatch):
+    resp = DummyResp(b'x' * 40)
+    monkeypatch.setattr(urllib.request, 'urlopen', lambda req, timeout=None: resp)
+    monkeypatch.setattr(extraction_url, '_READ_CHUNK', 10)
+    text = extraction_url.fetch_url('http://example.com', max_size=15)
+    assert len(text) <= 20
+    assert resp.read_calls == 2
+
+
+def test_stop_event(monkeypatch):
+    resp = DummyResp(b'x' * 40)
+    monkeypatch.setattr(urllib.request, 'urlopen', lambda req, timeout=None: resp)
+    extraction_url._CACHE.clear()
+
+    class Stop:
+        def is_set(self):
+            return True
+
+    assert extraction_url.fetch_url('http://example.org', stop_event=Stop()) is None
+    assert resp.read_calls == 0

--- a/tests/test_property_extraction.py
+++ b/tests/test_property_extraction.py
@@ -1,0 +1,28 @@
+import pytest
+
+from emailbot.extraction import smart_extract_emails
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("john\u200B.doe@example.com", ["john.doe@example.com"]),
+        ("joh\u00ADn.doe@example.com", ["john.doe@example.com"]),
+        ("tеst@exаmple.com", ["test@example.com"]),
+        ("john\n.doe@example.com", ["john.doe@example.com"]),
+    ],
+)
+def test_extraction_handles_obfuscations(text, expected):
+    assert smart_extract_emails(text) == expected
+
+
+@pytest.mark.parametrize(
+    "nums, domain",
+    [
+        ("1", "example.com"),
+        ("123", "mail.ru"),
+    ],
+)
+def test_no_number_domain_glue(nums, domain):
+    text = nums + domain
+    assert smart_extract_emails(text) == []


### PR DESCRIPTION
## Summary
- remove binary PDF fixtures and generate PDFs on the fly with PyMuPDF
- drop hypothesis dependency and use deterministic test cases
- ensure all tests run fully offline

## Testing
- `pytest -q`
- `pre-commit run --files requirements.txt tests/test_dedupe_footnotes.py tests/test_gold_dataset.py tests/test_property_extraction.py tests/fixtures/html/footnotes.html` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*


------
https://chatgpt.com/codex/tasks/task_e_68b857b115b88326959095809c7e9c6c