### PR TITLE
Normalize local-part homoglyphs for OCR-parsed emails

### DIFF
--- a/tests/test_pdf_homoglyphs.py
+++ b/tests/test_pdf_homoglyphs.py
@@ -1,0 +1,22 @@
+from utils.email_clean import parse_emails_unified, extract_emails
+
+
+def test_cyrillic_c_in_localpart_kept_as_c():
+    # первая буква кириллицей: 'сhukanov.ev@gmail.com' → должно стать 'chukanov.ev@gmail.com'
+    src = "контакт: сhukanov.ev@gmail.com"
+    got = parse_emails_unified(src)
+    assert got == ["chukanov.ev@gmail.com"]
+
+
+def test_middle_dot_between_initials():
+    # разделитель-«точка» из PDF: '·' → '.'
+    src = "почта: chukanov·ev@gmail.com"
+    got = parse_emails_unified(src)
+    assert got == ["chukanov.ev@gmail.com"]
+
+
+def test_both_issues_together():
+    src = "e-mail: сhukanov·ev@gmail.com"
+    # промежуточный extract_emails тоже должен поймать корректно
+    assert extract_emails(src) == ["chukanov.ev@gmail.com"]
+    assert parse_emails_unified(src) == ["chukanov.ev@gmail.com"]


### PR DESCRIPTION
## Summary
- normalize local-part text by replacing Cyrillic homoglyphs with Latin and converting mid-dot variants to '.'
- add tests covering OCR homoglyph issues in PDF parsing

## Testing
- `python -m black utils/email_clean.py tests/test_pdf_homoglyphs.py`
- `flake8 utils/email_clean.py tests/test_pdf_homoglyphs.py` *(failed: command not found)*
- `pytest tests/test_pdf_homoglyphs.py tests/test_pdf_ocr.py tests/test_email_clean.py tests/test_unified_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_68c123f383988326bf33552c4c64479c