### PR TITLE
Improve Sent folder detection and add IMAP smoke test

### DIFF
--- a/smoke.py
+++ b/smoke.py
@@ -1,14 +1,19 @@
 #!/usr/bin/env python3
-"""Run extractor on gold fixtures and print a short summary."""
+"""Run extractor on gold fixtures or perform IMAP smoke checks."""
 
 from __future__ import annotations
 
+import argparse
+import imaplib
+import os
 import pathlib
+from email.message import EmailMessage
 
 from emailbot.extraction import strip_html, smart_extract_emails, extract_from_pdf
+from emailbot import messaging
 
 
-def main() -> None:
+def _run_extractor() -> None:
     base = pathlib.Path("tests/fixtures/gold")
     for path in sorted(base.iterdir()):
         if path.suffix == ".pdf":
@@ -22,6 +27,39 @@ def main() -> None:
             count = len(emails)
             q = stats.get("quarantined", 0)
         print(f"{path.name}: {count} ok, {q} quarantined")
+
+
+def _check_sent_append() -> None:
+    addr = os.getenv("EMAIL_ADDRESS") or messaging.EMAIL_ADDRESS
+    pwd = os.getenv("EMAIL_PASSWORD") or messaging.EMAIL_PASSWORD
+    if not addr or not pwd:
+        raise SystemExit("EMAIL_ADDRESS/EMAIL_PASSWORD not configured")
+    imap = imaplib.IMAP4_SSL("imap.mail.ru")
+    imap.login(addr, pwd)
+    folder = messaging.get_preferred_sent_folder(imap)
+    msg = EmailMessage()
+    msg["From"] = addr
+    msg["To"] = addr
+    msg.set_content("")
+    status, _ = imap.append(f'"{folder}"', "", None, msg.as_bytes())
+    imap.logout()
+    if status != "OK":
+        raise RuntimeError("APPEND failed")
+    print(f"APPEND to {folder}: OK")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check-sent-append",
+        action="store_true",
+        help="verify that APPEND to detected Sent folder succeeds",
+    )
+    args = parser.parse_args()
+    if args.check_sent_append:
+        _check_sent_append()
+    else:
+        _run_extractor()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- enhance detection of localized IMAP Sent folders and persist choice
- add smoke flag to verify APPEND into detected Sent folder

## Testing
- `pre-commit run --files emailbot/messaging.py smoke.py` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `python smoke.py --check-sent-append` *(fails: EMAIL_ADDRESS/EMAIL_PASSWORD not configured)*
- `pytest` *(fails: tests/test_bot_handlers.py::test_handle_text_manual_emails)*

------
https://chatgpt.com/codex/tasks/task_e_68bebc3664d08326a201e6c414ea4ef2