### PR TITLE
Validate TLDs and filter invalid domains

### DIFF
--- a/emailbot/dedupe.py
+++ b/emailbot/dedupe.py
@@ -76,7 +76,7 @@ def merge_footnote_prefix_variants(hits: List["EmailHit"], stats: Dict[str, int]
                 if not cond:
                     continue
                 removed.add(idx_short)
-                stats["footnote_trimmed_merged"] = stats.get("footnote_trimmed_merged", 0) + 1
+                stats["footnote_pairs_merged"] = stats.get("footnote_pairs_merged", 0) + 1
 
     return [h for idx, h in enumerate(hits) if idx not in removed]
 

--- a/emailbot/extraction_url.py
+++ b/emailbot/extraction_url.py
@@ -194,8 +194,6 @@ def extract_ldjson_hits(html: str, base_url: str, stats: Dict[str, int]) -> List
         except Exception:
             continue
         hits.extend(_extract_from_json(data, f"url:{base_url}", stats))
-    if hits:
-        stats["hits_ldjson"] = stats.get("hits_ldjson", 0) + len(hits)
     return hits
 
 
@@ -241,8 +239,6 @@ def extract_bundle_hits(
             if decoded:
                 for e in _SIMPLE_EMAIL_RE.findall(decoded):
                     hits.append(EmailHit(email=e.lower(), source_ref=source_ref, origin="bundle"))
-    if hits:
-        stats["hits_bundle"] = stats.get("hits_bundle", 0) + len(hits)
     return hits
 
 
@@ -278,6 +274,7 @@ def extract_sitemap_hits(
         if not data:
             continue
         seen += 1
+        stats["sitemap_urls_scanned"] = stats.get("sitemap_urls_scanned", 0) + 1
         try:
             from xml.etree import ElementTree as ET
 

--- a/emailbot/messaging_utils.py
+++ b/emailbot/messaging_utils.py
@@ -10,6 +10,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Dict, Iterable, Tuple, Literal
 
+from .tld_registry import tld_of
+
 SUPPRESS_PATH = Path("/mnt/data/suppress_list.csv")  # e-mail, code, reason, first_seen, last_seen, hits
 BOUNCE_LOG_PATH = Path("/mnt/data/bounce_log.csv")   # ts, email, code, msg, phase
 SYNC_SEEN_EVENTS_PATH = Path("/mnt/data/sync_seen_events.csv")
@@ -497,54 +499,51 @@ def is_suppressed(email: str) -> bool:
 
 
 DOMESTIC_CCTLD = {
-    "ru",
-    "su",
-    "рф",
-    "xn--p1ai",
-    "by",
-    "kz",
-    "ua",
-    "uz",
-    "kg",
-    "am",
-    "az",
-    "ge",
+    "RU",
+    "SU",
+    "XN--P1AI",
+    "BY",
+    "KZ",
+    "UA",
+    "UZ",
+    "KG",
+    "AM",
+    "AZ",
+    "GE",
 }
 
 GENERIC_GTLD = {
-    "com",
-    "org",
-    "net",
-    "info",
-    "biz",
-    "edu",
-    "gov",
-    "io",
-    "ai",
-    "app",
-    "dev",
-    "pro",
-    "name",
-    "club",
-    "site",
-    "online",
-    "xyz",
-    "top",
-    "store",
-    "tech",
+    "COM",
+    "ORG",
+    "NET",
+    "INFO",
+    "BIZ",
+    "EDU",
+    "GOV",
+    "IO",
+    "AI",
+    "APP",
+    "DEV",
+    "PRO",
+    "NAME",
+    "CLUB",
+    "SITE",
+    "ONLINE",
+    "XYZ",
+    "TOP",
+    "STORE",
+    "TECH",
 }
 
 
 def classify_tld(email: str) -> Literal["domestic", "foreign", "generic"]:
-    email = (email or "").strip().lower()
+    email = (email or "").strip()
     if "@" not in email:
         return "foreign"
     domain = email.split("@", 1)[1]
-    try:
-        domain = domain.encode("idna").decode("ascii")
-    except Exception:
-        domain = domain.encode("ascii", "ignore").decode("ascii")
-    tld = domain.rsplit(".", 1)[-1]
+    tld = tld_of(domain)
+    if tld is None:
+        return "foreign"
     if tld in DOMESTIC_CCTLD:
         return "domestic"
     if tld in GENERIC_GTLD:

--- a/emailbot/reporting.py
+++ b/emailbot/reporting.py
@@ -2,7 +2,33 @@
 
 from __future__ import annotations
 
+import json
+import logging
+from datetime import datetime
 from typing import Iterable, List, Optional
+
+
+def _now_ts() -> str:
+    return datetime.utcnow().isoformat(timespec="milliseconds") + "Z"
+
+
+_DIGEST_LOGGER = logging.getLogger("emailbot.digest")
+
+
+def log_extract_digest(stats: dict) -> None:
+    """Log a one-line JSON digest for extraction statistics."""
+
+    data = {"ts": _now_ts(), "level": "INFO", "component": "extract"}
+    data.update(stats)
+    _DIGEST_LOGGER.info(json.dumps(data, ensure_ascii=False))
+
+
+def log_mass_filter_digest(ctx: dict) -> None:
+    """Log a one-line JSON digest for mass-mail filter statistics."""
+
+    data = {"ts": _now_ts(), "level": "INFO", "component": "mass_filter"}
+    data.update(ctx)
+    _DIGEST_LOGGER.info(json.dumps(data, ensure_ascii=False))
 
 
 def build_mass_report_text(

--- a/emailbot/tld_registry.py
+++ b/emailbot/tld_registry.py
@@ -1,0 +1,47 @@
+"""Offline registry of TLDs used for validation."""
+
+from __future__ import annotations
+
+from typing import Set
+
+# Hardcoded list of known TLDs (uppercase, IDNA/ASCII).
+# This list includes generic TLDs, common ccTLDs and domestic ones.
+KNOWN_TLDS: Set[str] = {
+    "COM", "ORG", "NET", "EDU", "GOV", "MIL", "INT", "INFO", "BIZ", "NAME",
+    "PRO", "AERO", "COOP", "MUSEUM", "TRAVEL", "MOBI", "ONLINE", "SITE",
+    "AGENCY", "APP", "DEV", "IO", "AI", "CLUB", "XYZ", "TOP", "STORE",
+    "TECH",
+    # Domestic and nearby ccTLDs
+    "RU", "SU", "BY", "KZ", "UA", "UZ", "KG", "AM", "AZ", "GE", "XN--P1AI",
+    "XN--80ASEHDB",  # .ОНЛАЙН
+    # Common ccTLDs
+    "US", "UK", "CA", "DE", "FR", "IT", "PL", "CZ", "SK", "CH", "SE", "NO",
+    "FI", "ES", "PT", "NL", "BE", "TR", "CN", "JP", "KR", "LT", "LV", "EE",
+    "IN", "BR", "AR", "AU", "NZ", "AT", "DK", "GR", "HU", "RO", "RS", "BG",
+    "MD", "IL", "IE", "HK", "SG", "MY", "ID", "TH", "VN", "PK", "AE", "QA",
+    "SA", "EG", "MA", "TN", "AL", "MK", "BA", "HR", "SI", "ME", "IS", "LI",
+    "ZA", "NG", "KE",
+}
+
+
+def tld_of(domain: str) -> str | None:
+    """Return last label of ``domain`` as ASCII uppercase TLD."""
+
+    if not domain:
+        return None
+    try:
+        ascii_domain = domain.encode("idna").decode("ascii")
+    except Exception:
+        return None
+    if "." not in ascii_domain:
+        return None
+    tld = ascii_domain.rsplit(".", 1)[-1]
+    if not tld:
+        return None
+    return tld.upper()
+
+
+def is_known_tld(tld: str) -> bool:
+    """Return True if ``tld`` is in the known TLD registry."""
+
+    return tld.upper() in KNOWN_TLDS

--- a/tests/test_dedupe_footnotes.py
+++ b/tests/test_dedupe_footnotes.py
@@ -14,7 +14,7 @@ def test_trimmed_variant_removed():
     stats = {}
     res = merge_footnote_prefix_variants([long, short], stats)
     assert res == [long]
-    assert stats.get("footnote_trimmed_merged") == 1
+    assert stats.get("footnote_pairs_merged") == 1
 
 
 def test_different_addresses_not_merged():
@@ -23,7 +23,7 @@ def test_different_addresses_not_merged():
     stats = {}
     res = merge_footnote_prefix_variants([a, b], stats)
     assert {h.email for h in res} == {a.email, b.email}
-    assert stats.get("footnote_trimmed_merged", 0) == 0
+    assert stats.get("footnote_pairs_merged", 0) == 0
 
 
 def _make_pdf(path, text):
@@ -42,7 +42,7 @@ def test_pdf_footnote_trimmed_is_merged(tmp_path):
     emails, stats = extract_any(str(pdf))
     assert "959536_vorobeva@mail.ru" in emails
     assert "59536_vorobeva@mail.ru" not in emails
-    assert stats.get("footnote_trimmed_merged", 0) >= 1
+    assert stats.get("footnote_pairs_merged", 0) >= 1
 
 
 def test_singleton_digit_repaired():

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,4 +1,63 @@
-from emailbot.reporting import build_mass_report_text
+import json
+import logging
+import zipfile
+
+from emailbot import extraction
+from emailbot.reporting import build_mass_report_text, log_mass_filter_digest
+
+
+def _records(caplog):
+    return [r for r in caplog.records if r.name == "emailbot.digest"]
+
+
+def test_extract_digest_logging(tmp_path, caplog):
+    html = tmp_path / "sample.html"
+    html.write_text("<a href='mailto:x@y.ru'>x</a> +m@h.abs", encoding="utf-8")
+    with caplog.at_level(logging.INFO, logger="emailbot.digest"):
+        extraction.extract_any(str(html))
+    recs = _records(caplog)
+    assert len(recs) == 1
+    data = json.loads(recs[0].message)
+    assert data["component"] == "extract"
+    for key in ("total_found", "invalid_tld", "elapsed_ms", "entry"):
+        assert key in data
+    assert "@" not in recs[0].message
+
+    caplog.clear()
+    inner = tmp_path / "inner.txt"
+    inner.write_text("inner@example.com", encoding="utf-8")
+    zip_path = tmp_path / "sample.zip"
+    with zipfile.ZipFile(zip_path, "w") as z:
+        z.write(inner, "inner.txt")
+    with caplog.at_level(logging.INFO, logger="emailbot.digest"):
+        extraction.extract_any(str(zip_path))
+    recs = _records(caplog)
+    assert len(recs) == 1
+    data = json.loads(recs[0].message)
+    assert data["component"] == "extract"
+    for key in ("total_found", "invalid_tld", "elapsed_ms", "entry"):
+        assert key in data
+    assert "@" not in recs[0].message
+
+
+def test_mass_filter_digest_logging(caplog):
+    ctx = {
+        "input_total": 5,
+        "after_suppress": 4,
+        "foreign_blocked": 1,
+        "after_180d": 3,
+        "sent_planned": 2,
+        "skipped_by_dup_in_batch": 1,
+    }
+    with caplog.at_level(logging.INFO, logger="emailbot.digest"):
+        log_mass_filter_digest(ctx)
+    recs = _records(caplog)
+    assert len(recs) == 1
+    data = json.loads(recs[0].message)
+    assert data["component"] == "mass_filter"
+    for key, val in ctx.items():
+        assert data[key] == val
+    assert "@" not in recs[0].message
 
 
 def test_build_mass_report_text_ignores_blocked():
@@ -14,6 +73,6 @@ def test_build_mass_report_text_ignores_blocked():
     assert "неработающие" not in text
     assert "✅ Отправлено: 2" in text
     assert "⏳ Пропущены (<180 дней): 1" in text
-    # ensure addresses listed with bullets
     assert "• a@example.com" in text
     assert "• c@example.com" in text
+

--- a/tests/test_tld_validation.py
+++ b/tests/test_tld_validation.py
@@ -1,0 +1,31 @@
+from emailbot.extraction_common import filter_invalid_tld
+from emailbot import messaging_utils as mu
+from emailbot.extraction import smart_extract_emails
+
+
+def test_filter_invalid_tld():
+    emails = [
+        "+m@h.abs",
+        "a.d@a.message",
+        "tri@hlon.org",
+        "office@rustriathlon.ru",
+        "marcela.ss950@gmail.com.br",
+    ]
+    valid, stats = filter_invalid_tld(emails)
+    assert stats["invalid_tld"] == 2
+    assert sorted(valid) == [
+        "marcela.ss950@gmail.com.br",
+        "office@rustriathlon.ru",
+        "tri@hlon.org",
+    ]
+
+
+def test_smart_extract_skips_unknown_tld():
+    text = "+m@h.abs a.d@a.message tri@hlon.org"
+    assert smart_extract_emails(text) == ["tri@hlon.org"]
+
+
+def test_classify_tld_generic_domestic_foreign():
+    assert mu.classify_tld("user@gmail.com") == "generic"
+    assert mu.classify_tld("office@rustriathlon.ru") == "domestic"
+    assert mu.classify_tld("marcela.ss950@gmail.com.br") == "foreign"


### PR DESCRIPTION
## Summary
- log extraction and mass-mail filter digests as single-line JSON records
- collect unified extraction stats including totals, source breakdown and timing
- record mass mailing filter outcomes and keep report builder intact

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9921ea94c8326b9dfe1c80fdf7556