### PR TITLE
feat: add stricter domain validation

### DIFF
--- a/tests/test_email_clean.py
+++ b/tests/test_email_clean.py
@@ -62,3 +62,20 @@ def test_ocr_comma_before_tld():
     src = "foo@bar,ru"
     got = extract_emails(src)
     assert got == ["foo@bar.ru"]
+
+
+def test_reject_double_dots_and_hyphen_edges():
+    assert sanitize_email("user@foo..bar.com") == ""
+    assert sanitize_email("user@-foo.com") == ""
+    assert sanitize_email("user@foo-.com") == ""
+
+
+def test_label_length_and_tld_rules():
+    long_label = "a" * 64
+    assert sanitize_email(f"user@{long_label}.com") == ""
+    assert sanitize_email("user@example.c0m") == ""
+    assert sanitize_email("user@example." + "a" * 25) == ""
+    assert (
+        sanitize_email("user@example." + "a" * 24)
+        == "user@example." + "a" * 24
+    )


### PR DESCRIPTION
## Summary
- tighten ASCII domain validation pattern to block edge hyphens and invalid TLDs
- re-check domain after IDNA encoding to strip out invalid Unicode domains
- add tests for double dots, edge hyphens and TLD length rules

## Testing
- `pre-commit run --files utils/email_clean.py tests/test_email_clean.py` *(fails: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bff4a251448326af89b0ea90b6fe01