### PR TITLE
Use local send log for daily report

### DIFF
--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -27,6 +27,7 @@ from telegram import (
 from telegram.ext import ContextTypes
 
 from utils.email_clean import parse_emails_unified
+from utils.send_stats import summarize_today
 
 from . import extraction as _extraction
 from . import extraction_url as _extraction_url
@@ -738,13 +739,14 @@ async def report_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
 def get_report(period: str = "day") -> str:
     """Return statistics of sent e-mails for the given period."""
+    if period == "day":
+        s = summarize_today()
+        return f"Успешных: {s.get('ok',0)}\nОшибок: {s.get('err',0)}"
 
     if not os.path.exists(LOG_FILE):
         return "Нет данных о рассылках."
     now = datetime.now()
-    if period == "day":
-        start_at = now - timedelta(days=1)
-    elif period == "week":
+    if period == "week":
         start_at = now - timedelta(weeks=1)
     elif period == "month":
         start_at = now - timedelta(days=30)

--- a/mailer/smtp_sender.py
+++ b/mailer/smtp_sender.py
@@ -4,6 +4,8 @@ import smtplib
 from typing import Iterable
 from email.message import EmailMessage
 
+from utils.send_stats import log_error, log_success
+
 PORT = int(os.getenv("SMTP_PORT", "587"))
 USE_SSL = os.getenv("SMTP_SSL", "0") == "1"
 logger = logging.getLogger(__name__)
@@ -36,7 +38,19 @@ def send_messages(messages: Iterable[EmailMessage], user: str, password: str, ho
                     pass
                 try:
                     smtp.send_message(msg)
-                except Exception:
+                    try:
+                        log_success(msg.get("To", ""), msg.get("X-EBOT-Group", ""))
+                    except Exception:
+                        pass
+                except Exception as e:
+                    try:
+                        log_error(
+                            msg.get("To", ""),
+                            msg.get("X-EBOT-Group", ""),
+                            repr(e),
+                        )
+                    except Exception:
+                        pass
                     try:
                         smtp.rset()
                     except Exception:
@@ -61,7 +75,19 @@ def send_messages(messages: Iterable[EmailMessage], user: str, password: str, ho
                     pass
                 try:
                     smtp.send_message(msg)
-                except Exception:
+                    try:
+                        log_success(msg.get("To", ""), msg.get("X-EBOT-Group", ""))
+                    except Exception:
+                        pass
+                except Exception as e:
+                    try:
+                        log_error(
+                            msg.get("To", ""),
+                            msg.get("X-EBOT-Group", ""),
+                            repr(e),
+                        )
+                    except Exception:
+                        pass
                     try:
                         smtp.rset()
                     except Exception:

--- a/utils/send_stats.py
+++ b/utils/send_stats.py
@@ -1,0 +1,49 @@
+import json
+import os
+import datetime as dt
+from pathlib import Path
+
+_PATH = Path(os.getenv("SEND_STATS_PATH", "var/send_stats.jsonl"))
+_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+def log_success(email: str, group: str) -> None:
+    rec = {
+        "ts": dt.datetime.utcnow().isoformat() + "Z",
+        "date": dt.date.today().isoformat(),
+        "email": email,
+        "group": (group or "").strip().lower(),
+        "status": "sent",
+    }
+    with _PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+def summarize_today() -> dict:
+    today = dt.date.today().isoformat()
+    ok = 0
+    errs = 0
+    if not _PATH.exists():
+        return {"ok": 0, "err": 0}
+    with _PATH.open("r", encoding="utf-8") as f:
+        for line in f:
+            try:
+                rec = json.loads(line)
+            except Exception:
+                continue
+            if rec.get("date") == today:
+                if rec.get("status") == "sent":
+                    ok += 1
+                elif rec.get("status") == "error":
+                    errs += 1
+    return {"ok": ok, "err": errs}
+
+def log_error(email: str, group: str, reason: str) -> None:
+    rec = {
+        "ts": dt.datetime.utcnow().isoformat() + "Z",
+        "date": dt.date.today().isoformat(),
+        "email": email,
+        "group": (group or "").strip().lower(),
+        "status": "error",
+        "reason": reason[:300],
+    }
+    with _PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(rec, ensure_ascii=False) + "\n")


### PR DESCRIPTION
## Summary
- log successful/error email sends to local JSONL file
- report today's send stats from local log instead of waiting for IMAP sync

## Testing
- `pre-commit run --files emailbot/bot_handlers.py mailer/smtp_sender.py utils/send_stats.py` *(fails: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c12cc35afc8326be002fe3009cd9d3