### PR TITLE
Refactor sent log handling and sync

### DIFF
--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -744,9 +744,8 @@ async def sync_imap_command(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         clear_recent_sent_cache()
         await update.message.reply_text(
             "🔄 "
-            f"Писем: {stats['scanned_messages']}, получателей: {stats['recipients_seen']}, "
             f"новых: {stats['new_contacts']}, обновлено: {stats['updated_contacts']}, "
-            f"дубликатов: {stats['skipped_duplicates']}"
+            f"пропущено: {stats['skipped_events']}, всего: {stats['total_rows_after']}"
         )
     except Exception as e:
         await update.message.reply_text(f"❌ Ошибка синхронизации: {e}")
@@ -1665,9 +1664,8 @@ async def autosync_imap_with_message(query: CallbackQuery) -> None:
     clear_recent_sent_cache()
     await query.message.reply_text(
         "✅ Синхронизация завершена. "
-        f"Писем: {stats['scanned_messages']}, получателей: {stats['recipients_seen']}, "
         f"новых: {stats['new_contacts']}, обновлено: {stats['updated_contacts']}, "
-        f"дубликатов: {stats['skipped_duplicates']}.\n"
+        f"пропущено: {stats['skipped_events']}, всего: {stats['total_rows_after']}.\n"
         f"История отправки обновлена на последние 6 месяцев."
     )
 

--- a/tests/test_retry_last.py
+++ b/tests/test_retry_last.py
@@ -98,7 +98,7 @@ def test_retry_last_no_soft(monkeypatch, tmp_path):
     assert update.message.replies[-1] == "Нет писем для ретрая"
 
 
-def test_sync_skips_seen_events(monkeypatch, tmp_path):
+def test_sync_uses_upsert_and_no_duplicates(monkeypatch, tmp_path):
     log = tmp_path / "sent_log.csv"
     seen = tmp_path / "seen.csv"
     monkeypatch.setattr(messaging, "LOG_FILE", str(log))
@@ -137,4 +137,4 @@ def test_sync_skips_seen_events(monkeypatch, tmp_path):
 
     assert stats1["new_contacts"] == 1
     assert stats2["new_contacts"] == 0
-    assert stats2["skipped_duplicates"] == 1
+    assert stats2["skipped_events"] == 1


### PR DESCRIPTION
## Summary
- add schema migration with legacy header mapping for sent_log.csv
- canonicalize emails and implement idempotent sent log upserts
- sync IMAP history using upsert-only and track new/update/skip stats

## Testing
- `pytest`
- `pre-commit run --files emailbot/messaging_utils.py emailbot/messaging.py emailbot/bot_handlers.py tests/test_messaging_utils.py tests/test_retry_last.py` *(failed: unable to access 'https://github.com/pre-commit/pre-commit-hooks/')*


------
https://chatgpt.com/codex/tasks/task_e_68b94c25880483268e59dead49fc8ed5