### PR TITLE
feat: add from header selection

### DIFF
--- a/tests/test_messaging_from.py
+++ b/tests/test_messaging_from.py
@@ -1,0 +1,28 @@
+import os
+import pytest
+from emailbot import messaging
+
+
+@pytest.mark.parametrize(
+    "group, expected",
+    [
+        ("медицина", "Редакция литературы по медицине, спорту и туризму"),
+        ("спорт", "Редакция литературы по медицине, спорту и туризму"),
+        ("туризм", "Редакция литературы по медицине, спорту и туризму"),
+        ("психология", "Редакция литературы"),
+        ("география", "Редакция литературы"),
+        ("биоинформатика", "Редакция литературы"),
+    ],
+)
+def test_choose_from_header(monkeypatch, group, expected):
+    monkeypatch.setenv("EMAIL_ADDRESS", "test@lanbook.ru")
+    msgs = messaging.build_messages_for_group(group, ["rcpt@example.com"], {})
+    assert len(msgs) == 1
+    msg = msgs[0]
+    assert "From" in msg
+    value = msg["From"]
+    # проверяем, что имя совпадает
+    assert value.startswith(expected), f"unexpected From: {value}"
+    # и адрес подтянулся из EMAIL_ADDRESS
+    assert "<test@lanbook.ru>" in value
+


### PR DESCRIPTION
## Summary
- choose sender name based on mailing group
- set From header in group message builder
- cover sender selection with tests

## Testing
- `pytest tests/test_messaging_from.py tests/test_messaging.py`


------
https://chatgpt.com/codex/tasks/task_e_68c027bc5d408326bc75cff8be86cc2c