### PR TITLE
Add SMTP timeout env and message idempotency

### DIFF
--- a/emailbot/messaging_utils.py
+++ b/emailbot/messaging_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import csv
 import logging
 import os

--- a/emailbot/smtp_client.py
+++ b/emailbot/smtp_client.py
@@ -14,7 +14,7 @@ class SmtpClient:
         username: str,
         password: str,
         use_ssl: Optional[bool] = None,
-        timeout: int = 15,
+        timeout: Optional[float] = None,
     ):
         self.host = host
         self.port = port
@@ -23,6 +23,11 @@ class SmtpClient:
         if use_ssl is None:
             use_ssl = os.getenv("SMTP_SSL", "0") == "1"
         self.use_ssl = use_ssl
+        if timeout is None:
+            try:
+                timeout = float(os.getenv("SMTP_TIMEOUT", "30"))
+            except Exception:
+                timeout = 30.0
         self.timeout = timeout
         self._server: Optional[smtplib.SMTP] = None
 

--- a/mailer/smtp_sender.py
+++ b/mailer/smtp_sender.py
@@ -3,7 +3,12 @@ import smtplib
 from typing import Iterable
 from email.message import EmailMessage
 
-TIMEOUT = 15
+PORT = int(os.getenv("SMTP_PORT", "587"))
+USE_SSL = os.getenv("SMTP_SSL", "0") == "1"
+try:
+    TIMEOUT = float(os.getenv("SMTP_TIMEOUT", "30"))
+except Exception:
+    TIMEOUT = 30.0
 
 
 def send_messages(messages: Iterable[EmailMessage], user: str, password: str, host: str) -> None:
@@ -12,10 +17,8 @@ def send_messages(messages: Iterable[EmailMessage], user: str, password: str, ho
     Any failure resets the session so that the next message does not get
     a mysterious ``503 sender already given`` error.
     """
-    port = int(os.getenv("SMTP_PORT", "587"))
-    use_ssl = os.getenv("SMTP_SSL", "0") == "1"
-    if use_ssl:
-        with smtplib.SMTP_SSL(host, port, timeout=TIMEOUT) as smtp:
+    if USE_SSL:
+        with smtplib.SMTP_SSL(host, PORT, timeout=TIMEOUT) as smtp:
             smtp.ehlo()
             smtp.login(user, password)
             for msg in messages:
@@ -28,7 +31,7 @@ def send_messages(messages: Iterable[EmailMessage], user: str, password: str, ho
                         pass
                     raise
     else:
-        with smtplib.SMTP(host, port, timeout=TIMEOUT) as smtp:
+        with smtplib.SMTP(host, PORT, timeout=TIMEOUT) as smtp:
             smtp.ehlo()
             smtp.starttls()
             smtp.ehlo()

--- a/tests/test_blocklist.py
+++ b/tests/test_blocklist.py
@@ -1,0 +1,32 @@
+import os
+from email.message import EmailMessage
+
+from emailbot.messaging import _is_blocklisted
+
+
+def _msg(to_):
+    m = EmailMessage()
+    m["From"] = "bot@example.com"
+    m["To"] = to_
+    m["Subject"] = "x"
+    return m
+
+
+def test_default_blocklist():
+    assert _is_blocklisted("no-reply@site.com")
+    assert _is_blocklisted("mailer-daemon@site.com")
+    assert not _is_blocklisted("user@site.com")
+
+
+def test_support_toggle(monkeypatch):
+    monkeypatch.setenv("FILTER_SUPPORT", "1")
+    assert _is_blocklisted("support@vendor.io")
+    monkeypatch.setenv("FILTER_SUPPORT", "0")
+    assert not _is_blocklisted("support@vendor.io")
+
+
+def test_extra_blocklist(monkeypatch):
+    monkeypatch.setenv("FILTER_BLOCKLIST", "helpdesk@x.com, alerts@news.io")
+    assert _is_blocklisted("alerts@news.io")
+    assert not _is_blocklisted("user@news.io")
+

--- a/tests/test_idempotency.py
+++ b/tests/test_idempotency.py
@@ -1,0 +1,28 @@
+from email.message import EmailMessage
+
+from emailbot.messaging import was_sent_recently, mark_sent, _make_send_key
+
+
+def _msg(ftu=("a@b.com", "c@d.com", "hi")):
+    m = EmailMessage()
+    m["From"] = ftu[0]
+    m["To"] = ftu[1]
+    m["Subject"] = ftu[2]
+    return m
+
+
+def test_was_sent_recently_flow(tmp_path, monkeypatch):
+    # redirect storage file
+    monkeypatch.setattr("emailbot.messaging.SENT_IDS_FILE", tmp_path / "sent_ids.jsonl")
+    msg = _msg()
+    assert was_sent_recently(msg) is False
+    mark_sent(msg)
+    # after marking, it should be True
+    assert was_sent_recently(msg) is True
+
+
+def test_make_key_is_stable_same_day():
+    m1 = _msg(("a@b.com", "c@d.com", "s"))
+    m2 = _msg(("a@b.com", "c@d.com", "s"))
+    assert _make_send_key(m1) == _make_send_key(m2)
+


### PR DESCRIPTION
## Summary
- read SMTP timeout from environment in SMTP client and sender
- persist per-day sent message ids and filter blocklisted addresses
- add tests for blocklist and idempotency utilities

## Testing
- `pre-commit run --files emailbot/smtp_client.py mailer/smtp_sender.py emailbot/messaging_utils.py emailbot/messaging.py tests/test_blocklist.py tests/test_idempotency.py` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68beeba8bd8083269dec7a559ad3290f