### PR TITLE
Add inline actions for suspicious emails

### DIFF
--- a/bot/handlers/report.py
+++ b/bot/handlers/report.py
@@ -1,5 +1,6 @@
 import random
 from utils.email_clean import parse_emails_unified
+from telegram import InlineKeyboardMarkup, InlineKeyboardButton
 
 
 def build_examples(emails: list[str], k: int = 10) -> list[str]:
@@ -29,17 +30,34 @@ async def send_report(update, context, extractor_result) -> None:
         f"Найдено адресов: {len(unique)}",
         f"Уникальных (после очистки): {len(unique)}",
     ]
+    kb = None
     if suspects:
         lines += [
             "",
-            "⚠️ Подозрительные (возможно, «съелась» первая буква): "
-            f"{len(suspects)}",
+            f"⚠️ Подозрительные (возможно, «съелась» первая буква): {len(suspects)}",
             *suspects[:5],
+            "",
+            "Вы можете принять их как есть или вручную исправить.",
         ]
+        kb = InlineKeyboardMarkup(
+            [
+                [
+                    InlineKeyboardButton(
+                        "✅ Принять подозрительные", callback_data="accept_suspects"
+                    ),
+                    InlineKeyboardButton(
+                        "✍️ Исправить адреса", callback_data="edit_suspects"
+                    ),
+                ]
+            ]
+        )
     if examples:
         lines += ["", "🧪 Примеры:", *examples]
 
-    await update.message.reply_text("\n".join(lines))
+    if kb:
+        await update.message.reply_text("\n".join(lines), reply_markup=kb)
+    else:
+        await update.message.reply_text("\n".join(lines))
     context.user_data["emails_suspects"] = suspects
 
 def make_summary_message(

--- a/email_bot.py
+++ b/email_bot.py
@@ -15,6 +15,7 @@ from telegram.ext import (
     ApplicationBuilder,
     CallbackQueryHandler,
     CommandHandler,
+    ConversationHandler,
     MessageHandler,
     filters,
 )
@@ -103,6 +104,30 @@ def main() -> None:
     app.add_handler(CommandHandler("features", bot_handlers.features))
     app.add_handler(CommandHandler("reports", bot_handlers.handle_reports))
     app.add_handler(CommandHandler("reports_debug", bot_handlers.handle_reports_debug))
+
+    # Inline-кнопки для подозрительных адресов
+    app.add_handler(
+        CallbackQueryHandler(bot_handlers.on_accept_suspects, pattern="^accept_suspects$")
+    )
+    app.add_handler(
+        CallbackQueryHandler(bot_handlers.on_edit_suspects, pattern="^edit_suspects$")
+    )
+    app.add_handler(
+        ConversationHandler(
+            entry_points=[],
+            states={
+                bot_handlers.EDIT_SUSPECTS_INPUT: [
+                    MessageHandler(
+                        filters.TEXT & ~filters.COMMAND,
+                        bot_handlers.on_edit_suspects_input,
+                    )
+                ]
+            },
+            fallbacks=[],
+            name="edit_suspects_flow",
+            persistent=False,
+        )
+    )
 
     app.add_handler(
         MessageHandler(filters.TEXT & filters.Regex("^📤"), bot_handlers.prompt_upload)

--- a/tests/test_suspects_flow.py
+++ b/tests/test_suspects_flow.py
@@ -1,0 +1,13 @@
+def test_merge_suspects_into_sendable():
+    user_data = {
+        "emails_for_sending": ["ok1@mail.ru", "ok2@mail.ru"],
+        "emails_suspects": ["alex@mail.ru", "boris@yandex.ru"],
+    }
+    sendable = set(user_data.get("emails_for_sending") or [])
+    for e in user_data.get("emails_suspects") or []:
+        sendable.add(e)
+    user_data["emails_for_sending"] = sorted(sendable)
+    user_data["emails_suspects"] = []
+    assert "alex@mail.ru" in user_data["emails_for_sending"]
+    assert "boris@yandex.ru" in user_data["emails_for_sending"]
+    assert user_data["emails_suspects"] == []


### PR DESCRIPTION
## Summary
- show inline buttons when suspicious email addresses are found
- add handlers to accept or edit suspicious addresses and register them in the bot
- test merging suspects into the send list

## Testing
- `pytest -q`
- `flake8` *(fails: command not found / install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68c565e5694c8326be1e8df2b6f40a24