### PR TITLE
Fix manual email parsing

### DIFF
--- a/utils/email_clean.py
+++ b/utils/email_clean.py
@@ -80,9 +80,6 @@ def sanitize_email(email: str) -> str:
 
     local, domain = s.split('@', 1)
     local = local.replace(',', '.')   # ошибки OCR: запятая вместо точки
-    for part in local.split('.'):
-        if any(part.startswith(tld) and len(part) > len(tld) for tld in _TLD_PREFIXES):
-            return ""
     # убираем сноску в начале
     cleaned = _strip_leading_footnote(local)
     # убираем мусорные тире/точки по краям, оставшиеся от переносов


### PR DESCRIPTION
## Summary
- keep newline and whitespace separation when normalizing text to avoid concatenated emails
- sanitize addresses by removing leading footnote digits and trimming punctuation while preserving valid locals like `support`
- ensure deduplicated manual email list remains sorted

## Testing
- `pytest -q tests/test_bot_handlers.py::test_handle_text_manual_emails`


------
https://chatgpt.com/codex/tasks/task_e_68bec92a9a408326ae0516b07d6a5c39