### PR TITLE
Use recommended defaults for OCR and obfuscation settings

### DIFF
--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -30,6 +30,7 @@ from .extraction import normalize_email, smart_extract_emails, extract_emails_ma
 from .reporting import build_mass_report_text
 from . import settings
 from . import mass_state
+from .settings_store import DEFAULTS
 
 
 def _preclean_text_for_emails(text: str) -> str:
@@ -223,12 +224,24 @@ async def features(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     settings.load()
 
     def _status() -> str:
-        return (
-            f"STRICT_OBFUSCATION={'on' if settings.STRICT_OBFUSCATION else 'off'}\n"
-            f"FOOTNOTE_RADIUS_PAGES={settings.FOOTNOTE_RADIUS_PAGES}\n"
-            f"PDF_LAYOUT_AWARE={'on' if settings.PDF_LAYOUT_AWARE else 'off'}\n"
-            f"ENABLE_OCR={'on' if settings.ENABLE_OCR else 'off'}"
-        )
+        lines = []
+        line = f"STRICT_OBFUSCATION={'on' if settings.STRICT_OBFUSCATION else 'off'}"
+        if settings.STRICT_OBFUSCATION == DEFAULTS["STRICT_OBFUSCATION"]:
+            line += " (рекомендуется)"
+        lines.append(line)
+        line = f"FOOTNOTE_RADIUS_PAGES={settings.FOOTNOTE_RADIUS_PAGES}"
+        if settings.FOOTNOTE_RADIUS_PAGES == DEFAULTS["FOOTNOTE_RADIUS_PAGES"]:
+            line += " (рекомендуется)"
+        lines.append(line)
+        line = f"PDF_LAYOUT_AWARE={'on' if settings.PDF_LAYOUT_AWARE else 'off'}"
+        if settings.PDF_LAYOUT_AWARE == DEFAULTS["PDF_LAYOUT_AWARE"]:
+            line += " (рекомендуется)"
+        lines.append(line)
+        line = f"ENABLE_OCR={'on' if settings.ENABLE_OCR else 'off'}"
+        if settings.ENABLE_OCR == DEFAULTS["ENABLE_OCR"]:
+            line += " (рекомендуется)"
+        lines.append(line)
+        return "\n".join(lines)
 
     def _keyboard() -> InlineKeyboardMarkup:
         return InlineKeyboardMarkup(
@@ -256,10 +269,22 @@ async def features(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                         callback_data="feat:ocr:toggle",
                     )
                 ],
+                [
+                    InlineKeyboardButton(
+                        "Сбросить к рекомендованным",
+                        callback_data="feat:reset:defaults",
+                    )
+                ],
             ]
         )
 
-    await update.message.reply_text(_status(), reply_markup=_keyboard())
+    def _doc() -> str:
+        return (
+            "ℹ️ Рекомендуемые настройки: строгие обфускации — ON, радиус сносок — 1, "
+            "PDF-layout — OFF, OCR — OFF."
+        )
+
+    await update.message.reply_text(f"{_status()}\n\n{_doc()}", reply_markup=_keyboard())
 
 
 async def features_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -308,6 +333,12 @@ async def features_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
                 if settings.ENABLE_OCR
                 else "🔍 OCR выключен. Скан-PDF без текста пропускаются без распознавания."
             )
+        elif data == "feat:reset:defaults":
+            settings.STRICT_OBFUSCATION = DEFAULTS["STRICT_OBFUSCATION"]
+            settings.FOOTNOTE_RADIUS_PAGES = DEFAULTS["FOOTNOTE_RADIUS_PAGES"]
+            settings.PDF_LAYOUT_AWARE = DEFAULTS["PDF_LAYOUT_AWARE"]
+            settings.ENABLE_OCR = DEFAULTS["ENABLE_OCR"]
+            hint = "↩️ Сброшено к рекомендованным настройкам."
         else:
             raise ValueError
         settings.save()
@@ -315,12 +346,24 @@ async def features_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         hint = "⛔ Недопустимое значение."
 
     def _status() -> str:
-        return (
-            f"STRICT_OBFUSCATION={'on' if settings.STRICT_OBFUSCATION else 'off'}\n"
-            f"FOOTNOTE_RADIUS_PAGES={settings.FOOTNOTE_RADIUS_PAGES}\n"
-            f"PDF_LAYOUT_AWARE={'on' if settings.PDF_LAYOUT_AWARE else 'off'}\n"
-            f"ENABLE_OCR={'on' if settings.ENABLE_OCR else 'off'}"
-        )
+        lines = []
+        line = f"STRICT_OBFUSCATION={'on' if settings.STRICT_OBFUSCATION else 'off'}"
+        if settings.STRICT_OBFUSCATION == DEFAULTS["STRICT_OBFUSCATION"]:
+            line += " (рекомендуется)"
+        lines.append(line)
+        line = f"FOOTNOTE_RADIUS_PAGES={settings.FOOTNOTE_RADIUS_PAGES}"
+        if settings.FOOTNOTE_RADIUS_PAGES == DEFAULTS["FOOTNOTE_RADIUS_PAGES"]:
+            line += " (рекомендуется)"
+        lines.append(line)
+        line = f"PDF_LAYOUT_AWARE={'on' if settings.PDF_LAYOUT_AWARE else 'off'}"
+        if settings.PDF_LAYOUT_AWARE == DEFAULTS["PDF_LAYOUT_AWARE"]:
+            line += " (рекомендуется)"
+        lines.append(line)
+        line = f"ENABLE_OCR={'on' if settings.ENABLE_OCR else 'off'}"
+        if settings.ENABLE_OCR == DEFAULTS["ENABLE_OCR"]:
+            line += " (рекомендуется)"
+        lines.append(line)
+        return "\n".join(lines)
 
     def _keyboard() -> InlineKeyboardMarkup:
         return InlineKeyboardMarkup(
@@ -348,11 +391,25 @@ async def features_callback(update: Update, context: ContextTypes.DEFAULT_TYPE) 
                         callback_data="feat:ocr:toggle",
                     )
                 ],
+                [
+                    InlineKeyboardButton(
+                        "Сбросить к рекомендованным",
+                        callback_data="feat:reset:defaults",
+                    )
+                ],
             ]
         )
 
+    def _doc() -> str:
+        return (
+            "ℹ️ Рекомендуемые настройки: строгие обфускации — ON, радиус сносок — 1, "
+            "PDF-layout — OFF, OCR — OFF."
+        )
+
     await query.answer()
-    await query.edit_message_text(f"{_status()}\n\n{hint}", reply_markup=_keyboard())
+    await query.edit_message_text(
+        f"{_status()}\n\n{hint}\n\n{_doc()}", reply_markup=_keyboard()
+    )
 
 
 async def diag(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/emailbot/extraction.py
+++ b/emailbot/extraction.py
@@ -20,6 +20,7 @@ from .dedupe import merge_footnote_prefix_variants
 from .extraction_common import normalize_email, normalize_text, preprocess_text
 from .extraction_pdf import extract_from_pdf
 from .extraction_zip import extract_emails_from_zip
+from .settings_store import get
 
 __all__ = [
     "EmailHit",
@@ -573,7 +574,10 @@ def extract_from_url(
 ) -> tuple[list[EmailHit], Dict]:
     """Загрузить веб-страницу и извлечь e-mail-адреса."""
 
-    settings.load()
+    settings.STRICT_OBFUSCATION = get("STRICT_OBFUSCATION", settings.STRICT_OBFUSCATION)
+    settings.FOOTNOTE_RADIUS_PAGES = get("FOOTNOTE_RADIUS_PAGES", settings.FOOTNOTE_RADIUS_PAGES)
+    settings.PDF_LAYOUT_AWARE = get("PDF_LAYOUT_AWARE", settings.PDF_LAYOUT_AWARE)
+    settings.ENABLE_OCR = get("ENABLE_OCR", settings.ENABLE_OCR)
 
     import re
     import urllib.parse
@@ -655,7 +659,10 @@ def extract_any(
     иначе возвращает отсортированный список уникальных адресов.
     """
 
-    settings.load()
+    settings.STRICT_OBFUSCATION = get("STRICT_OBFUSCATION", settings.STRICT_OBFUSCATION)
+    settings.FOOTNOTE_RADIUS_PAGES = get("FOOTNOTE_RADIUS_PAGES", settings.FOOTNOTE_RADIUS_PAGES)
+    settings.PDF_LAYOUT_AWARE = get("PDF_LAYOUT_AWARE", settings.PDF_LAYOUT_AWARE)
+    settings.ENABLE_OCR = get("ENABLE_OCR", settings.ENABLE_OCR)
 
     import os
     import re

--- a/tests/test_admin_defaults.py
+++ b/tests/test_admin_defaults.py
@@ -1,0 +1,86 @@
+import asyncio
+import types
+import pytest
+
+import emailbot.bot_handlers as bh
+import emailbot.settings_store as store
+from emailbot.settings_store import get, set
+
+
+class DummyMessage:
+    def __init__(self, text: str | None = None, chat_id: int = 123):
+        self.text = text
+        self.chat = types.SimpleNamespace(id=chat_id)
+        self.replies: list[str] = []
+        self.reply_markups: list | None = []
+
+    async def reply_text(self, text, reply_markup=None):
+        self.replies.append(text)
+        self.reply_markups.append(reply_markup)
+        return self
+
+
+class DummyQuery:
+    def __init__(self, data: str, chat_id: int):
+        self.data = data
+        self.message = DummyMessage(chat_id=chat_id)
+        self.from_user = types.SimpleNamespace(id=chat_id)
+
+    async def answer(self, *a, **k):
+        return
+
+    async def edit_message_text(self, text, reply_markup=None):
+        await self.message.reply_text(text, reply_markup=reply_markup)
+
+
+class DummyUpdate:
+    def __init__(self, text: str | None = None, chat_id: int = 123, callback_data: str | None = None):
+        self.message = DummyMessage(text=text, chat_id=chat_id)
+        self.effective_user = types.SimpleNamespace(id=chat_id)
+        if callback_data is not None:
+            self.callback_query = DummyQuery(callback_data, chat_id)
+
+
+class DummyContext:
+    def __init__(self):
+        self.chat_data: dict = {}
+        self.user_data: dict = {}
+
+
+def run(coro):
+    return asyncio.run(coro)
+
+
+def test_defaults_and_reset(monkeypatch, tmp_path):
+    path = tmp_path / "settings.json"
+    monkeypatch.setattr(store, "SETTINGS_PATH", path)
+    store._cache = None
+    store._mtime = 0.0
+
+    assert get("STRICT_OBFUSCATION") is True
+    assert get("FOOTNOTE_RADIUS_PAGES") == 1
+    assert get("PDF_LAYOUT_AWARE") is False
+    assert get("ENABLE_OCR") is False
+
+    set("STRICT_OBFUSCATION", False)
+    set("FOOTNOTE_RADIUS_PAGES", 2)
+    set("PDF_LAYOUT_AWARE", True)
+    set("ENABLE_OCR", True)
+
+    assert get("STRICT_OBFUSCATION") is False
+
+    monkeypatch.setattr(bh, "ADMIN_IDS", {123})
+    update = DummyUpdate(callback_data="feat:reset:defaults", chat_id=123)
+    ctx = DummyContext()
+    run(bh.features_callback(update, ctx))
+
+    assert get("STRICT_OBFUSCATION") is True
+    assert get("FOOTNOTE_RADIUS_PAGES") == 1
+    assert get("PDF_LAYOUT_AWARE") is False
+    assert get("ENABLE_OCR") is False
+
+    monkeypatch.setattr(bh, "ADMIN_IDS", {999})
+    update2 = DummyUpdate(text="/features", chat_id=1)
+    ctx2 = DummyContext()
+    run(bh.features(update2, ctx2))
+    assert update2.message.replies == ["Команда доступна только администратору."]

--- a/tests/test_admin_features.py
+++ b/tests/test_admin_features.py
@@ -89,6 +89,7 @@ def test_features_admin_flow(monkeypatch):
         "feat:radius:2",
         "feat:layout:toggle",
         "feat:ocr:toggle",
+        "feat:reset:defaults",
     ]
 
     # Toggle strict

--- a/tests/test_pdf_ocr.py
+++ b/tests/test_pdf_ocr.py
@@ -22,8 +22,15 @@ def test_ocr_toggle(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(ep, "_ocr_page", lambda page: "scan@example.com")
     monkeypatch.setattr(ep, "preprocess_text", lambda t: t)
 
-    settings = types.SimpleNamespace(PDF_LAYOUT_AWARE=False, ENABLE_OCR=False, load=lambda: None)
+    settings = types.SimpleNamespace(
+        PDF_LAYOUT_AWARE=False,
+        ENABLE_OCR=False,
+        STRICT_OBFUSCATION=True,
+        FOOTNOTE_RADIUS_PAGES=1,
+        load=lambda: None,
+    )
     monkeypatch.setattr(ep, "settings", settings)
+    monkeypatch.setattr(ep, "get", lambda key, default=None: getattr(settings, key, default))
 
     hits, stats = ep.extract_from_pdf(str(pdf))
     assert [h.email for h in hits] == []
@@ -39,8 +46,15 @@ def test_stop_event(monkeypatch, tmp_path: Path):
     _create_blank_pdf(pdf)
 
     monkeypatch.setattr(ep, "_ocr_page", lambda page: "")
-    settings = types.SimpleNamespace(PDF_LAYOUT_AWARE=False, ENABLE_OCR=True, load=lambda: None)
+    settings = types.SimpleNamespace(
+        PDF_LAYOUT_AWARE=False,
+        ENABLE_OCR=True,
+        STRICT_OBFUSCATION=True,
+        FOOTNOTE_RADIUS_PAGES=1,
+        load=lambda: None,
+    )
     monkeypatch.setattr(ep, "settings", settings)
+    monkeypatch.setattr(ep, "get", lambda key, default=None: getattr(settings, key, default))
 
     event = threading.Event()
     event.set()


### PR DESCRIPTION
## Summary
- persist default feature flags and auto-populate missing keys
- respect recommended defaults when reading settings and add admin reset
- test default settings creation and admin reset

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b88b85c8e083268094e7429f6ccb80