### PR TITLE
Introduce unified email parsing pipeline with debugging

### DIFF
--- a/tests/test_unified_parser.py
+++ b/tests/test_unified_parser.py
@@ -1,0 +1,63 @@
+import pytest
+
+from utils.email_clean import parse_emails_unified
+
+
+def test_simple_space_delimited():
+    src = "a@b.com c@d.com"
+    assert parse_emails_unified(src) == ["a@b.com", "c@d.com"]
+
+
+def test_multiline_and_nbsp_and_zwsp():
+    src = "p1@mail.ru\u200b\np2@mail.ru\u00a0p3@mail.ru"
+    got = parse_emails_unified(src)
+    assert got == ["p1@mail.ru", "p2@mail.ru", "p3@mail.ru"]
+
+
+def test_fio_glued_with_email():
+    src = "ивановсергейamazonka.sambo@list.ru"
+    assert parse_emails_unified(src) == ["amazonka.sambo@list.ru"]
+
+
+def test_deobfuscate_at_dot_ru_and_ru():
+    src = "ivan.petrov [at] gmail [dot] com; pavel(собака)yandex(точка)ru"
+    got = parse_emails_unified(src)
+    assert "ivan.petrov@gmail.com" in got
+    assert "pavel@yandex.ru" in got
+
+
+def test_ocr_comma_before_tld():
+    src = "user@mail,ru and other"
+    assert parse_emails_unified(src) == ["user@mail.ru"]
+
+
+def test_provider_dedupe_gmail_dots_plus():
+    src = "ivan.petrov+tag@gmail.com ivanpetrov@gmail.com"
+    got = parse_emails_unified(src)
+    assert got == ["ivan.petrov+tag@gmail.com"]
+
+
+def test_provider_dedupe_yandex_plus():
+    src = "pavel+news@yandex.ru pavel@yandex.ru"
+    got = parse_emails_unified(src)
+    assert got == ["pavel+news@yandex.ru"]
+
+
+def test_provider_dedupe_mailru_plus():
+    src = "name+abc@mail.ru name@mail.ru"
+    got = parse_emails_unified(src)
+    assert got == ["name+abc@mail.ru"]
+
+
+def test_unicode_domain_punycode_kept_correct():
+    src = "test@тест.рф"
+    got = parse_emails_unified(src)
+    assert got == ["test@xn--e1aybc.xn--p1ai"]
+
+
+@pytest.mark.parametrize("flag", ["0", "1"])
+def test_debug_flag_does_not_change_output(monkeypatch, flag):
+    monkeypatch.setenv("EMAIL_PARSE_DEBUG", flag)
+    src = "a@b.com, c@d.com"
+    got = parse_emails_unified(src)
+    assert got == ["a@b.com", "c@d.com"]


### PR DESCRIPTION
## Summary
- add configurable debug logging and unified parse_emails_unified pipeline
- route manual bot input through parse_emails_unified
- cover unified parser with tests, including provider-specific dedupe and unicode domain handling

## Testing
- `pre-commit run --files utils/email_clean.py emailbot/bot_handlers.py tests/test_unified_parser.py --config .pre-commit-config.local.yaml`
- `pytest tests/test_unified_parser.py tests/test_manual_parse.py tests/test_deobfuscate.py tests/test_email_clean.py tests/test_sanitize.py tests/test_dedupe.py tests/test_dedupe_footnotes.py tests/test_bot_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68bffed188648326953817745fd4520a