### PR TITLE
feat: canonical email dedupe keeps original addresses

### DIFF
--- a/tests/test_canonical_vs_original.py
+++ b/tests/test_canonical_vs_original.py
@@ -1,0 +1,29 @@
+from utils.email_clean import canonicalize_email, dedupe_keep_original
+
+
+def test_gmail_dots_and_plus_are_canonicalized():
+    originals = [
+        "y.pavelchuk.xhe@gmail.com",
+        "ypavelchukxhe+tag@gmail.com",
+        "Y.PAVELCHUK.XHE@GMAIL.COM",
+    ]
+    canon = [canonicalize_email(x) for x in originals]
+    # все каноны должны совпасть
+    assert len(set(canon)) == 1
+    # дедуп сохранит первый оригинал (с точками)
+    keep = dedupe_keep_original(originals)
+    assert keep == ["y.pavelchuk.xhe@gmail.com"]
+
+
+def test_yandex_plus_is_removed_in_canonical_only():
+    originals = ["ivan.petrov+yad@yandex.ru", "ivan.petrov@yandex.ru"]
+    keep = dedupe_keep_original(originals)
+    # дубликат выкинут, но первый вариант (с +yad) сохранится для отправки
+    assert keep == ["ivan.petrov+yad@yandex.ru"]
+
+
+def test_other_domains_keep_dots():
+    originals = ["name.surname@uni.edu", "namesurname@uni.edu"]
+    # для других доменов точки значимы → это не дубли
+    keep = dedupe_keep_original(originals)
+    assert keep == originals

--- a/tests/test_unified_parser.py
+++ b/tests/test_unified_parser.py
@@ -1,6 +1,6 @@
 import pytest
 
-from utils.email_clean import parse_emails_unified
+from utils.email_clean import dedupe_keep_original, parse_emails_unified
 
 
 def test_simple_space_delimited():
@@ -33,19 +33,19 @@ def test_ocr_comma_before_tld():
 
 def test_provider_dedupe_gmail_dots_plus():
     src = "ivan.petrov+tag@gmail.com ivanpetrov@gmail.com"
-    got = parse_emails_unified(src)
+    got = dedupe_keep_original(parse_emails_unified(src))
     assert got == ["ivan.petrov+tag@gmail.com"]
 
 
 def test_provider_dedupe_yandex_plus():
     src = "pavel+news@yandex.ru pavel@yandex.ru"
-    got = parse_emails_unified(src)
+    got = dedupe_keep_original(parse_emails_unified(src))
     assert got == ["pavel+news@yandex.ru"]
 
 
 def test_provider_dedupe_mailru_plus():
     src = "name+abc@mail.ru name@mail.ru"
-    got = parse_emails_unified(src)
+    got = dedupe_keep_original(parse_emails_unified(src))
     assert got == ["name+abc@mail.ru"]
 
 


### PR DESCRIPTION
## Summary
- add canonicalize_email and dedupe_keep_original helpers
- keep original email text while deduping in bot handlers
- cover canonical vs original addresses with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c16fc95e588326940f170fe6caa47e