### PR TITLE
Add synthetic factories and network layer injection

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,3 +6,5 @@ repos:
       - id: check-merge-conflict
       - id: end-of-file-fixer
       - id: trailing-whitespace
+      - id: forbid-binary
+        files: "\\.(pdf|docx|xlsx|zip)$"

--- a/emailbot/extraction_common.py
+++ b/emailbot/extraction_common.py
@@ -16,6 +16,8 @@ __all__ = [
     "maybe_decode_base64",
     "is_valid_domain",
     "filter_invalid_tld",
+    "score_candidate",
+    "CANDIDATE_SCORE_THRESHOLD",
 ]
 
 # Mapping of Cyrillic homoglyphs to their Latin counterparts
@@ -243,3 +245,36 @@ def filter_invalid_tld(emails: list[str]) -> tuple[list[str], dict]:
         else:
             dropped += 1
     return valid, {"invalid_tld": dropped}
+
+
+def score_candidate(features: dict) -> int:
+    """Compute a simple score for a candidate e-mail address.
+
+    The score is a sum of feature weights.  Currently only a handful of
+    lightweight heuristics is implemented which allows the caller to decide
+    whether the candidate should be accepted or placed into quarantine.
+
+    Parameters
+    ----------
+    features:
+        Mapping describing properties of the candidate.  Supported keys:
+
+        ``tld_known`` (bool)
+            ``True`` if the domain has a known TLD.
+
+    Returns
+    -------
+    int
+        Calculated score.
+    """
+
+    score = 0
+    if features.get("tld_known"):
+        score += 1
+    return score
+
+
+# Minimal score required for a candidate to be accepted.  Lower-scored
+# addresses are put into a quarantine bucket and are not returned by the
+# extractor.
+CANDIDATE_SCORE_THRESHOLD = 1

--- a/smoke.py
+++ b/smoke.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Run extractor on gold fixtures and print a short summary."""
+
+from __future__ import annotations
+
+import pathlib
+
+from emailbot.extraction import strip_html, smart_extract_emails, extract_from_pdf
+
+
+def main() -> None:
+    base = pathlib.Path("tests/fixtures/gold")
+    for path in sorted(base.iterdir()):
+        if path.suffix == ".pdf":
+            hits, stats = extract_from_pdf(str(path))
+            count = len(hits)
+            q = stats.get("quarantined", 0)
+        else:
+            text = strip_html(path.read_text(encoding="utf-8"))
+            stats: dict = {}
+            emails = smart_extract_emails(text, stats)
+            count = len(emails)
+            q = stats.get("quarantined", 0)
+        print(f"{path.name}: {count} ok, {q} quarantined")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,3 +4,35 @@ import sys
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import pytest
+from dataclasses import dataclass
+
+
+@dataclass
+class _Resp:
+    text: str = ""
+    content: bytes = b""
+
+
+def _mk_resp(data: bytes | str) -> _Resp:
+    if isinstance(data, bytes):
+        try:
+            text = data.decode("utf-8")
+        except Exception:
+            text = ""
+        return _Resp(text=text, content=data)
+    else:
+        return _Resp(text=data, content=data.encode("utf-8"))
+
+
+@pytest.fixture
+def make_fetch():
+    def factory(mapping: dict[str, bytes | str | Path]):
+        def fetch(url: str) -> _Resp:
+            data = mapping[url]
+            if isinstance(data, Path):
+                return _mk_resp(data.read_bytes())
+            return _mk_resp(data)
+        return fetch
+    return factory

--- a/tests/fixtures/gold/alpfederation.html
+++ b/tests/fixtures/gold/alpfederation.html
@@ -1,0 +1,3 @@
+<html><body>
+<p>Связь: +7-999-777-66-55stark_velik@mail.ru</p>
+</body></html>

--- a/tests/fixtures/gold/pentathlon.html
+++ b/tests/fixtures/gold/pentathlon.html
@@ -1,0 +1,5 @@
+<html><body>
+<ul>
+<li><span>a</span>buse@pentathlon-russia.ru</li>
+</ul>
+</body></html>

--- a/tests/fixtures/gold/rustriathlon.html
+++ b/tests/fixtures/gold/rustriathlon.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html><body>
+<div id="app">
+<p>Контакты регионов:</p>
+<p>Регион 1: <span>info@rustriathlon.ru</span></p>
+<p>Некорректный пример: <span>bad@rustriathlon.testtld</span></p>
+</div>
+<script>console.log('spa');</script>
+</body></html>

--- a/tests/fixtures/gold/shooting.html
+++ b/tests/fixtures/gold/shooting.html
@@ -1,0 +1,4 @@
+<html><body>
+<h1>Контакты</h1>
+<p>По всем вопросам пишите на <a href="mailto:info@shooting-russia.ru">info@shooting-russia.ru</a></p>
+</body></html>

--- a/tests/fixtures/gold/tagbreak.html
+++ b/tests/fixtures/gold/tagbreak.html
@@ -1,0 +1,3 @@
+<html><body>
+<p><span>b</span>iathlon@example.com</p>
+</body></html>

--- a/tests/test_gold_dataset.py
+++ b/tests/test_gold_dataset.py
@@ -1,11 +1,90 @@
 import pathlib
 
-from emailbot.extraction import strip_html, smart_extract_emails
+from emailbot.extraction import (
+    strip_html,
+    smart_extract_emails,
+    extract_from_pdf,
+    extract_from_url,
+)
+from tests.util_factories import make_pdf
+from emailbot.extraction_common import filter_invalid_tld
 
 
-def test_html_fixture_numbers():
-    html_path = pathlib.Path('tests/fixtures/html/footnotes.html')
-    html = html_path.read_text(encoding='utf-8')
+def test_spa_and_sitemap(tmp_path, make_fetch):
+    policy = make_pdf(tmp_path, [("office@site.ru license@site.ru", {})])
+    spa_html = '<html><body>enable JavaScript<script src="app.js"></script></body></html>'
+    sitemap = (
+        "<?xml version='1.0'?><urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'>"
+        "<url><loc>http://test.local/docs/policy.pdf</loc></url></urlset>"
+    )
+    files = {
+        "http://test.local/spa.html": spa_html,
+        "http://test.local/app.js": "",
+        "http://test.local/robots.txt": "Sitemap: http://test.local/sitemap.xml",
+        "http://test.local/sitemap.xml": sitemap,
+        "http://test.local/docs/policy.pdf": policy.read_bytes(),
+    }
+    fetch = make_fetch(files)
+    hits, stats = extract_from_url("http://test.local/spa.html", fetch=fetch)
+    emails = {h.email for h in hits}
+    assert emails == {"office@site.ru", "license@site.ru"}
+    assert stats.get("hits_sitemap", 0) > 0
+
+
+def test_phone_prefix_stripped(tmp_path):
+    html = (
+        "<p>+7-913-123-45-67stark_velik@mail.ru valid@example.com "
+        "01-37-93elena-ivanova@yandex.ru other@example.org</p>"
+    )
     text = strip_html(html)
-    emails = smart_extract_emails(text)
-    assert emails == ['john.doe@example.com', 'jane.doe@example.org']
+    stats: dict = {}
+    emails = set(smart_extract_emails(text, stats))
+    expected = {
+        "stark_velik@mail.ru",
+        "elena-ivanova@yandex.ru",
+        "valid@example.com",
+        "other@example.org",
+    }
+    assert expected <= emails
+    assert stats.get("phone_prefix_stripped", 0) > 0
+
+
+def test_tag_break_keeps_letter(tmp_path):
+    html = "<p><span>b</span>iathlon@yandex.ru •biathlon@yandex.ru</p>"
+    text = strip_html(html)
+    emails = set(smart_extract_emails(text))
+    assert emails == {"biathlon@yandex.ru"}
+
+
+def test_pdf_footnotes(tmp_path):
+    blocks = [
+        ("¹", {"superscript": True}),
+        ("96soul@mail.ru", {}),
+    ]
+    pdf = make_pdf(tmp_path, blocks)
+    hits, stats = extract_from_pdf(str(pdf))
+    emails = {h.email for h in hits}
+    assert emails == {"96soul@mail.ru"}
+
+
+def test_obfuscations(tmp_path, make_fetch):
+    html = (
+        "<p>user [at] site [dot] ru, user&#64;site.ru, user&commat;site.ru.</p>"
+        "<script src='bundle.js'></script>"
+    )
+    js = 'const x = atob("dXNlckBzaXRlLnJ1");'
+    files = {
+        "http://test.local/obf.html": html,
+        "http://test.local/bundle.js": js,
+    }
+    fetch = make_fetch(files)
+    hits, stats = extract_from_url("http://test.local/obf.html", fetch=fetch)
+    emails = {h.email for h in hits}
+    assert emails == {"user@site.ru"}
+
+
+def test_tld_filter_docx(tmp_path):
+    emails = ["good@site.ru", "bad@site.zzz", "test@host.abs"]
+    filtered, stats = filter_invalid_tld(emails)
+    assert set(filtered) == {"good@site.ru"}
+    assert stats.get("invalid_tld", 0) == 2

--- a/tests/util_factories.py
+++ b/tests/util_factories.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+import csv
+import zipfile
+
+import fitz  # PyMuPDF
+from docx import Document
+from openpyxl import Workbook
+
+
+def make_pdf(tmp_path: Path, blocks: list[tuple[str, dict]]) -> Path:
+    """Create a PDF file with ``blocks`` written sequentially.
+
+    Each block is a ``(text, options)`` tuple.  Supported options:
+
+    ``{"superscript": True}`` – render text in a smaller font shifted up.
+    ``{"newline": True}`` – move cursor to the next line before rendering.
+    """
+
+    doc = fitz.open()
+    page = doc.new_page()
+    x, y = 72, 72
+    fontsize = 12
+    line_height = fontsize + 2
+    for text, opts in blocks:
+        sup = opts.get("superscript")
+        parts = text.split("\n")
+        for idx, part in enumerate(parts):
+            if sup:
+                size = fontsize * 0.7
+                page.insert_text((x, y - size * 0.3), part, fontsize=size)
+                width = size * 0.6 * len(part)
+            else:
+                page.insert_text((x, y), part, fontsize=fontsize)
+                width = fontsize * 0.6 * len(part)
+            x += width
+            if idx < len(parts) - 1:
+                y += line_height
+                x = 72
+        if opts.get("newline"):
+            y += line_height
+            x = 72
+    path = tmp_path / "temp.pdf"
+    doc.save(path)
+    doc.close()
+    return path
+
+
+def make_docx(tmp_path: Path, lines: list[str]) -> Path:
+    doc = Document()
+    for line in lines:
+        doc.add_paragraph(line)
+    path = tmp_path / "temp.docx"
+    doc.save(path)
+    return path
+
+
+def make_xlsx(tmp_path: Path, rows: list[list[str]]) -> Path:
+    wb = Workbook()
+    ws = wb.active
+    for row in rows:
+        ws.append(row)
+    path = tmp_path / "temp.xlsx"
+    wb.save(path)
+    return path
+
+
+def make_csv(tmp_path: Path, lines: list[str]) -> Path:
+    path = tmp_path / "temp.csv"
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.writer(f)
+        for line in lines:
+            writer.writerow([line])
+    return path
+
+
+def make_zip(tmp_path: Path, paths: list[Path]) -> Path:
+    path = tmp_path / "temp.zip"
+    with zipfile.ZipFile(path, "w") as z:
+        for p in paths:
+            z.write(p, arcname=p.name)
+    return path


### PR DESCRIPTION
## Summary
- add file factories for generating PDFs, DOCX, XLSX, CSV and ZIP during tests
- allow injecting a custom fetcher into URL extraction for offline testing
- replace gold dataset with synthetic fixtures exercising sitemap, obfuscation and TLD filtering

## Testing
- `pre-commit run --files tests/util_factories.py tests/conftest.py tests/test_gold_dataset.py emailbot/extraction_url.py emailbot/extraction.py .pre-commit-config.yaml` *(fails: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*
- `pytest -q`
- `python smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_68bab71f27448326aaf998dadf50b8de