### PR TITLE
Improve document stream extraction and safe temp cleanup

### DIFF
--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -151,6 +151,13 @@ def test_extract_from_documents(tmp_path: Path):
     assert [h.email for h in hits_txt] == ["d@text.com"]
 
 
+def test_xlsx_no_handle_leak(tmp_path: Path):
+    path = tmp_path / "leak.xlsx"
+    _create_xlsx(path, "leak@example.com")
+    extraction.extract_from_xlsx(str(path))
+    os.remove(path)
+
+
 @pytest.mark.asyncio
 async def test_zip_handler_signature(monkeypatch, tmp_path: Path):
     from tests.test_bot_handlers import DummyContext, DummyDocument, DummyUpdate


### PR DESCRIPTION
## Summary
- add `_safe_unlink` helper and avoid temp files when extracting from ZIPs
- support in-memory extraction for pdf/docx/xlsx/txt/csv/html via `extract_any_stream`
- ensure openpyxl workbooks are always closed and add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9477fb3c883268ca6425329871914