### PR TITLE
Fix prefix stripping heuristics

### DIFF
--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -8,8 +8,8 @@ from emailbot.extraction import smart_extract_emails
     [
         ("\u00b9ivanov@uni.edu", ["ivanov@uni.edu"]),
         ("1petrov@uni.edu", ["petrov@uni.edu"]),
-        ("apetrov@uni.edu", ["petrov@uni.edu"]),
-        ("aivanov@uni.edu", ["ivanov@uni.edu"]),
+        ("apetrov@uni.edu", ["apetrov@uni.edu"]),
+        ("aivanov@uni.edu", ["aivanov@uni.edu"]),
         ("name-name@dept.domain.co.uk", ["name-name@dept.domain.co.uk"]),
         (
             "user+tag_2024%eq=ok/part'one~x@sub-domain.xn--80asehdb",

--- a/tests/test_prefixes.py
+++ b/tests/test_prefixes.py
@@ -1,0 +1,40 @@
+import pytest
+from emailbot.extraction import smart_extract_emails
+
+
+def test_numeric_prefix_trimmed():
+    assert smart_extract_emails(" 1john@example.com") == ["john@example.com"]
+
+
+def test_numeric_prefix_with_marker_trimmed():
+    assert smart_extract_emails("1)john@example.com") == ["john@example.com"]
+
+
+def test_letter_prefix_with_list_context_trimmed():
+    assert smart_extract_emails("a)john@example.com") == ["john@example.com"]
+
+
+def test_letter_prefix_without_context_kept():
+    assert smart_extract_emails(" ajohn@example.com") == ["ajohn@example.com"]
+
+
+def test_letter_prefix_multi_mode_trimmed():
+    text = " afoo@example.com\n bbar@example.com\n cqux@example.com\n ajane@example.com"
+    assert smart_extract_emails(text) == [
+        "foo@example.com",
+        "bar@example.com",
+        "qux@example.com",
+        "jane@example.com",
+    ]
+
+
+def test_letter_b_no_multi_mode_kept():
+    assert smart_extract_emails(" bjane@example.com") == ["bjane@example.com"]
+
+
+def test_letter_c_with_list_context_trimmed():
+    assert smart_extract_emails("c)joe@example.com") == ["joe@example.com"]
+
+
+def test_rfc_chars_preserved_after_trim():
+    assert smart_extract_emails("1x.y+z@example.com") == ["x.y+z@example.com"]


### PR DESCRIPTION
## Summary
- avoid trimming first character unless numeric footnote or a/b/c in list or multi-prefix context
- add comprehensive tests for prefix scenarios and adjust existing expectations

## Testing
- `pre-commit run --files emailbot/extraction.py tests/test_prefixes.py tests/test_extraction.py` *(fails: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9f850fec0832695ea1d15efec7cb9