### PR TITLE
Improve footnote repair and layout-aware guards

### DIFF
--- a/emailbot/extraction_common.py
+++ b/emailbot/extraction_common.py
@@ -49,13 +49,12 @@ def normalize_text(s: str) -> str:
     s = s.replace("\u00A0", " ")  # NBSP
     s = _Z_SPACE_RE.sub(" ", s)
 
-    # Zero-width and soft hyphen characters
+    # Zero-width characters
     s = (
         s.replace("\u200B", "")
         .replace("\u200C", "")
         .replace("\u200D", "")
         .replace("\uFEFF", "")
-        .replace("\u00AD", "")
     )
 
     # Various dashes/minuses -> ASCII '-'
@@ -119,11 +118,10 @@ def preprocess_text(text: str) -> str:
 
     text = normalize_text(text)
 
-    # Glue hyphenated line breaks and plain line breaks inside addresses,
-    # but only for alphabetic segments beyond the first character so that
-    # leading digits aren't accidentally concatenated.
-    text = re.sub(r"([A-Za-z])-\n([A-Za-z])", r"\1-\2", text)
-    text = re.sub(r"([A-Za-z])\n([A-Za-z.])", r"\1\2", text)
+    # Glue hyphenated/soft hyphen line breaks inside addresses starting from
+    # the second local-part character so that leading digits aren't lost.
+    text = re.sub(r"(?<=\w\w)-?\s*\n(?=[\w.])", "", text)
+    text = re.sub(r"(?<=\w\w)\u00AD(?=[\w.])", "", text)
     return text
 
 

--- a/emailbot/extraction_pdf.py
+++ b/emailbot/extraction_pdf.py
@@ -145,11 +145,10 @@ def extract_from_pdf(path: str, stop_event: Optional[object] = None) -> tuple[li
         logger.debug("ocr_pages=%d", ocr_pages)
 
     hits = merge_footnote_prefix_variants(hits, stats)
-    hits, fixed = repair_footnote_singletons(hits, layout)
-    if fixed:
-        stats["footnote_singletons_repaired"] = stats.get(
-            "footnote_singletons_repaired", 0
-        ) + fixed
+    hits, fstats = repair_footnote_singletons(hits, layout)
+    for k, v in fstats.items():
+        if v:
+            stats[k] = stats.get(k, 0) + v
     hits = _dedupe(hits)
 
     return hits, stats
@@ -231,11 +230,10 @@ def extract_from_pdf_stream(
         logger.debug("ocr_pages=%d", ocr_pages)
 
     hits = merge_footnote_prefix_variants(hits, stats)
-    hits, fixed = repair_footnote_singletons(hits, layout)
-    if fixed:
-        stats["footnote_singletons_repaired"] = stats.get(
-            "footnote_singletons_repaired", 0
-        ) + fixed
+    hits, fstats = repair_footnote_singletons(hits, layout)
+    for k, v in fstats.items():
+        if v:
+            stats[k] = stats.get(k, 0) + v
     hits = _dedupe(hits)
 
     return hits, stats

--- a/emailbot/extraction_zip.py
+++ b/emailbot/extraction_zip.py
@@ -163,11 +163,10 @@ def extract_emails_from_zip(
 
     z.close()
     hits = merge_footnote_prefix_variants(hits, stats)
-    hits, fixed = repair_footnote_singletons(hits, settings.PDF_LAYOUT_AWARE)
-    if fixed:
-        stats["footnote_singletons_repaired"] = stats.get(
-            "footnote_singletons_repaired", 0
-        ) + fixed
+    hits, fstats = repair_footnote_singletons(hits, settings.PDF_LAYOUT_AWARE)
+    for k, v in fstats.items():
+        if v:
+            stats[k] = stats.get(k, 0) + v
     hits = _dedupe(hits)
     emails, extra = filter_invalid_tld([h.email for h in hits])
     stats["invalid_tld"] = stats.get("invalid_tld", 0) + extra.get("invalid_tld", 0)

--- a/emailbot/reporting.py
+++ b/emailbot/reporting.py
@@ -18,7 +18,14 @@ _DIGEST_LOGGER = logging.getLogger("emailbot.digest")
 def log_extract_digest(stats: dict) -> None:
     """Log a one-line JSON digest for extraction statistics."""
 
-    data = {"ts": _now_ts(), "level": "INFO", "component": "extract"}
+    data = {
+        "ts": _now_ts(),
+        "level": "INFO",
+        "component": "extract",
+        "footnote_singletons_repaired": stats.get("footnote_singletons_repaired", 0),
+        "footnote_guard_skips": stats.get("footnote_guard_skips", 0),
+        "footnote_ambiguous_kept": stats.get("footnote_ambiguous_kept", 0),
+    }
     data.update(stats)
     _DIGEST_LOGGER.info(json.dumps(data, ensure_ascii=False))
 

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -16,7 +16,7 @@ from emailbot.extraction import smart_extract_emails
             ["user+tag_2024%eq=ok/part'one~x@sub-domain.xn--80asehdb"],
         ),
         ("na.me+tag@domain.ru", ["na.me+tag@domain.ru"]),
-        ("name-\nname@domain.ru", ["name-name@domain.ru"]),
+        ("name-\nname@domain.ru", ["namename@domain.ru"]),
         ("na\nme@domain.ru", ["name@domain.ru"]),
         ("mail@uni.ru\u0434\u043e\u0446\u0435\u043d\u0442", ["mail@uni.ru"]),
         ("mail@domain.rufaculty", ["mail@domain.ru"]),
@@ -46,4 +46,5 @@ def test_preprocess_preserves_digits():
     from emailbot.extraction_common import preprocess_text
 
     assert preprocess_text("9\n6soul@mail.ru").startswith("9\n6soul")
-    assert preprocess_text("name-\nname@domain.ru").startswith("name-name@domain.ru")
+    assert preprocess_text("name-\nname@domain.ru").startswith("namename@domain.ru")
+    assert preprocess_text("name\u00ADname@domain.ru").startswith("namename@domain.ru")

--- a/tests/test_repair_singletons.py
+++ b/tests/test_repair_singletons.py
@@ -2,7 +2,6 @@ import pytest
 
 from emailbot.dedupe import repair_footnote_singletons
 from emailbot.extraction import EmailHit
-from emailbot.dedupe import repair_footnote_singletons
 
 
 def make_hit(email: str, pre: str) -> EmailHit:
@@ -17,21 +16,21 @@ def make_hit(email: str, pre: str) -> EmailHit:
 
 def test_superscript_singleton_repaired():
     h = make_hit("1dergal@yandex.ru", pre="¹")
-    res, fixed = repair_footnote_singletons([h])
+    res, stats = repair_footnote_singletons([h])
     assert res[0].email == "dergal@yandex.ru"
     assert res[0].origin == "footnote_repaired"
-    assert fixed == 1
+    assert stats["footnote_singletons_repaired"] == 1
 
 
 def test_normal_address_untouched():
     h = make_hit("6soul@mail.ru", pre=" ")
-    res, fixed = repair_footnote_singletons([h])
+    res, stats = repair_footnote_singletons([h])
     assert res == [h]
-    assert fixed == 0
+    assert stats["footnote_singletons_repaired"] == 0
 
 
 def test_double_digit_not_repaired():
     h = make_hit("20yaik11@mail.ru", pre="2")
-    res, fixed = repair_footnote_singletons([h])
+    res, stats = repair_footnote_singletons([h])
     assert res == [h]
-    assert fixed == 0
+    assert stats["footnote_singletons_repaired"] == 0


### PR DESCRIPTION
## Summary
- add `is_superscript_digit` helper and overhaul `repair_footnote_singletons`
- prevent first-login char loss when joining broken lines and soft hyphens
- record footnote repair metrics in extraction digest

## Testing
- `pre-commit run --files emailbot/dedupe.py emailbot/extraction_common.py emailbot/extraction.py emailbot/extraction_pdf.py emailbot/extraction_zip.py emailbot/reporting.py tests/test_dedupe_footnotes.py tests/test_extraction.py tests/test_repair_singletons.py` *(failed: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9b17676308326a96a97a2a2a7c8d6