### PR TITLE
Improve email boundary handling, dedupe, and preview sampling

### DIFF
--- a/bot/handlers/report.py
+++ b/bot/handlers/report.py
@@ -1,16 +1,13 @@
 import random
 
+
 def build_examples(emails: list[str], k: int = 10) -> list[str]:
     # крипто-рандом, чтобы телеграм-кэш и однаковый вход давали разные примеры
     rng = random.SystemRandom()
-    n = min(k, len(emails))
-    if n == 0:
-        return []
-    # Ожидаем, что сюда приходят уже очищенные адреса. На всякий случай
-    # удалим дубликаты, чтобы примеры не повторялись.
     unique = list(dict.fromkeys(emails))
-    sample = rng.sample(unique, n)
-    return sample
+    if len(unique) <= k:
+        return unique
+    return rng.sample(unique, k)
 
 def make_summary_message(stats, emails: list[str]) -> str:
     examples = build_examples(emails)

--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -113,11 +113,10 @@ def is_numeric_localpart(email_addr: str) -> bool:
 
 def sample_preview(items, k: int):
     lst = list(dict.fromkeys(items))
-    n = min(k, len(lst))
-    if n <= 0:
-        return []
-    rng = random.SystemRandom()
-    return rng.sample(lst, n)
+    if len(lst) <= k:
+        return lst
+    rng = random.SystemRandom()    # не влияет на глобальное состояние
+    return rng.sample(lst, k)
 
 
 from .messaging import (  # noqa: E402,F401  # isort: skip

--- a/emailbot/extraction_common.py
+++ b/emailbot/extraction_common.py
@@ -51,13 +51,23 @@ def normalize_text(s: str) -> str:
     s = s.replace("\u00A0", " ")  # NBSP
     s = _Z_SPACE_RE.sub(" ", s)
 
-    # Zero-width characters
-    s = (
-        s.replace("\u200B", "")
-        .replace("\u200C", "")
-        .replace("\u200D", "")
-        .replace("\uFEFF", "")
+    # Zero-width / invisibles / BiDi marks / soft hyphen и пр.
+    # Это центрально важно, чтобы не «съедалась» первая буква e-mail.
+    INVISIBLES_RE = re.compile(
+        r"[\u00AD"                # SOFT HYPHEN
+        r"\u200B-\u200F"          # ZWSP..RLM
+        r"\u202A-\u202E"          # LRE..RLO/PDF
+        r"\u2028\u2029"           # LINE/PARAGRAPH SEP
+        r"\u202F"                 # NARROW NBSP
+        r"\u205F"                 # MEDIUM MATH SPACE
+        r"\u2060-\u206F"          # WORD JOINER..INVISIBLE OPS
+        r"\u2066-\u2069"          # LRI/RLI/FSI/PDI
+        r"\uFEFF"                 # ZW NBSP (BOM)
+        r"\u1680"                 # OGHAM SPACE MARK
+        r"\u180E"                 # MONGOLIAN VOWEL SEPARATOR
+        r"]"
     )
+    s = INVISIBLES_RE.sub("", s)
 
     # Various dashes/minuses -> ASCII '-'
     s = (


### PR DESCRIPTION
## Summary
- allow manual email extraction after any separator without truncating first char
- strip an extended range of invisible characters during text normalization
- dedupe emails using canonical form but keep original address for sending
- randomize preview examples without affecting global RNG

## Testing
- `pre-commit run --files emailbot/extraction.py emailbot/extraction_common.py emailbot/bot_handlers.py bot/handlers/report.py` *(failed: fatal: unable to access 'https://github.com/pre-commit/pre-commit-hooks/': CONNECT tunnel failed, response 403)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1918a56ec8326b14ea32ea0be5c2b