### PR TITLE
Improve manual email parsing and add tests

### DIFF
--- a/bot/handlers/manual_send.py
+++ b/bot/handlers/manual_send.py
@@ -1,0 +1,51 @@
+"""Utilities for manual e-mail sending.
+
+This module currently exposes :func:`parse_manual_input` which is used to
+normalize user supplied e-mail addresses.  The function extracts potential
+addresses from arbitrary text, sanitises them and removes duplicates including
+"footnote" variants ("55alex@example.com" vs ``alex@example.com``).
+"""
+
+from __future__ import annotations
+
+from utils.email_clean import (
+    extract_emails,
+    sanitize_email,
+    dedupe_with_variants,
+)
+
+
+def parse_manual_input(text: str) -> list[str]:
+    """Extract e-mail addresses from arbitrary text.
+
+    The parser supports mixed separators (commas, spaces, semicolons, new
+    lines), strips surrounding punctuation, drops invalid addresses and
+    de‑duplicates, removing "footnote" prefixes such as ``55alex@``.
+
+    Parameters
+    ----------
+    text:
+        Raw text entered by a user in the chat.
+
+    Returns
+    -------
+    list[str]
+        A list of cleaned and unique e‑mail addresses.
+    """
+
+    # 1) Extract raw e-mail substrings
+    raw = extract_emails(text)
+    if not raw:
+        return []
+
+    # 2) Sanitize each address; ``sanitize_email`` returns "" for invalid ones
+    cleaned = [sanitize_email(e) for e in raw]
+    cleaned = [e for e in cleaned if e]
+
+    # 3) Deduplicate, removing footnote variants
+    emails = dedupe_with_variants(cleaned)
+    return emails
+
+
+__all__ = ["parse_manual_input"]
+

--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -144,13 +144,13 @@ def test_handle_text_manual_emails():
 
     assert ctx.user_data["manual_emails"] == [
         "123@site.com",
-        "1test@site.com",
         "support@support.com",
+        "test@site.com",
         "user@example.com",
     ]
     assert ctx.user_data["awaiting_manual_email"] is False
     assert (
-        "К отправке: 123@site.com, 1test@site.com, support@support.com, user@example.com"
+        "К отправке: 123@site.com, support@support.com, test@site.com, user@example.com"
         in update.message.replies[0]
     )
 

--- a/tests/test_manual_parse.py
+++ b/tests/test_manual_parse.py
@@ -1,0 +1,23 @@
+from bot.handlers.manual_send import parse_manual_input
+
+
+def test_manual_multiline_commas_semicolons():
+    text = """pavelshabalin@mail.ru
+shataev1@rambler.ru, aaksviaz@mail.ru
+elena-dzhioeva@yandex.ru; mashkov47@mail.ru
+stark_velik@mail.ru
+ovalov@gmail.com
+"""
+    emails = parse_manual_input(text)
+    assert "ovalov@gmail.com" in emails
+    assert not any("mail.ruovalov" in e for e in emails)
+    assert set(emails) >= {
+        "pavelshabalin@mail.ru",
+        "shataev1@rambler.ru",
+        "aaksviaz@mail.ru",
+        "elena-dzhioeva@yandex.ru",
+        "mashkov47@mail.ru",
+        "stark_velik@mail.ru",
+        "ovalov@gmail.com",
+    }
+


### PR DESCRIPTION
## Summary
- add `parse_manual_input` to extract, sanitize and deduplicate addresses
- use new parser in manual handler for consistent cleaned output
- add regression tests for manual email parsing

## Testing
- `pytest -q -k manual_parse`
- `pytest -q`
- `python email_bot.py` *(fails: Переменная окружения EMAIL_PASSWORD не задана)*

------
https://chatgpt.com/codex/tasks/task_e_68be8c47d124832686c009453a06977f