### PR TITLE
feat: dedupe batch emails and persist mass mailing state

### DIFF
--- a/emailbot/mass_state.py
+++ b/emailbot/mass_state.py
@@ -1,0 +1,33 @@
+import json
+import os
+from typing import Any, Dict, Optional
+
+STATE_PATH = "/mnt/data/mass_state.json"
+
+
+def load_state() -> Optional[Dict[str, Any]]:
+    """Load saved mass mailing state if present."""
+    try:
+        with open(STATE_PATH, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return None
+
+
+def save_state(state: Dict[str, Any]) -> None:
+    """Persist mass mailing state to disk."""
+    os.makedirs(os.path.dirname(STATE_PATH), exist_ok=True)
+    tmp = STATE_PATH + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(state, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, STATE_PATH)
+
+
+def clear_state() -> None:
+    """Remove saved state."""
+    try:
+        os.remove(STATE_PATH)
+    except FileNotFoundError:
+        pass


### PR DESCRIPTION
## Summary
- skip empty sections in preview and merge emails to avoid duplicates across batch uploads
- persist mass mailing progress in /mnt/data/mass_state.json and resume unfinished batches

## Testing
- `pre-commit run --files emailbot/bot_handlers.py emailbot/mass_state.py` *(failed: CONNECT tunnel failed)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b87d3f73088326b2dacd2a636dc865