### PR TITLE
feat: skip manual mass send when no emails

### DIFF
--- a/emailbot/messaging.py
+++ b/emailbot/messaging.py
@@ -75,6 +75,7 @@ SIGNATURE_TEXT = (
 )
 EMAIL_ADDRESS = ""
 EMAIL_PASSWORD = ""
+SMTP_HOST = os.getenv("SMTP_HOST", "smtp.mail.ru")
 
 IMAP_FOLDER_FILE = SCRIPT_DIR / "imap_sent_folder.txt"
 
@@ -738,6 +739,26 @@ def get_sent_today() -> Set[str]:
 
 def count_sent_today() -> int:
     return len(get_sent_today())
+
+
+def start_manual_mass_send(group: str, emails: List[str], *args, **kwargs) -> None:
+    logger.info("Manual mass send: group=%s count=%d", group, len(emails))
+    # Guard от пустых рассылок
+    if not emails:
+        logger.info("Manual mass send skipped: empty recipient list")
+        notify_user("Отправка не запущена: нет адресов для отправки.")
+        return
+    notify_user("Запущено — выполняю в фоне...")
+    notify_user(f"✉️ Рассылка начата. Отправляем {len(emails)} писем...")
+
+    messages = kwargs.get("messages", [])
+    sent = _send_batch(
+        messages,
+        host=SMTP_HOST,
+        user=EMAIL_ADDRESS,
+        password=EMAIL_PASSWORD,
+    )
+    notify_user(f"✅ Отправлено писем: {sent}")
 
 
 def prepare_mass_mailing(emails: list[str]):


### PR DESCRIPTION
## Summary
- prevent manual mass send when recipient list is empty
- add configurable SMTP host constant

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf44fa16a883269d03727478bad589