### PR TITLE
Improve TLD classification and foreign preview logic

### DIFF
--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -277,3 +277,27 @@ async def test_send_manual_email_no_block_mentions(monkeypatch):
     text = "\n".join(update.callback_query.message.replies)
     assert "блок" not in text
     assert "180" not in text
+
+
+def test_preview_separates_foreign():
+    ctx = DummyContext()
+    allowed_all = {
+        "user@ncfu.ru",
+        "user@gmail.com",
+        "user@gmail.com.br",
+    }
+    filtered = ["user@ncfu.ru", "user@gmail.com"]
+    foreign = ["user@gmail.com.br"]
+    run(
+        bh._compose_report_and_save(
+            ctx,
+            allowed_all,
+            filtered,
+            [],
+            foreign,
+            0,
+        )
+    )
+    state = ctx.chat_data[SESSION_KEY]
+    assert "user@gmail.com.br" in state.foreign
+    assert "user@gmail.com.br" not in state.preview_allowed_all

--- a/tests/test_messaging_utils.py
+++ b/tests/test_messaging_utils.py
@@ -90,3 +90,13 @@ def test_upsert_idempotent(tmp_path):
     with path.open() as f:
         rows = list(csv.DictReader(f))
     assert len(rows) == 1
+
+
+def test_classify_tld():
+    assert mu.classify_tld("user@gmail.com") == "generic"
+    assert mu.classify_tld("user@ncfu.ru") == "domestic"
+    assert mu.classify_tld("user@gmail.com.br") == "foreign"
+    assert mu.classify_tld("user@edu.br") == "foreign"
+    assert mu.classify_tld("user@ufjf.br") == "foreign"
+    assert mu.classify_tld("user@ufmg.br") == "foreign"
+    assert mu.classify_tld("user@ufop.edu.br") == "foreign"


### PR DESCRIPTION
## Summary
- Implement `classify_tld` with domestic and generic TLD lists
- Use classifier to filter foreign domains and avoid duplicate previews
- Update tests for TLD classification and preview separation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b966e6b12083269f650c2b26092efa