### PR TITLE
Handle IMAP sent folder names in modified UTF-7

### DIFF
--- a/tests/test_detect_sent_folder.py
+++ b/tests/test_detect_sent_folder.py
@@ -1,7 +1,4 @@
-import types
-from pathlib import Path
-
-from emailbot.messaging_utils import detect_sent_folder, SENT_CACHE_FILE
+from emailbot.messaging_utils import detect_sent_folder
 
 
 class DummyImap:
@@ -15,7 +12,9 @@ class DummyImap:
 
 def test_detect_sent_folder_prefers_flagged_sent(tmp_path, monkeypatch):
     # перенаправим кэш в временную директорию
-    monkeypatch.setattr("emailbot.messaging_utils.SENT_CACHE_FILE", tmp_path / "imap_sent_folder.txt")
+    monkeypatch.setattr(
+        "emailbot.messaging_utils.SENT_CACHE_FILE", tmp_path / "imap_sent_folder.txt"
+    )
     imap = DummyImap(
         [
             b'(\\HasNoChildren) "/" "INBOX"',
@@ -26,14 +25,15 @@ def test_detect_sent_folder_prefers_flagged_sent(tmp_path, monkeypatch):
     sent = detect_sent_folder(imap)
     assert sent == "Sent"
     # и кэш должен сохраниться
-    assert (
-        (tmp_path / "imap_sent_folder.txt").read_text(encoding="utf-8").strip()
-        == "Sent"
-    )
+    assert (tmp_path / "imap_sent_folder.txt").read_text(
+        encoding="utf-8"
+    ).strip() == "Sent"
 
 
 def test_detect_sent_folder_localized_ru(tmp_path, monkeypatch):
-    monkeypatch.setattr("emailbot.messaging_utils.SENT_CACHE_FILE", tmp_path / "imap_sent_folder.txt")
+    monkeypatch.setattr(
+        "emailbot.messaging_utils.SENT_CACHE_FILE", tmp_path / "imap_sent_folder.txt"
+    )
     imap = DummyImap(
         [
             b'(\\HasNoChildren) "/" "INBOX"',
@@ -41,7 +41,7 @@ def test_detect_sent_folder_localized_ru(tmp_path, monkeypatch):
         ]
     )
     sent = detect_sent_folder(imap)
-    assert sent == "&BB4EQgQ,BEAEMAQyBDsENQQ9BD0ESwQ1-"
+    assert sent == "Отправленные"
 
 
 def test_detect_sent_folder_uses_cache(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- decode IMAP mailbox names using modified UTF-7 when detecting the Sent folder and cache them as text
- ensure imap APPEND adds the standard `\Seen` flag
- simplify saving messages to the Sent folder using environment configuration

## Testing
- `python -m isort emailbot/messaging_utils.py emailbot/messaging.py tests/test_detect_sent_folder.py`
- `python -m black emailbot/messaging_utils.py emailbot/messaging.py tests/test_detect_sent_folder.py`
- `python -m ruff check --fix emailbot/messaging_utils.py emailbot/messaging.py tests/test_detect_sent_folder.py`
- `pytest`
- `pre-commit run --files emailbot/messaging_utils.py emailbot/messaging.py tests/test_detect_sent_folder.py` *(fails: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2f3e19b883269f1c90c244a84247