### PR TITLE
Handle hidden characters around emails

### DIFF
--- a/tests/test_prefix_boundary_loss.py
+++ b/tests/test_prefix_boundary_loss.py
@@ -1,0 +1,20 @@
+from utils.email_clean import extract_emails, parse_emails_unified
+
+
+def test_no_first_char_loss_after_word_boundary():
+    # буква "b" не должна пропадать
+    src = "ФИОbalan7@yandex.ru"
+    assert extract_emails(src) == ["balan7@yandex.ru"]
+    assert parse_emails_unified(src) == ["balan7@yandex.ru"]
+
+
+def test_no_first_char_loss_with_soft_hyphen_before():
+    # soft hyphen (невидимый перенос) перед локалом
+    src = "контакт:­balan7@yandex.ru"
+    assert parse_emails_unified(src) == ["balan7@yandex.ru"]
+
+
+def test_no_first_char_loss_with_zwsp_before():
+    # zero-width space перед локалом
+    src = "контакт:​balan7@yandex.ru"
+    assert parse_emails_unified(src) == ["balan7@yandex.ru"]


### PR DESCRIPTION
## Summary
- Strip zero-width and soft-hyphen characters that disrupt PDF/OCR email boundaries
- Normalize local parts using Unicode-aware boundaries and Cyrillic homograph mapping
- Avoid mutating text when emails are glued to words by using regex boundaries instead

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c141826584832695f221c3d2dd2c4d