### PR TITLE
Improve email sanitization and IMAP sent-folder utilities

### DIFF
--- a/tests/test_append_to_sent.py
+++ b/tests/test_append_to_sent.py
@@ -1,0 +1,20 @@
+from emailbot.messaging_utils import append_to_sent
+
+
+class DummyImap:
+    def __init__(self):
+        self.append_calls = []
+
+    def append(self, mailbox, flags, date_time, message):
+        self.append_calls.append((mailbox, flags, date_time, message))
+        return "OK", None
+
+
+def test_append_to_sent_calls_imap_append():
+    imap = DummyImap()
+    ok, _ = append_to_sent(imap, "Sent", b"From: x\nTo: y\n\nBody")
+    assert ok == "OK"
+    assert imap.append_calls, "APPEND must be called exactly once"
+    mb, flags, ts, msg = imap.append_calls[0]
+    assert mb == "Sent"
+    assert b"Body" in msg

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -6,7 +6,7 @@ def test_dedupe_with_footnote_and_clean():
 def test_dedupe_only_variants_keeps_shortest():
     from utils.email_clean import dedupe_with_variants
     got = dedupe_with_variants(["123alex@example.com", "9alex@example.com"])
-    assert got == ["alex@example.com"]
+    assert got == ["9alex@example.com"]
 
 def test_no_cross_domain_collapse():
     from utils.email_clean import dedupe_with_variants

--- a/tests/test_detect_sent_folder.py
+++ b/tests/test_detect_sent_folder.py
@@ -1,0 +1,51 @@
+import types
+from pathlib import Path
+
+from emailbot.messaging_utils import detect_sent_folder, SENT_CACHE_FILE
+
+
+class DummyImap:
+    def __init__(self, mailboxes):
+        # формат ответа imap.list(): ('OK', [b'(\\HasNoChildren \\Sent) "/" "Sent"', ...])
+        self._mailboxes = mailboxes
+
+    def list(self):
+        return "OK", [mb.encode("utf-8") for mb in self._mailboxes]
+
+
+def test_detect_sent_folder_prefers_flagged_sent(tmp_path, monkeypatch):
+    # перенаправим кэш в временную директорию
+    monkeypatch.setattr("emailbot.messaging_utils.SENT_CACHE_FILE", tmp_path / "imap_sent_folder.txt")
+    imap = DummyImap(
+        [
+            '(\\HasNoChildren) "/" "INBOX"',
+            '(\\HasNoChildren \\Sent) "/" "Sent"',
+            '(\\HasNoChildren) "/" "Отправленные"',
+        ]
+    )
+    sent = detect_sent_folder(imap)
+    assert sent == "Sent"
+    # и кэш должен сохраниться
+    assert (tmp_path / "imap_sent_folder.txt").read_text(encoding="utf-8").strip() == "Sent"
+
+
+def test_detect_sent_folder_localized_ru(tmp_path, monkeypatch):
+    monkeypatch.setattr("emailbot.messaging_utils.SENT_CACHE_FILE", tmp_path / "imap_sent_folder.txt")
+    imap = DummyImap(
+        [
+            '(\\HasNoChildren) "/" "INBOX"',
+            '(\\HasNoChildren) "/" "Отправленные"',
+        ]
+    )
+    sent = detect_sent_folder(imap)
+    assert sent == "Отправленные"
+
+
+def test_detect_sent_folder_uses_cache(tmp_path, monkeypatch):
+    cache = tmp_path / "imap_sent_folder.txt"
+    cache.write_text("Sent", encoding="utf-8")
+    monkeypatch.setattr("emailbot.messaging_utils.SENT_CACHE_FILE", cache)
+    # list не должен вызываться, вернётся кэш
+    imap = DummyImap([])
+    sent = detect_sent_folder(imap)
+    assert sent == "Sent"

--- a/tests/test_email_clean.py
+++ b/tests/test_email_clean.py
@@ -43,3 +43,10 @@ def test_nbsp_and_zwsp_boundaries():
 
 def test_invalid_concatenation_not_accepted():
     assert sanitize_email("mail.ruovalov@gmail.com") == ""
+
+
+def test_question_mark_anchor_trimming():
+    src = "test@site.com?param=1"
+    got = extract_emails(src)
+    assert "test@site.com" in got
+    assert not any("param=" in x for x in got)

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -410,7 +410,7 @@ def test_domain_rate_limit(monkeypatch, caplog):
         messaging.send_raw_smtp_with_retry("m", "b@example.com")
 
     assert sleeps and sleeps[0] >= messaging._DOMAIN_RATE_LIMIT
-    assert any("rate limit" in r.message for r in caplog.records)
+    assert any("rate-limit" in r.message for r in caplog.records)
 
 
 def test_soft_bounce_retry_and_no_suppress(monkeypatch, caplog):

--- a/tests/test_rate_limit_logging.py
+++ b/tests/test_rate_limit_logging.py
@@ -1,0 +1,10 @@
+import logging
+from emailbot.messaging import log_domain_rate_limit
+
+
+def test_log_domain_rate_limit(caplog):
+    caplog.set_level(logging.INFO)
+    # не спим в тесте: передаём sleep_s=0
+    log_domain_rate_limit("example.com", 0)
+    assert any("rate-limit" in rec.message for rec in caplog.records)
+    assert any("example.com" in rec.message for rec in caplog.records)

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,0 +1,23 @@
+import pytest
+
+from utils.email_clean import sanitize_email, dedupe_with_variants
+
+
+def test_strip_leading_footnote_in_local_part():
+    assert sanitize_email("1test@site.com") == "test@site.com"
+    assert sanitize_email("55alex@example.com") == "alex@example.com"
+
+
+def test_trim_local_part_edges():
+    assert sanitize_email("..test-@site.com") == "test@site.com"
+    assert sanitize_email("__user__@example.org") == "user@example.org"
+
+
+def test_dedupe_with_variants_prefers_clean():
+    got = dedupe_with_variants(["55alex@example.com", "alex@example.com"])
+    assert got == ["alex@example.com"]
+
+
+def test_dedupe_only_variants_keeps_shortest():
+    got = dedupe_with_variants(["123alex@example.com", "9alex@example.com"])
+    assert got == ["9alex@example.com"]


### PR DESCRIPTION
## Summary
- add cached IMAP sent-folder detection and helper to append messages
- log domain rate limiting via `log_domain_rate_limit`
- harden email sanitization against concatenated addresses and refine variant deduping
- add tests for sanitization, sent-folder detection, IMAP append and rate-limit logging

## Testing
- `pytest -q`
- `pre-commit run --files emailbot/messaging_utils.py emailbot/messaging.py utils/email_clean.py tests/test_sanitize.py tests/test_detect_sent_folder.py tests/test_rate_limit_logging.py tests/test_append_to_sent.py tests/test_email_clean.py tests/test_dedupe.py tests/test_messaging.py` *(failed: `fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403`)*

------
https://chatgpt.com/codex/tasks/task_e_68bed9dd76088326b6dc50afebbd8f2c