### PR TITLE
Add dedupe and IDNA email tests

### DIFF
--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -1,0 +1,14 @@
+def test_dedupe_with_footnote_and_clean():
+    from utils.email_clean import dedupe_with_variants
+    got = dedupe_with_variants(["55alex@example.com", "alex@example.com"])
+    assert got == ["alex@example.com"]
+
+def test_dedupe_only_variants_keeps_shortest():
+    from utils.email_clean import dedupe_with_variants
+    got = dedupe_with_variants(["123alex@example.com", "9alex@example.com"])
+    assert got == ["alex@example.com"]
+
+def test_no_cross_domain_collapse():
+    from utils.email_clean import dedupe_with_variants
+    got = dedupe_with_variants(["alex@a.com", "alex@b.com"])
+    assert sorted(got) == ["alex@a.com", "alex@b.com"]

--- a/tests/test_idna.py
+++ b/tests/test_idna.py
@@ -1,0 +1,9 @@
+import unicodedata
+
+from utils.email_clean import sanitize_email
+
+
+def test_unicode_domain_punycode_local_nfc():
+    got = sanitize_email("test@почта.рф")
+    assert got == "test@xn--80a1acny.xn--p1ai"
+    assert unicodedata.is_normalized("NFC", got.split("@", 1)[0])


### PR DESCRIPTION
## Summary
- cover footnote and domain variants in dedupe_with_variants
- add IDNA test to ensure unicode domains are converted to punycode

## Testing
- `pytest tests/test_dedupe.py tests/test_idna.py -q`
- `pytest -q` *(fails: AssertionError in tests/test_bot_handlers.py::test_handle_text_manual_emails)*

------
https://chatgpt.com/codex/tasks/task_e_68beb72e007c8326a23ddff66a6180bb