### PR TITLE
feat: add optional smtp ssl fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,5 @@ EMAIL_ADDRESS="your_mail@mail.ru"
 EMAIL_PASSWORD="app_specific_password"
 TELEGRAM_BOT_TOKEN="your_telegram_bot_token"
 INLINE_LOGO=1
+SMTP_PORT=587
+SMTP_SSL=0

--- a/emailbot/smtp_client.py
+++ b/emailbot/smtp_client.py
@@ -1,3 +1,4 @@
+import os
 import smtplib
 import ssl
 from typing import Optional
@@ -7,21 +8,34 @@ class SmtpClient:
     """Simple SMTP client with context manager support."""
 
     def __init__(
-        self, host: str, port: int, username: str, password: str, use_ssl: bool = True
+        self,
+        host: str,
+        port: int,
+        username: str,
+        password: str,
+        use_ssl: Optional[bool] = None,
+        timeout: int = 15,
     ):
         self.host = host
         self.port = port
         self.username = username
         self.password = password
+        if use_ssl is None:
+            use_ssl = os.getenv("SMTP_SSL", "0") == "1"
         self.use_ssl = use_ssl
+        self.timeout = timeout
         self._server: Optional[smtplib.SMTP] = None
 
     def __enter__(self) -> "SmtpClient":
         context = ssl.create_default_context()
         if self.use_ssl:
-            self._server = smtplib.SMTP_SSL(self.host, self.port, context=context)
+            self._server = smtplib.SMTP_SSL(
+                self.host, self.port, timeout=self.timeout, context=context
+            )
         else:
-            self._server = smtplib.SMTP(self.host, self.port)
+            self._server = smtplib.SMTP(
+                self.host, self.port, timeout=self.timeout
+            )
             self._server.starttls(context=context)
         self._server.login(self.username, self.password)
         return self

--- a/mailer/smtp_sender.py
+++ b/mailer/smtp_sender.py
@@ -1,3 +1,4 @@
+import os
 import smtplib
 from typing import Iterable
 from email.message import EmailMessage
@@ -11,17 +12,33 @@ def send_messages(messages: Iterable[EmailMessage], user: str, password: str, ho
     Any failure resets the session so that the next message does not get
     a mysterious ``503 sender already given`` error.
     """
-    with smtplib.SMTP(host, 587, timeout=TIMEOUT) as smtp:
-        smtp.ehlo()
-        smtp.starttls()
-        smtp.ehlo()
-        smtp.login(user, password)
-        for msg in messages:
-            try:
-                smtp.send_message(msg)
-            except Exception:
+    port = int(os.getenv("SMTP_PORT", "587"))
+    use_ssl = os.getenv("SMTP_SSL", "0") == "1"
+    if use_ssl:
+        with smtplib.SMTP_SSL(host, port, timeout=TIMEOUT) as smtp:
+            smtp.ehlo()
+            smtp.login(user, password)
+            for msg in messages:
                 try:
-                    smtp.rset()
+                    smtp.send_message(msg)
                 except Exception:
-                    pass
-                raise
+                    try:
+                        smtp.rset()
+                    except Exception:
+                        pass
+                    raise
+    else:
+        with smtplib.SMTP(host, port, timeout=TIMEOUT) as smtp:
+            smtp.ehlo()
+            smtp.starttls()
+            smtp.ehlo()
+            smtp.login(user, password)
+            for msg in messages:
+                try:
+                    smtp.send_message(msg)
+                except Exception:
+                    try:
+                        smtp.rset()
+                    except Exception:
+                        pass
+                    raise

--- a/tests/test_smtp_client_env.py
+++ b/tests/test_smtp_client_env.py
@@ -1,0 +1,63 @@
+import smtplib
+
+import pytest
+
+from emailbot.smtp_client import SmtpClient
+
+
+class DummySMTP:
+    def __init__(self):
+        self.starttls_called = False
+        self.login_called = False
+
+    def starttls(self, context=None):
+        self.starttls_called = True
+
+    def login(self, user, password):
+        self.login_called = True
+
+    def quit(self):
+        pass
+
+    def sendmail(self, *a, **k):
+        pass
+
+
+def test_smtp_client_uses_ssl_from_env(monkeypatch):
+    dummy = DummySMTP()
+    ssl_called = False
+
+    def fake_ssl(*args, **kwargs):
+        nonlocal ssl_called
+        ssl_called = True
+        return dummy
+
+    monkeypatch.setattr(smtplib, "SMTP_SSL", fake_ssl)
+    monkeypatch.setattr(smtplib, "SMTP", lambda *a, **k: dummy)
+    monkeypatch.setenv("SMTP_SSL", "1")
+
+    with SmtpClient("host", 587, "user", "pass"):
+        pass
+
+    assert ssl_called
+    assert not dummy.starttls_called
+
+
+def test_smtp_client_uses_starttls_when_ssl_disabled(monkeypatch):
+    dummy = DummySMTP()
+    smtp_called = False
+
+    def fake_smtp(*args, **kwargs):
+        nonlocal smtp_called
+        smtp_called = True
+        return dummy
+
+    monkeypatch.setattr(smtplib, "SMTP", fake_smtp)
+    monkeypatch.setattr(smtplib, "SMTP_SSL", lambda *a, **k: dummy)
+    monkeypatch.setenv("SMTP_SSL", "0")
+
+    with SmtpClient("host", 587, "user", "pass"):
+        pass
+
+    assert smtp_called
+    assert dummy.starttls_called


### PR DESCRIPTION
## Summary
- allow choosing SSL or STARTTLS via `SMTP_SSL` flag
- read `SMTP_PORT` and SSL flag when opening SMTP connections
- test SMTP client initialization based on environment

## Testing
- `pre-commit run --files .env.example emailbot/smtp_client.py mailer/smtp_sender.py tests/test_smtp_client_env.py` *(failed: CONNECT tunnel failed, response 403)*
- `pytest -q` *(failed: tests/test_bot_handlers.py::test_handle_text_manual_emails)*

------
https://chatgpt.com/codex/tasks/task_e_68bec043289c832691373f1a3b439bae