### PR TITLE
Fix OCR soft sign and PDF dot variants in email local-part

### DIFF
--- a/tests/test_pdf_homoglyphs.py
+++ b/tests/test_pdf_homoglyphs.py
@@ -1,22 +1,18 @@
 from utils.email_clean import parse_emails_unified, extract_emails
 
 
-def test_cyrillic_c_in_localpart_kept_as_c():
-    # первая буква кириллицей: 'сhukanov.ev@gmail.com' → должно стать 'chukanov.ev@gmail.com'
-    src = "контакт: сhukanov.ev@gmail.com"
+def test_cyrillic_soft_sign_to_b_in_localpart():
+    # должно стать 'balan7@yandex.ru'
+    src = "контакт: ьalan7@yandex.ru"
     got = parse_emails_unified(src)
-    assert got == ["chukanov.ev@gmail.com"]
+    assert got == ["balan7@yandex.ru"]
 
 
-def test_middle_dot_between_initials():
-    # разделитель-«точка» из PDF: '·' → '.'
-    src = "почта: chukanov·ev@gmail.com"
-    got = parse_emails_unified(src)
-    assert got == ["chukanov.ev@gmail.com"]
-
-
-def test_both_issues_together():
+def test_cyrillic_c_and_middle_dot_to_dot():
     src = "e-mail: сhukanov·ev@gmail.com"
-    # промежуточный extract_emails тоже должен поймать корректно
-    assert extract_emails(src) == ["chukanov.ev@gmail.com"]
     assert parse_emails_unified(src) == ["chukanov.ev@gmail.com"]
+
+
+def test_extract_emails_after_normalize_localparts():
+    src = "почта: сhukanov·ev@gmail.com"
+    assert extract_emails(src) == ["chukanov.ev@gmail.com"]

--- a/utils/email_clean.py
+++ b/utils/email_clean.py
@@ -67,9 +67,12 @@ _LOCAL_HOMO_MAP = str.maketrans(
         "Н": "H",
         "В": "B",
         "І": "I",
+        # OCR: мягкий знак часто распознаётся вместо латинской 'b'
+        "ь": "b",
+        "Ь": "B",
     }
 )
-_DOT_VARIANTS = "[\u00b7\u2022\u2219\u22c5\u2027\u30fb\u0387]"  # · • ∙ ⋅ ․ ・ ϙ
+_DOT_VARIANTS = r"[\u00B7\u2022\u2219\u22C5\u2027\u30FB\u0387\u2024\u2044]"  # · • ∙ ⋅ ․ ・ · (one-dot leader) / (slash as dot в OCR)
 _LOCAL_CANDIDATE = re.compile(r"(?P<local>[^\s@]{1,64})@(?P<rest>[^\s<>\[\]\(\)\{\}]+)")
 
 


### PR DESCRIPTION
## Summary
- handle soft sign OCR mistakes mapping to Latin b/B
- normalize additional PDF dot variants in email local-part
- test soft sign and PDF dot normalization

## Testing
- `pre-commit run --files utils/email_clean.py tests/test_pdf_homoglyphs.py` *(failed: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `pytest tests/test_pdf_homoglyphs.py`

------
https://chatgpt.com/codex/tasks/task_e_68c1285e799883269dd992a626620883