### PR TITLE
feat: improve reporting diagnostics and smtp logging

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -101,6 +101,8 @@ def main() -> None:
     app.add_handler(CommandHandler("retry_last", bot_handlers.retry_last_command))
     app.add_handler(CommandHandler("diag", bot_handlers.diag))
     app.add_handler(CommandHandler("features", bot_handlers.features))
+    app.add_handler(CommandHandler("reports", bot_handlers.handle_reports))
+    app.add_handler(CommandHandler("reports_debug", bot_handlers.handle_reports_debug))
 
     app.add_handler(
         MessageHandler(filters.TEXT & filters.Regex("^📤"), bot_handlers.prompt_upload)

--- a/utils/send_stats.py
+++ b/utils/send_stats.py
@@ -7,22 +7,44 @@ try:
 except Exception:  # pragma: no cover - fallback for older Python
     ZoneInfo = None
 
-_PATH = Path(os.getenv("SEND_STATS_PATH", "var/send_stats.jsonl"))
+
+def _resolve_path(p: str) -> Path:
+    """Return absolute path resolving ``~`` and relative segments."""
+
+    path = Path(p).expanduser()
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    return path.resolve()
+
+
+_PATH = _resolve_path(os.getenv("SEND_STATS_PATH", "var/send_stats.jsonl"))
 _PATH.parent.mkdir(parents=True, exist_ok=True)
-_TZ_NAME = os.getenv("REPORT_TZ", "Europe/Moscow")
+_TZ_NAME = (os.getenv("REPORT_TZ", "Europe/Moscow") or "Europe/Moscow").strip()
 
 
 def _now_utc() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _tzinfo():
+    """Resolve timezone from ``REPORT_TZ`` with MSK fallback."""
+
+    name = _TZ_NAME.lower()
+    if name in ("msk", "moscow", "europe/moscow", "russia/moscow"):
+        try:
+            return ZoneInfo("Europe/Moscow")
+        except Exception:
+            return timezone(timedelta(hours=3))
+    try:
+        return ZoneInfo(_TZ_NAME)
+    except Exception:
+        return timezone.utc
+
+
 def _to_local(dt_utc: datetime) -> datetime:
     if dt_utc.tzinfo is None:
         dt_utc = dt_utc.replace(tzinfo=timezone.utc)
-    if ZoneInfo:
-        return dt_utc.astimezone(ZoneInfo(_TZ_NAME))
-    # fallback: системная локаль (на крайний случай)
-    return dt_utc.astimezone()
+    return dt_utc.astimezone(_tzinfo())
 
 
 def log_success(email: str, group: str) -> None:
@@ -49,7 +71,7 @@ def log_error(email: str, group: str, reason: str) -> None:
 
 
 def _iter_today_week(scope: str):
-    """Предикат для отбора записей по ЛОКАЛЬНОЙ (REPORT_TZ) дате/неделе."""
+    """Предикат для отбора записей по ЛОКАЛЬНОЙ (REPORT_TZ/фоллбэк MSK) дате/неделе."""
 
     now_local = _to_local(_now_utc())
     if scope == "day":
@@ -108,7 +130,7 @@ def summarize_week() -> dict:
 def current_tz_label() -> str:
     """Возвращает краткую метку TZ для подписи отчётов, напр. 'MSK'."""
 
-    if _TZ_NAME.lower() in ("europe/moscow", "moscow", "msk"):
+    if _TZ_NAME.lower() in ("europe/moscow", "moscow", "msk", "russia/moscow"):
         return "MSK"
     return _TZ_NAME
 


### PR DESCRIPTION
## Summary
- improve path resolution and timezone fallback for send stats
- add report diagnostics command and binding
- ensure SMTP sender logs success and errors after retries

## Testing
- `pre-commit run --files email_bot.py emailbot/bot_handlers.py mailer/smtp_sender.py utils/send_stats.py` *(failed: CalledProcessError: command: ('/usr/bin/git', 'fetch', 'origin', '--tags'))*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c44013712483269a09f57a66115f55