### PR TITLE
feat: unify manual input parsing pipeline

### DIFF
--- a/bot/handlers/manual_send.py
+++ b/bot/handlers/manual_send.py
@@ -1,50 +1,12 @@
 """Utilities for manual e-mail sending.
 
-This module currently exposes :func:`parse_manual_input` which is used to
-normalize user supplied e-mail addresses.  The function extracts potential
-addresses from arbitrary text, sanitises them and removes duplicates including
-"footnote" variants ("55alex@example.com" vs ``alex@example.com``).
+This module re-exports :func:`parse_manual_input` from :mod:`utils.email_clean`
+to provide a stable import location for callers.
 """
 
 from __future__ import annotations
 
-from utils.email_clean import (
-    extract_emails,
-    sanitize_email,
-    dedupe_with_variants,
-)
-
-
-def parse_manual_input(text: str) -> list[str]:
-    """Extract e-mail addresses from arbitrary text.
-
-    The parser supports mixed separators (commas, spaces, semicolons, new
-    lines), strips surrounding punctuation, drops invalid addresses and
-    de‑duplicates, removing "footnote" prefixes such as ``55alex@``.
-
-    Parameters
-    ----------
-    text:
-        Raw text entered by a user in the chat.
-
-    Returns
-    -------
-    list[str]
-        A list of cleaned and unique e‑mail addresses.
-    """
-
-    # 1) Extract raw e-mail substrings
-    raw = extract_emails(text)
-    if not raw:
-        return []
-
-    # 2) Sanitize each address; ``sanitize_email`` returns "" for invalid ones
-    cleaned = [sanitize_email(e) for e in raw]
-    cleaned = [e for e in cleaned if e]
-
-    # 3) Deduplicate, removing footnote variants
-    emails = dedupe_with_variants(cleaned)
-    return emails
+from utils.email_clean import parse_manual_input
 
 
 __all__ = ["parse_manual_input"]

--- a/utils/email_clean.py
+++ b/utils/email_clean.py
@@ -138,3 +138,14 @@ def dedupe_with_variants(emails: list[str]) -> list[str]:
             final.add(sorted(vars_set, key=len)[0])
 
     return sorted(final)
+
+
+def parse_manual_input(text: str) -> list[str]:
+    """
+    Унифицированный парсер ручного ввода.
+    Использует тот же пайплайн, что и для файлов/сайтов:
+      extract_emails → sanitize_email → dedupe_with_variants
+    """
+    raw = extract_emails(text)
+    cleaned = [e for e in (sanitize_email(x) for x in raw) if e]
+    return dedupe_with_variants(cleaned)


### PR DESCRIPTION
## Summary
- re-export manual email input parser from utils
- centralize manual text parsing in unified pipeline

## Testing
- `pre-commit run --files utils/email_clean.py bot/handlers/manual_send.py` *(fails: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfd4dfcc188326a9b946e083a32cf7