### PR TITLE
Add admin feature hints and OCR safeguards

### DIFF
--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -217,6 +217,7 @@ async def features(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     user = update.effective_user
     if not user or user.id not in ADMIN_IDS:
+        await update.message.reply_text("Команда доступна только администратору.")
         return
 
     settings.load()
@@ -234,26 +235,25 @@ async def features(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             [
                 [
                     InlineKeyboardButton(
-                        f"Обфускации: {'строгий' if settings.STRICT_OBFUSCATION else 'обычный'} ⏼",
-                        callback_data="feature_strict",
+                        f"Обфускации: {'Строгий' if settings.STRICT_OBFUSCATION else 'Обычный'} ⏼",
+                        callback_data="feat:strict:toggle",
                     )
                 ],
                 [
-                    InlineKeyboardButton(
-                        f"Сноски: радиус {settings.FOOTNOTE_RADIUS_PAGES}",
-                        callback_data="feature_footnote",
-                    )
+                    InlineKeyboardButton("Сноски: радиус 0", callback_data="feat:radius:0"),
+                    InlineKeyboardButton("1", callback_data="feat:radius:1"),
+                    InlineKeyboardButton("2", callback_data="feat:radius:2"),
                 ],
                 [
                     InlineKeyboardButton(
                         f"PDF-layout {'on' if settings.PDF_LAYOUT_AWARE else 'off'} ⏼",
-                        callback_data="feature_pdf",
+                        callback_data="feat:layout:toggle",
                     )
                 ],
                 [
                     InlineKeyboardButton(
                         f"OCR {'on' if settings.ENABLE_OCR else 'off'} ⏼",
-                        callback_data="feature_ocr",
+                        callback_data="feat:ocr:toggle",
                     )
                 ],
             ]
@@ -276,15 +276,43 @@ async def features_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
     settings.load()
 
     data = query.data or ""
-    if data == "feature_strict":
-        settings.STRICT_OBFUSCATION = not settings.STRICT_OBFUSCATION
-    elif data == "feature_footnote":
-        settings.FOOTNOTE_RADIUS_PAGES = (settings.FOOTNOTE_RADIUS_PAGES + 1) % 3
-    elif data == "feature_pdf":
-        settings.PDF_LAYOUT_AWARE = not settings.PDF_LAYOUT_AWARE
-    elif data == "feature_ocr":
-        settings.ENABLE_OCR = not settings.ENABLE_OCR
-    settings.save()
+    hint = ""
+    try:
+        if data == "feat:strict:toggle":
+            settings.STRICT_OBFUSCATION = not settings.STRICT_OBFUSCATION
+            hint = (
+                "🛡️ Строгий режим включён. Парсер принимает обфускации только с явными “at/dot”. "
+                "Ложные «121536@gmail.com» с чисел не появятся. На реальные адреса с @/mailto это не влияет."
+                if settings.STRICT_OBFUSCATION
+                else "⚠️ Строгий режим выключен. Парсер будет пытаться восстановить адреса из менее явных обфускаций. Возможен рост ложных совпадений на «число + домен»."
+            )
+        elif data.startswith("feat:radius:"):
+            n = int(data.rsplit(":", 1)[-1])
+            if n not in {0, 1, 2}:
+                raise ValueError
+            settings.FOOTNOTE_RADIUS_PAGES = n
+            hint = (
+                f"📝 Радиус сносок: {n}. Дубликаты «урезанных» адресов будут склеиваться в пределах той же страницы и ±{n} стр. того же файла."
+            )
+        elif data == "feat:layout:toggle":
+            settings.PDF_LAYOUT_AWARE = not settings.PDF_LAYOUT_AWARE
+            hint = (
+                "📄 Учёт макета PDF включён. Надстрочные (сноски) обрабатываются точнее. Может работать медленнее на больших PDF."
+                if settings.PDF_LAYOUT_AWARE
+                else "📄 Учёт макета PDF выключен. Используется стандартное извлечение текста."
+            )
+        elif data == "feat:ocr:toggle":
+            settings.ENABLE_OCR = not settings.ENABLE_OCR
+            hint = (
+                "🔍 OCR включён. Будем распознавать e-mail в скан-PDF. Анализ станет медленнее. Ограничения: до 10 страниц, таймаут 30 сек."
+                if settings.ENABLE_OCR
+                else "🔍 OCR выключен. Скан-PDF без текста пропускаются без распознавания."
+            )
+        else:
+            raise ValueError
+        settings.save()
+    except Exception:
+        hint = "⛔ Недопустимое значение."
 
     def _status() -> str:
         return (
@@ -299,33 +327,32 @@ async def features_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
             [
                 [
                     InlineKeyboardButton(
-                        f"Обфускации: {'строгий' if settings.STRICT_OBFUSCATION else 'обычный'} ⏼",
-                        callback_data="feature_strict",
+                        f"Обфускации: {'Строгий' if settings.STRICT_OBFUSCATION else 'Обычный'} ⏼",
+                        callback_data="feat:strict:toggle",
                     )
                 ],
                 [
-                    InlineKeyboardButton(
-                        f"Сноски: радиус {settings.FOOTNOTE_RADIUS_PAGES}",
-                        callback_data="feature_footnote",
-                    )
+                    InlineKeyboardButton("Сноски: радиус 0", callback_data="feat:radius:0"),
+                    InlineKeyboardButton("1", callback_data="feat:radius:1"),
+                    InlineKeyboardButton("2", callback_data="feat:radius:2"),
                 ],
                 [
                     InlineKeyboardButton(
                         f"PDF-layout {'on' if settings.PDF_LAYOUT_AWARE else 'off'} ⏼",
-                        callback_data="feature_pdf",
+                        callback_data="feat:layout:toggle",
                     )
                 ],
                 [
                     InlineKeyboardButton(
                         f"OCR {'on' if settings.ENABLE_OCR else 'off'} ⏼",
-                        callback_data="feature_ocr",
+                        callback_data="feat:ocr:toggle",
                     )
                 ],
             ]
         )
 
     await query.answer()
-    await query.edit_message_text(_status(), reply_markup=_keyboard())
+    await query.edit_message_text(f"{_status()}\n\n{hint}", reply_markup=_keyboard())
 
 
 async def diag(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/emailbot/extraction_pdf.py
+++ b/emailbot/extraction_pdf.py
@@ -1,6 +1,7 @@
 """PDF extraction helpers with optional layout and OCR features."""
 from __future__ import annotations
 
+import logging
 import re
 import statistics
 import time
@@ -22,8 +23,10 @@ _SUP_DIGITS = str.maketrans({
     "9": "⁹",
 })
 
-_OCR_PAGE_LIMIT = 5
+_OCR_PAGE_LIMIT = 10
 _OCR_TIME_LIMIT = 30  # seconds
+
+logger = logging.getLogger(__name__)
 
 
 def _page_text_layout(page) -> str:
@@ -128,7 +131,11 @@ def extract_from_pdf(path: str, stop_event: Optional[object] = None) -> tuple[li
                         post=post,
                     )
                 )
+        if stop_event and getattr(stop_event, "is_set", lambda: False)():
+            break
     doc.close()
+    if settings.ENABLE_OCR:
+        logger.debug("ocr_pages=%d", ocr_pages)
     return _dedupe(hits), stats
 
 

--- a/emailbot/settings_store.py
+++ b/emailbot/settings_store.py
@@ -28,7 +28,16 @@ def get(name: str, default: Any | None = None) -> Any:
 
 
 def set(name: str, value: Any) -> None:
-    """Persist a setting value to :data:`SETTINGS_PATH`."""
+    """Persist a setting value to :data:`SETTINGS_PATH` with validation."""
+
+    allowed = {
+        "STRICT_OBFUSCATION": {True, False},
+        "FOOTNOTE_RADIUS_PAGES": {0, 1, 2},
+        "PDF_LAYOUT_AWARE": {True, False},
+        "ENABLE_OCR": {True, False},
+    }
+    if name in allowed and value not in allowed[name]:
+        raise ValueError("invalid value")
     data = _load()
     data[name] = value
     try:

--- a/tests/test_admin_features.py
+++ b/tests/test_admin_features.py
@@ -1,0 +1,122 @@
+import asyncio
+import types
+
+import pytest
+from telegram import InlineKeyboardMarkup
+
+import emailbot.bot_handlers as bh
+
+
+class DummyMessage:
+    def __init__(self, text: str | None = None, chat_id: int = 123):
+        self.text = text
+        self.chat = types.SimpleNamespace(id=chat_id)
+        self.replies: list[str] = []
+        self.reply_markups: list | None = []
+
+    async def reply_text(self, text, reply_markup=None):
+        self.replies.append(text)
+        self.reply_markups.append(reply_markup)
+        return self
+
+
+class DummyQuery:
+    def __init__(self, data: str, chat_id: int):
+        self.data = data
+        self.message = DummyMessage(chat_id=chat_id)
+        self.from_user = types.SimpleNamespace(id=chat_id)
+
+    async def answer(self, *a, **k):
+        return
+
+    async def edit_message_text(self, text, reply_markup=None):
+        await self.message.reply_text(text, reply_markup=reply_markup)
+
+
+class DummyUpdate:
+    def __init__(self, text: str | None = None, chat_id: int = 123, callback_data: str | None = None):
+        self.message = DummyMessage(text=text, chat_id=chat_id)
+        self.effective_user = types.SimpleNamespace(id=chat_id)
+        if callback_data is not None:
+            self.callback_query = DummyQuery(callback_data, chat_id)
+
+
+class DummyContext:
+    def __init__(self):
+        self.chat_data: dict = {}
+        self.user_data: dict = {}
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_features_non_admin(monkeypatch):
+    monkeypatch.setattr(bh, "ADMIN_IDS", {999})
+    update = DummyUpdate(text="/features", chat_id=1)
+    ctx = DummyContext()
+    run(bh.features(update, ctx))
+    assert update.message.replies == ["Команда доступна только администратору."]
+
+
+def _init_settings(monkeypatch):
+    import emailbot.settings as settings
+
+    monkeypatch.setattr(settings, "STRICT_OBFUSCATION", True)
+    monkeypatch.setattr(settings, "FOOTNOTE_RADIUS_PAGES", 1)
+    monkeypatch.setattr(settings, "PDF_LAYOUT_AWARE", False)
+    monkeypatch.setattr(settings, "ENABLE_OCR", False)
+    monkeypatch.setattr(settings, "load", lambda: None)
+    monkeypatch.setattr(settings, "save", lambda: None)
+    return settings
+
+
+def test_features_admin_flow(monkeypatch):
+    monkeypatch.setattr(bh, "ADMIN_IDS", {123})
+    _init_settings(monkeypatch)
+
+    update = DummyUpdate(text="/features", chat_id=123)
+    ctx = DummyContext()
+    run(bh.features(update, ctx))
+
+    markup = update.message.reply_markups[0]
+    assert isinstance(markup, InlineKeyboardMarkup)
+    buttons = [b.callback_data for row in markup.inline_keyboard for b in row]
+    assert buttons == [
+        "feat:strict:toggle",
+        "feat:radius:0",
+        "feat:radius:1",
+        "feat:radius:2",
+        "feat:layout:toggle",
+        "feat:ocr:toggle",
+    ]
+
+    # Toggle strict
+    cb = DummyUpdate(callback_data="feat:strict:toggle", chat_id=123)
+    run(bh.features_callback(cb, ctx))
+    text = cb.callback_query.message.replies[-1]
+    assert "STRICT_OBFUSCATION=off" in text
+    assert "⚠️" in text
+
+    # Set radius to 2
+    cb = DummyUpdate(callback_data="feat:radius:2", chat_id=123)
+    run(bh.features_callback(cb, ctx))
+    text = cb.callback_query.message.replies[-1]
+    assert "FOOTNOTE_RADIUS_PAGES=2" in text
+    assert "📝 Радиус сносок: 2." in text
+
+    # Toggle layout on then off
+    cb = DummyUpdate(callback_data="feat:layout:toggle", chat_id=123)
+    run(bh.features_callback(cb, ctx))
+    assert "📄 Учёт макета PDF включён" in cb.callback_query.message.replies[-1]
+    cb = DummyUpdate(callback_data="feat:layout:toggle", chat_id=123)
+    run(bh.features_callback(cb, ctx))
+    assert "📄 Учёт макета PDF выключен" in cb.callback_query.message.replies[-1]
+
+    # Toggle OCR on then off
+    cb = DummyUpdate(callback_data="feat:ocr:toggle", chat_id=123)
+    run(bh.features_callback(cb, ctx))
+    assert "🔍 OCR включён" in cb.callback_query.message.replies[-1]
+    cb = DummyUpdate(callback_data="feat:ocr:toggle", chat_id=123)
+    run(bh.features_callback(cb, ctx))
+    assert "🔍 OCR выключен" in cb.callback_query.message.replies[-1]

--- a/tests/test_pdf_ocr.py
+++ b/tests/test_pdf_ocr.py
@@ -1,0 +1,48 @@
+import threading
+from pathlib import Path
+import types
+
+import pytest
+
+import emailbot.extraction_pdf as ep
+
+
+def _create_blank_pdf(path: Path) -> None:
+    import fitz  # type: ignore
+
+    doc = fitz.open()
+    doc.new_page()
+    doc.save(path)
+
+
+def test_ocr_toggle(monkeypatch, tmp_path: Path):
+    pdf = tmp_path / "scan.pdf"
+    _create_blank_pdf(pdf)
+
+    monkeypatch.setattr(ep, "_ocr_page", lambda page: "scan@example.com")
+    monkeypatch.setattr(ep, "preprocess_text", lambda t: t)
+
+    settings = types.SimpleNamespace(PDF_LAYOUT_AWARE=False, ENABLE_OCR=False, load=lambda: None)
+    monkeypatch.setattr(ep, "settings", settings)
+
+    hits, stats = ep.extract_from_pdf(str(pdf))
+    assert [h.email for h in hits] == []
+
+    settings.ENABLE_OCR = True
+    hits, stats = ep.extract_from_pdf(str(pdf))
+    assert [h.email for h in hits] == ["scan@example.com"]
+    assert stats["ocr_pages"] == 1
+
+
+def test_stop_event(monkeypatch, tmp_path: Path):
+    pdf = tmp_path / "scan.pdf"
+    _create_blank_pdf(pdf)
+
+    monkeypatch.setattr(ep, "_ocr_page", lambda page: "")
+    settings = types.SimpleNamespace(PDF_LAYOUT_AWARE=False, ENABLE_OCR=True, load=lambda: None)
+    monkeypatch.setattr(ep, "settings", settings)
+
+    event = threading.Event()
+    event.set()
+    hits, stats = ep.extract_from_pdf(str(pdf), stop_event=event)
+    assert stats["pages"] == 0


### PR DESCRIPTION
## Summary
- Show admin-only feature toggles with inline buttons and detailed hints
- Validate settings values when persisting configuration
- Limit OCR processing to 10 pages with timeout and debug logging
- Test feature access, hint rendering, OCR toggling, and stop events

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b88614f78c83268999de67bc1712e6