### PR TITLE
Add tests for email deobfuscation

### DIFF
--- a/tests/test_deobfuscate.py
+++ b/tests/test_deobfuscate.py
@@ -1,0 +1,27 @@
+from utils.email_clean import extract_emails, dedupe_with_variants
+
+
+def test_english_obfuscation():
+    src = "Write me: ivan.petrov [at] gmail [dot] com"
+    assert extract_emails(src) == ["ivan.petrov@gmail.com"]
+
+
+def test_russian_obfuscation():
+    src = "почта: ivan(собака)yandex(точка)ru"
+    assert extract_emails(src) == ["ivan@yandex.ru"]
+
+
+def test_ocr_comma_before_tld():
+    src = "user@mail,ru"
+    assert extract_emails(src) == ["user@mail.ru"]
+
+
+def test_provider_dedupe_gmail_plus_and_dots():
+    lst = ["ivan.petrov+news@gmail.com", "ivanpetrov@gmail.com"]
+    assert dedupe_with_variants(lst) == ["ivan.petrov+news@gmail.com"]
+
+
+def test_provider_dedupe_yandex_plus():
+    lst = ["pavel+tag@yandex.ru", "pavel@yandex.ru"]
+    assert dedupe_with_variants(lst) == ["pavel+tag@yandex.ru"]
+


### PR DESCRIPTION
## Summary
- add tests covering deobfuscation patterns and provider-specific deduping

## Testing
- `pytest tests/test_deobfuscate.py`

------
https://chatgpt.com/codex/tasks/task_e_68bff9121d3483269760976d82b91ca7