### PR TITLE
feat: support additional mailing disciplines with custom signatures

### DIFF
--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -612,9 +612,20 @@ async def prompt_change_group(
     """Prompt the user to choose a mailing group."""
 
     keyboard = [
-        [InlineKeyboardButton("⚽ Спорт", callback_data="group_спорт")],
-        [InlineKeyboardButton("🏕 Туризм", callback_data="group_туризм")],
-        [InlineKeyboardButton("🩺 Медицина", callback_data="group_медицина")],
+        [
+            InlineKeyboardButton("🩺 Медицина", callback_data="group_медицина"),
+            InlineKeyboardButton("⚽ Спорт", callback_data="group_спорт"),
+        ],
+        [
+            InlineKeyboardButton("🏕 Туризм", callback_data="group_туризм"),
+            InlineKeyboardButton("🧠 Психология", callback_data="group_психология"),
+        ],
+        [
+            InlineKeyboardButton("🗺 География", callback_data="group_география"),
+            InlineKeyboardButton(
+                "🧬 Биоинформатика", callback_data="group_биоинформатика"
+            ),
+        ],
     ]
     await update.message.reply_text(
         "⬇️ Выберите направление рассылки:",
@@ -1051,9 +1062,20 @@ async def proceed_to_group(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     query = update.callback_query
     await query.answer()
     keyboard = [
-        [InlineKeyboardButton("⚽ Спорт", callback_data="group_спорт")],
-        [InlineKeyboardButton("🏕 Туризм", callback_data="group_туризм")],
-        [InlineKeyboardButton("🩺 Медицина", callback_data="group_медицина")],
+        [
+            InlineKeyboardButton("🩺 Медицина", callback_data="group_медицина"),
+            InlineKeyboardButton("⚽ Спорт", callback_data="group_спорт"),
+        ],
+        [
+            InlineKeyboardButton("🏕 Туризм", callback_data="group_туризм"),
+            InlineKeyboardButton("🧠 Психология", callback_data="group_психология"),
+        ],
+        [
+            InlineKeyboardButton("🗺 География", callback_data="group_география"),
+            InlineKeyboardButton(
+                "🧬 Биоинформатика", callback_data="group_биоинформатика"
+            ),
+        ],
     ]
     await query.message.reply_text(
         "⬇️ Выберите направление рассылки:",
@@ -1163,12 +1185,28 @@ async def handle_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
         context.chat_data["manual_send_mode"] = "allowed"  # allowed|all
 
         group_kb = [
-            [InlineKeyboardButton("⚽ Спорт", callback_data="manual_group_спорт")],
-            [InlineKeyboardButton("🏕 Туризм", callback_data="manual_group_туризм")],
             [
                 InlineKeyboardButton(
                     "🩺 Медицина", callback_data="manual_group_медицина"
-                )
+                ),
+                InlineKeyboardButton("⚽ Спорт", callback_data="manual_group_спорт"),
+            ],
+            [
+                InlineKeyboardButton(
+                    "🏕 Туризм", callback_data="manual_group_туризм"
+                ),
+                InlineKeyboardButton(
+                    "🧠 Психология", callback_data="manual_group_психология"
+                ),
+            ],
+            [
+                InlineKeyboardButton(
+                    "🗺 География", callback_data="manual_group_география"
+                ),
+                InlineKeyboardButton(
+                    "🧬 Биоинформатика",
+                    callback_data="manual_group_биоинформатика",
+                ),
             ],
         ]
 

--- a/templates/bioinformatics.html
+++ b/templates/bioinformatics.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    {{BODY}}
+    <br/><br/>
+    {{SIGNATURE}}
+  </body>
+</html>

--- a/templates/geography.html
+++ b/templates/geography.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    {{BODY}}
+    <br/><br/>
+    {{SIGNATURE}}
+  </body>
+</html>

--- a/templates/psychology.html
+++ b/templates/psychology.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    {{BODY}}
+    <br/><br/>
+    {{SIGNATURE}}
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- extend group selection keyboards with psychology, geography and bioinformatics
- add templates and dynamic signatures for new disciplines

## Testing
- `pre-commit run --files emailbot/bot_handlers.py emailbot/messaging.py templates/psychology.html templates/geography.html templates/bioinformatics.html` *(fails: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c00558862c8326b2b89482aaf18d80