### PR TITLE
feat: add admin feature toggles

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -100,6 +100,7 @@ def main() -> None:
     app.add_handler(CommandHandler("start", bot_handlers.start))
     app.add_handler(CommandHandler("retry_last", bot_handlers.retry_last_command))
     app.add_handler(CommandHandler("diag", bot_handlers.diag))
+    app.add_handler(CommandHandler("features", bot_handlers.features))
 
     app.add_handler(
         MessageHandler(filters.TEXT & filters.Regex("^📤"), bot_handlers.prompt_upload)
@@ -177,6 +178,9 @@ def main() -> None:
     )
     app.add_handler(
         CallbackQueryHandler(bot_handlers.show_foreign_list, pattern="^show_foreign$")
+    )
+    app.add_handler(
+        CallbackQueryHandler(bot_handlers.features_callback, pattern="^feature_")
     )
     app.add_handler(
         CallbackQueryHandler(bot_handlers.refresh_preview, pattern="^refresh_preview$")

--- a/emailbot/extraction.py
+++ b/emailbot/extraction.py
@@ -573,6 +573,8 @@ def extract_from_url(
 ) -> tuple[list[EmailHit], Dict]:
     """Загрузить веб-страницу и извлечь e-mail-адреса."""
 
+    settings.load()
+
     import re
     import urllib.parse
 
@@ -652,6 +654,8 @@ def extract_any(
     Если ``_return_hits`` истинно, функция возвращает список ``EmailHit``;
     иначе возвращает отсортированный список уникальных адресов.
     """
+
+    settings.load()
 
     import os
     import re

--- a/emailbot/extraction_pdf.py
+++ b/emailbot/extraction_pdf.py
@@ -71,6 +71,7 @@ def extract_from_pdf(path: str, stop_event: Optional[object] = None) -> tuple[li
     """Extract e-mail addresses from a PDF file."""
 
     from .extraction import EmailHit, extract_emails_document, _dedupe
+    settings.load()
 
     try:
         import fitz  # type: ignore

--- a/tests/test_url_obfuscation.py
+++ b/tests/test_url_obfuscation.py
@@ -49,17 +49,17 @@ def test_requires_at_token():
 
 
 def test_obfuscation_with_at():
-    html = "<html><body>121536 at gmail dot com</body></html>"
+    html = "<html><body>foo at gmail dot com</body></html>"
     server, url = _serve(html)
     try:
         hits, _ = extract_from_url(url)
     finally:
         server.shutdown()
     emails = [h.email for h in hits]
-    assert "121536@gmail.com" in emails
+    assert "foo@gmail.com" in emails
 
 
-def test_numeric_local_kept():
+def test_numeric_local_dropped():
     html = "<html><body>2@mail.ru and 2 at mail dot ru</body></html>"
     server, url = _serve(html)
     try:
@@ -68,5 +68,6 @@ def test_numeric_local_kept():
         server.shutdown()
     emails = [h.email for h in hits]
     assert "2@mail.ru" in emails
-    assert stats["obfuscated_hits"] >= 1
+    assert stats["obfuscated_hits"] == 0
+    assert stats.get("numeric_from_obfuscation_dropped", 0) >= 1
 


### PR DESCRIPTION
## Summary
- add persistent feature flags with admin UI to toggle them
- support runtime flag changes in extraction modules
- drop numeric obfuscated emails in strict mode

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b866b172a48326834dd14e2b0e7c5b