### PR TITLE
Repair PDF footnote singleton emails

### DIFF
--- a/emailbot/extraction_pdf.py
+++ b/emailbot/extraction_pdf.py
@@ -74,7 +74,12 @@ def _ocr_page(page) -> str:
 def extract_from_pdf(path: str, stop_event: Optional[object] = None) -> tuple[list["EmailHit"], Dict]:
     """Extract e-mail addresses from a PDF file."""
 
-    from .extraction import EmailHit, extract_emails_document, _dedupe
+    from .extraction import (
+        EmailHit,
+        extract_emails_document,
+        repair_footnote_singletons,
+        _dedupe,
+    )
     settings.load()
     strict = get("STRICT_OBFUSCATION", settings.STRICT_OBFUSCATION)
     radius = get("FOOTNOTE_RADIUS_PAGES", settings.FOOTNOTE_RADIUS_PAGES)
@@ -141,7 +146,9 @@ def extract_from_pdf(path: str, stop_event: Optional[object] = None) -> tuple[li
     doc.close()
     if ocr:
         logger.debug("ocr_pages=%d", ocr_pages)
-    return _dedupe(hits), stats
+    hits = _dedupe(hits)
+    hits = repair_footnote_singletons(hits, stats)
+    return hits, stats
 
 
 def extract_from_pdf_stream(
@@ -149,7 +156,12 @@ def extract_from_pdf_stream(
 ) -> tuple[list["EmailHit"], Dict]:
     """Extract e-mail addresses from PDF bytes."""
 
-    from .extraction import EmailHit, extract_emails_document, _dedupe
+    from .extraction import (
+        EmailHit,
+        extract_emails_document,
+        repair_footnote_singletons,
+        _dedupe,
+    )
 
     settings.load()
     strict = get("STRICT_OBFUSCATION", settings.STRICT_OBFUSCATION)
@@ -216,7 +228,9 @@ def extract_from_pdf_stream(
     doc.close()
     if ocr:
         logger.debug("ocr_pages=%d", ocr_pages)
-    return _dedupe(hits), stats
+    hits = _dedupe(hits)
+    hits = repair_footnote_singletons(hits, stats)
+    return hits, stats
 
 
 __all__ = ["extract_from_pdf", "extract_from_pdf_stream"]

--- a/emailbot/extraction_zip.py
+++ b/emailbot/extraction_zip.py
@@ -64,6 +64,7 @@ def extract_emails_from_zip(
         EmailHit,
         extract_any_stream,
         merge_footnote_prefix_variants,
+        repair_footnote_singletons,
         _dedupe,
     )
 
@@ -156,7 +157,9 @@ def extract_emails_from_zip(
 
     z.close()
     hits = merge_footnote_prefix_variants(hits, stats)
-    return _dedupe(hits), stats
+    hits = _dedupe(hits)
+    hits = repair_footnote_singletons(hits, stats)
+    return hits, stats
 
 
 __all__ = ["extract_emails_from_zip"]


### PR DESCRIPTION
## Summary
- strip duplicated footnote digits from the beginning of PDF-derived e-mails and record repair stats
- run `repair_footnote_singletons` after deduplication in all extraction pipelines
- add regression tests for footnote singleton repair

## Testing
- `pre-commit run --files emailbot/dedupe.py emailbot/extraction.py emailbot/extraction_zip.py emailbot/extraction_pdf.py tests/test_repair_singletons.py` *(failed: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b96cf0123083269b7675fc74ce7399