### PR TITLE
Handle manual email input correctly

### DIFF
--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -1106,28 +1106,17 @@ async def handle_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         return
     if context.user_data.get("awaiting_manual_email"):
         emails = parse_manual_input(text)
-        logger.info(
-            "Manual input parsing: raw=%r emails=%r",
-            text,
-            emails,
-        )
+        logger.info("Manual input parsing: raw=%r emails=%r", text, emails)
         if emails:
             context.user_data["manual_emails"] = emails
             context.user_data["awaiting_manual_email"] = False
             keyboard = [
                 [InlineKeyboardButton("⚽ Спорт", callback_data="manual_group_спорт")],
                 [InlineKeyboardButton("🏕 Туризм", callback_data="manual_group_туризм")],
-                [
-                    InlineKeyboardButton(
-                        "🩺 Медицина", callback_data="manual_group_медицина"
-                    )
-                ],
+                [InlineKeyboardButton("🩺 Медицина", callback_data="manual_group_медицина")],
             ]
             await update.message.reply_text(
-                (
-                    f"К отправке: {', '.join(emails)}\n\n"
-                    "⬇️ Выберите направление письма:"
-                ),
+                f"К отправке: {', '.join(emails)}\n\n⬇️ Выберите направление письма:",
                 reply_markup=InlineKeyboardMarkup(keyboard),
             )
         else:


### PR DESCRIPTION
## Summary
- Normalize text by removing zero-width characters and compressing whitespace
- Sanitize emails by stripping footnote digits and returning only valid addresses
- Handle manual email entry by saving parsed addresses and prompting for a mailing group

## Testing
- `pytest -q tests/test_bot_handlers.py::test_handle_text_manual_emails`
- `pre-commit run --files utils/email_clean.py emailbot/bot_handlers.py` *(failed: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*

------
https://chatgpt.com/codex/tasks/task_e_68bed38848808326a369ceea26300007