### PR TITLE
feat: canonical email history and sync dedupe

### DIFF
--- a/emailbot/messaging_utils.py
+++ b/emailbot/messaging_utils.py
@@ -1,12 +1,16 @@
 import csv
 import logging
+import os
 import re
+import time
+import unicodedata
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List
+from typing import List, Dict, Iterable, Tuple
 
 SUPPRESS_PATH = Path("/mnt/data/suppress_list.csv")  # e-mail, code, reason, first_seen, last_seen, hits
 BOUNCE_LOG_PATH = Path("/mnt/data/bounce_log.csv")   # ts, email, code, msg, phase
+SYNC_SEEN_EVENTS_PATH = Path("/mnt/data/sync_seen_events.csv")
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +41,176 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+_ZERO_WIDTH_RE = re.compile(r"[\u200B\u200C\u200D\uFEFF]")
+
+
+class FileLock:
+    """Very small cross-platform file lock."""
+
+    def __init__(self, target: Path):
+        self._path = target.with_suffix(target.suffix + ".lock")
+        self._fd: int | None = None
+
+    def acquire(self, retries: int = 5, delay: float = 0.1) -> None:
+        for i in range(retries):
+            try:
+                self._fd = os.open(self._path, os.O_CREAT | os.O_EXCL | os.O_RDWR)
+                return
+            except FileExistsError:
+                time.sleep(delay * (i + 1))
+        raise RuntimeError("could not acquire lock")
+
+    def release(self) -> None:
+        if self._fd is not None:
+            os.close(self._fd)
+            self._fd = None
+        try:
+            os.unlink(self._path)
+        except FileNotFoundError:
+            pass
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.release()
+
+
+def canonical_for_history(email: str) -> str:
+    """Return canonical key for history deduplication."""
+
+    email = (email or "").strip().strip("'\"")
+    email = _ZERO_WIDTH_RE.sub("", email)
+    email = unicodedata.normalize("NFKC", email).lower()
+    local, sep, domain = email.partition("@")
+    if not sep:
+        return email
+    try:
+        domain = domain.encode("idna").decode("ascii")
+    except Exception:
+        domain = domain.encode("ascii", "ignore").decode("ascii")
+    if domain in {"gmail.com", "googlemail.com"}:
+        domain = "gmail.com"
+        local = local.split("+", 1)[0].replace(".", "")
+    return f"{local}@{domain}"
+
+
+def _atomic_write(path: Path, rows: Iterable[Dict[str, str]], headers: List[str]) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", newline="", encoding="utf-8") as f:
+        w = csv.DictWriter(f, fieldnames=headers)
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+    os.replace(tmp, path)
+
+
+def load_sent_log(path: Path) -> Dict[str, datetime]:
+    data: Dict[str, datetime] = {}
+    if path.exists():
+        with path.open(encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                try:
+                    dt = datetime.fromisoformat(row["last_sent_at"])
+                except Exception:
+                    continue
+                data[row["key"]] = dt
+    return data
+
+
+def upsert_sent_log(
+    path: str | Path,
+    email: str,
+    ts: datetime,
+    source: str,
+    extra: Dict[str, str] | None = None,
+) -> Tuple[bool, bool]:
+    """Insert or update ``sent_log`` row."""
+
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    key = canonical_for_history(email)
+    inserted = False
+    updated = False
+    with FileLock(p):
+        current = load_sent_log(p)
+        existing = current.get(key)
+        if existing is None:
+            inserted = True
+        elif ts > existing:
+            updated = True
+        else:
+            return False, False
+        rows_data: List[Dict[str, str]] = []
+        if p.exists():
+            with p.open(encoding="utf-8") as f:
+                rows_data = list(csv.DictReader(f))
+        if inserted:
+            row = {"key": key, "email": email.strip(), "last_sent_at": ts.isoformat(), "source": source}
+            if extra:
+                row.update({k: str(v) for k, v in extra.items()})
+            rows_data.append(row)
+        else:
+            for row in rows_data:
+                if row.get("key") == key:
+                    row["email"] = email.strip()
+                    row["last_sent_at"] = ts.isoformat()
+                    row["source"] = source
+                    if extra:
+                        row.update({k: str(v) for k, v in extra.items()})
+        headers = rows_data[0].keys() if rows_data else ["key", "email", "last_sent_at", "source"]
+        _atomic_write(p, rows_data, list(headers))
+    return inserted, updated
+
+
+def dedupe_sent_log_inplace(path: str | Path) -> Dict[str, int]:
+    p = Path(path)
+    rows = []
+    if p.exists():
+        with p.open(encoding="utf-8") as f:
+            rows = list(csv.DictReader(f))
+    best: Dict[str, Dict[str, str]] = {}
+    for r in rows:
+        key = r.get("key") or canonical_for_history(r.get("email", ""))
+        try:
+            ts = datetime.fromisoformat(r.get("last_sent_at", ""))
+        except Exception:
+            continue
+        current = best.get(key)
+        if current is None or datetime.fromisoformat(current["last_sent_at"]) < ts:
+            r = dict(r)
+            r["key"] = key
+            best[key] = r
+    before = len(rows)
+    after = len(best)
+    headers = ["key", "email", "last_sent_at", "source"]
+    if best:
+        extra_fields = set().union(*(r.keys() for r in best.values()))
+        headers = [h for h in headers if h in extra_fields] + [h for h in extra_fields if h not in headers]
+    with FileLock(p):
+        _atomic_write(p, best.values(), headers)
+    return {"before": before, "after": after, "removed": before - after}
+
+
+def load_seen_events(path: Path) -> set[tuple[str, str]]:
+    events: set[tuple[str, str]] = set()
+    if path.exists():
+        with path.open(encoding="utf-8") as f:
+            reader = csv.reader(f)
+            for row in reader:
+                if len(row) >= 2:
+                    events.add((row[0], row[1]))
+    return events
+
+
+def save_seen_events(path: Path, events: Iterable[tuple[str, str]]) -> None:
+    headers = ["msgid", "key"]
+    rows = [dict(msgid=m, key=k) for m, k in events]
+    with FileLock(path):
+        _atomic_write(path, rows, headers)
+
+
 def _ensure_headers(p: Path, headers: List[str]):
     new = not p.exists()
     p.parent.mkdir(parents=True, exist_ok=True)
@@ -47,36 +221,20 @@ def _ensure_headers(p: Path, headers: List[str]):
     return f, w
 
 
-def _canon_180(email: str) -> str:
-    """Normalize e-mail for 180-day duplicate detection.
-
-    Gmail addresses are canonicalized by removing dots from the local part and
-    stripping anything after a ``+`` tag. The domain is lowercased. For other
-    domains we simply lower-case and trim the address.
-    """
-
-    email = (email or "").strip().lower()
-    local, sep, domain = email.partition("@")
-    if sep and domain in {"gmail.com", "googlemail.com"}:
-        local = local.split("+", 1)[0].replace(".", "")
-        email = f"{local}@{domain}"
-    return email
-
-
 def log_sent(email: str, *args, **kwargs):
-    """Wrapper around :func:`messaging.log_sent_email` with Gmail canon."""
+    """Wrapper around :func:`messaging.log_sent_email`."""
 
     from . import messaging as _messaging
 
-    return _messaging.log_sent_email(_canon_180(email), *args, **kwargs)
+    return _messaging.log_sent_email(email, *args, **kwargs)
 
 
 def was_sent_within(email: str, days: int = 180) -> bool:
-    """Check recent sends using Gmail canonicalization."""
+    """Check recent sends."""
 
     from . import messaging as _messaging
 
-    return _messaging.was_sent_within(_canon_180(email), days=days)
+    return _messaging.was_sent_within(email, days=days)
 
 
 def add_bounce(email: str, code: int | None, msg: str, phase: str) -> None:


### PR DESCRIPTION
## Summary
- canonicalize emails for history and track in sent log
- add atomic sent log upsert and IMAP sync dedupe
- expose admin dedupe command and sync statistics

## Testing
- `pytest`
- `pre-commit run --files emailbot/messaging_utils.py emailbot/messaging.py emailbot/bot_handlers.py tests/test_messaging_utils.py tests/test_messaging.py tests/test_retry_last.py` *(failed: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b93c5bfcd48326af093bae407307d9