### PR TITLE
Summaries without address lists

### DIFF
--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -12,6 +12,7 @@ import pytest
 from emailbot import messaging
 from emailbot import unsubscribe
 from emailbot import messaging_utils as mu
+from emailbot.reporting import build_mass_report_text
 
 
 @pytest.fixture(autouse=True)
@@ -95,6 +96,20 @@ def test_log_sent_email_records_entries(temp_files):
     assert row["email"] == "user@example.com"
     assert row["source"] == "group1"
     assert row["status"] == "ok"
+
+
+def test_mass_report_has_no_addresses():
+    text = build_mass_report_text(
+        ["a@example.com"],
+        ["b@example.com"],
+        ["c@example.de"],
+        ["d@example.com"],
+    )
+    assert "@" not in text
+    assert "✅ Отправлено: 1" in text
+    assert "⏳ Пропущены (<180 дней): 1" in text
+    assert "🚫 В блок-листе/недоступны: 1" in text
+    assert "🌍 Иностранные (отложены): 1" in text
 
 
 def test_build_message_adds_signature_and_unsubscribe(tmp_path, monkeypatch):

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -19,7 +19,15 @@ def test_extract_digest_logging(tmp_path, caplog):
     assert len(recs) == 1
     data = json.loads(recs[0].message)
     assert data["component"] == "extract"
-    for key in ("total_found", "invalid_tld", "elapsed_ms", "entry"):
+    for key in (
+        "total_found",
+        "invalid_tld",
+        "elapsed_ms",
+        "entry",
+        "left_guard_skips",
+        "prefix_expanded",
+        "footnote_singletons_repaired",
+    ):
         assert key in data
     assert "@" not in recs[0].message
 
@@ -35,7 +43,15 @@ def test_extract_digest_logging(tmp_path, caplog):
     assert len(recs) == 1
     data = json.loads(recs[0].message)
     assert data["component"] == "extract"
-    for key in ("total_found", "invalid_tld", "elapsed_ms", "entry"):
+    for key in (
+        "total_found",
+        "invalid_tld",
+        "elapsed_ms",
+        "entry",
+        "left_guard_skips",
+        "prefix_expanded",
+        "footnote_singletons_repaired",
+    ):
         assert key in data
     assert "@" not in recs[0].message
 
@@ -60,7 +76,7 @@ def test_mass_filter_digest_logging(caplog):
     assert "@" not in recs[0].message
 
 
-def test_build_mass_report_text_ignores_blocked():
+def test_build_mass_report_text_counts_only():
     sent_ok = ["a@example.com", "b@example.com"]
     skipped = ["c@example.com"]
     blocked_foreign = ["foreign@example.de"]
@@ -68,11 +84,9 @@ def test_build_mass_report_text_ignores_blocked():
 
     text = build_mass_report_text(sent_ok, skipped, blocked_foreign, blocked_invalid)
 
-    assert "В блок" not in text
-    assert "иностранные" not in text
-    assert "неработающие" not in text
+    assert "@" not in text
     assert "✅ Отправлено: 2" in text
     assert "⏳ Пропущены (<180 дней): 1" in text
-    assert "• a@example.com" in text
-    assert "• c@example.com" in text
+    assert "🚫 В блок-листе/недоступны: 1" in text
+    assert "🌍 Иностранные (отложены): 1" in text
 


### PR DESCRIPTION
## Summary
- Return only aggregate counts in mass-mailing summary and include blocked/foreign metrics
- Add digest logging fields for left_guard and prefix counters
- Verify reports omit raw addresses

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9ecc8d4108326a6fac9a8c5f918d5