### PR TITLE
feat(bot): show suspicious emails and randomize examples

### DIFF
--- a/utils/email_clean.py
+++ b/utils/email_clean.py
@@ -247,12 +247,12 @@ def _normalize_text(s: str) -> str:
     s = s.replace("\xa0", " ")
     # 1) убираем единым правилом все невидимые/служебные символы
     s = strip_invisibles(s)
-    # 2) безопасно разлепляем границы перед e-mail (НЕ изменяя сам адрес)
-    s = _fix_glued_boundaries(s)
-    # 3.5) аккуратно убираем сноски (не перед адресом)
-    s = _strip_footnotes(s)
-    # 4) нормализация только local-part (чинит 'сhukanov·ev@' → 'chukanov.ev@')
+    # 2) нормализация только local-part (чинит 'сhukanov·ev@' → 'chukanov.ev@')
     s = _normalize_localparts(s)
+    # 3) безопасно разлепляем границы перед e-mail (НЕ изменяя сам адрес)
+    s = _fix_glued_boundaries(s)
+    # 4) аккуратно убираем сноски (не перед адресом)
+    s = _strip_footnotes(s)
     # размаскировка "at/dot/собака/точка" перед границами
     s = _deobfuscate(s)
     # сжимаем повторяющиеся пробелы


### PR DESCRIPTION
## Summary
- detect suspicious emails whose first letter may be missing and surface them in reports
- randomize email examples in reports and store suspicious samples in user state
- normalize local parts before boundary fixes to correctly parse Cyrillic addresses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c32eac357483269fb44a487adfec08