### PR TITLE
Normalize HTML parser output

### DIFF
--- a/crawler/html_to_text.py
+++ b/crawler/html_to_text.py
@@ -1,11 +1,13 @@
 try:
-    from html2text import html2text as _html2text
+    from html2text import html2text
 except Exception:  # pragma: no cover - fallback if html2text is missing
-    def _html2text(html: str) -> str:  # type: ignore
+    def html2text(html: str) -> str:  # type: ignore
         return html
 
 from utils.email_clean import _normalize_text
 
+
 def html_to_text(html: str) -> str:
-    text = _html2text(html)
+    """Convert HTML into normalized plain text."""
+    text = html2text(html)
     return _normalize_text(text)


### PR DESCRIPTION
## Summary
- Normalize HTML-derived text to reduce garbage via `_normalize_text`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb2468ca708326b3a02e27bcd293d0