### PR TITLE
feat: unify gmail canonicalization

### DIFF
--- a/tests/test_normalize_email.py
+++ b/tests/test_normalize_email.py
@@ -1,0 +1,5 @@
+from emailbot.extraction_common import normalize_email
+
+def test_normalize_email_gmail_variants():
+    assert normalize_email('User.Name+tag@Gmail.com') == 'username@gmail.com'
+    assert normalize_email('user.name@googlemail.com') == 'username@gmail.com'


### PR DESCRIPTION
## Summary
- ensure normalization removes Gmail dots and tags
- delegate canonical_for_history to normalize_email
- test Gmail normalization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9be9190f0832695b1011454bcdf6e