### PR TITLE
Add offline pre-commit configuration and docs

### DIFF
--- a/.pre-commit-config.local.yaml
+++ b/.pre-commit-config.local.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: local
+    hooks:
+      - id: black
+        name: black
+        entry: python -m black
+        language: system
+        types: [python]
+
+      - id: ruff
+        name: ruff (lint+fix)
+        entry: python -m ruff check --fix
+        language: system
+        types: [python]
+
+      - id: isort
+        name: isort
+        entry: python -m isort
+        language: system
+        types: [python]

--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ GitHub Actions проверяет:
 
 Статус сборки: ![CI](https://github.com/taravskayavm/email_bot/actions/workflows/ci.yml/badge.svg)
 
+### Pre-commit офлайн
+Если нет доступа к GitHub (403 CONNECT), используйте локовую конфигурацию:
+1) Установите инструменты: `pip install -r requirements-dev.txt`
+2) Запуск на всех файлах:
+   - Bash: `pre-commit run --all-files --config .pre-commit-config.local.yaml`
+   - PowerShell: `pre-commit run --all-files --config .pre-commit-config.local.yaml`
+3) Точечный запуск:
+   `pre-commit run --files path/to/file.py --config .pre-commit-config.local.yaml`
+
+Локовая конфигурация не делает сетевых запросов и использует уже установленные пакеты.
+
 ---
 
 ⚠️ **License: All Rights Reserved**  

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pre-commit
+black
+ruff
+isort

--- a/smoke.ps1
+++ b/smoke.ps1
@@ -1,3 +1,4 @@
+# Pre-commit: pre-commit run --all-files --config .pre-commit-config.local.yaml
 python - <<'PY'
 from emailbot.extraction import extract_emails_manual
 s="name@uni.ru, user@mit.edu, 12345@lab.ru"


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.local.yaml` with local black, ruff, isort hooks
- document offline pre-commit workflow and dev requirements
- note offline pre-commit usage in smoke.ps1 script

## Testing
- `pre-commit run --files tests/util_factories.py tests/conftest.py tests/test_gold_dataset.py emailbot/extraction_url.py emailbot/extraction.py .pre-commit-config.yaml --config .pre-commit-config.local.yaml |& nl -ba`

------
https://chatgpt.com/codex/tasks/task_e_68baca8a1b5c83269f1f42d9a35436d2