### PR TITLE
Log domain rate limit pauses

### DIFF
--- a/emailbot/messaging.py
+++ b/emailbot/messaging.py
@@ -123,7 +123,9 @@ def _rate_limit_domain(recipient: str) -> None:
     if last is not None:
         elapsed = now - last
         if elapsed < _DOMAIN_RATE_LIMIT:
-            time.sleep(_DOMAIN_RATE_LIMIT - elapsed)
+            pause = _DOMAIN_RATE_LIMIT - elapsed
+            logger.info("Domain %s rate limit: sleeping %.2fs", domain, pause)
+            time.sleep(pause)
             now = last + _DOMAIN_RATE_LIMIT
     _last_domain_send[domain] = now
 


### PR DESCRIPTION
## Summary
- log per-domain rate limit pauses with domain name and wait time
- test domain rate limit logging

## Testing
- `pytest tests/test_messaging.py::test_domain_rate_limit -q`
- `pytest` *(fails: tests/test_bot_handlers.py::test_handle_text_manual_emails)*

------
https://chatgpt.com/codex/tasks/task_e_68bec4f36a2483268721d18bfc9d2d18