### PR TITLE
Fix superscript footnote handling in email sanitizer

### DIFF
--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -1,9 +1,9 @@
 import asyncio
+import imaplib
 import logging
 import types
-import imaplib
-import pytest
 
+import pytest
 from telegram import InlineKeyboardMarkup
 
 import emailbot.bot_handlers as bh
@@ -144,8 +144,8 @@ def test_handle_text_manual_emails():
 
     assert ctx.chat_data["manual_all_emails"] == [
         "123@site.com",
+        "1test@site.com",
         "support@support.com",
-        "test@site.com",
         "user@example.com",
     ]
     assert ctx.user_data["awaiting_manual_email"] is False
@@ -266,7 +266,11 @@ async def test_send_manual_email_no_block_mentions(monkeypatch):
 
     monkeypatch.setattr(imaplib, "IMAP4_SSL", lambda *a, **k: DummyImap())
 
-    monkeypatch.setattr(bh.messaging, "create_task_with_logging", lambda coro, _: asyncio.create_task(coro))
+    monkeypatch.setattr(
+        bh.messaging,
+        "create_task_with_logging",
+        lambda coro, _: asyncio.create_task(coro),
+    )
 
     await bh.send_manual_email(update, ctx)
     await asyncio.sleep(0)

--- a/tests/test_dedupe.py
+++ b/tests/test_dedupe.py
@@ -1,14 +1,19 @@
 def test_dedupe_with_footnote_and_clean():
     from utils.email_clean import dedupe_with_variants
-    got = dedupe_with_variants(["55alex@example.com", "alex@example.com"])
+
+    got = dedupe_with_variants(["¹alex@example.com", "alex@example.com"])
     assert got == ["alex@example.com"]
+
 
 def test_dedupe_only_variants_keeps_shortest():
     from utils.email_clean import dedupe_with_variants
-    got = dedupe_with_variants(["123alex@example.com", "9alex@example.com"])
-    assert got == ["9alex@example.com"]
+
+    got = dedupe_with_variants(["¹²³alex@example.com", "⁹alex@example.com"])
+    assert got == ["alex@example.com"]
+
 
 def test_no_cross_domain_collapse():
     from utils.email_clean import dedupe_with_variants
+
     got = dedupe_with_variants(["alex@a.com", "alex@b.com"])
     assert sorted(got) == ["alex@a.com", "alex@b.com"]

--- a/tests/test_email_clean.py
+++ b/tests/test_email_clean.py
@@ -1,9 +1,9 @@
-from utils.email_clean import sanitize_email, dedupe_with_variants, extract_emails
+from utils.email_clean import dedupe_with_variants, extract_emails, sanitize_email
 
 
 def test_footnote_prefix_removed_and_deduped():
     inp = [
-        "55alexandr.pyatnitsin@yandex.ru",
+        "¹alexandr.pyatnitsin@yandex.ru",
         "alexandr.pyatnitsin@yandex.ru",
     ]
     out = dedupe_with_variants(inp)
@@ -11,8 +11,14 @@ def test_footnote_prefix_removed_and_deduped():
 
 
 def test_punct_trim_and_params():
-    assert sanitize_email("(e.kuznetsova@alpfederation.ru)") == "e.kuznetsova@alpfederation.ru"
-    assert sanitize_email('e.rozhkova@alpfederation.ru?subject=Hi') == "e.rozhkova@alpfederation.ru"
+    assert (
+        sanitize_email("(e.kuznetsova@alpfederation.ru)")
+        == "e.kuznetsova@alpfederation.ru"
+    )
+    assert (
+        sanitize_email("e.rozhkova@alpfederation.ru?subject=Hi")
+        == "e.rozhkova@alpfederation.ru"
+    )
 
 
 def test_zero_width_and_nbsp():
@@ -27,8 +33,7 @@ def test_extract_and_clean():
 
 
 def test_no_concatenation_on_newlines():
-    src = ("pavelshabalin@mail.ru\n"
-           "ovalov@gmail.com\n")
+    src = "pavelshabalin@mail.ru\n" "ovalov@gmail.com\n"
     got = extract_emails(src)
     assert "pavelshabalin@mail.ru" in got
     assert "ovalov@gmail.com" in got
@@ -36,7 +41,7 @@ def test_no_concatenation_on_newlines():
 
 
 def test_nbsp_and_zwsp_boundaries():
-    src = "name@mail.ru\u00A0\n\u200bsecond@ya.ru"
+    src = "name@mail.ru\u00a0\n\u200bsecond@ya.ru"
     got = extract_emails(src)
     assert {"name@mail.ru", "second@ya.ru"} <= set(got)
 
@@ -75,7 +80,4 @@ def test_label_length_and_tld_rules():
     assert sanitize_email(f"user@{long_label}.com") == ""
     assert sanitize_email("user@example.c0m") == ""
     assert sanitize_email("user@example." + "a" * 25) == ""
-    assert (
-        sanitize_email("user@example." + "a" * 24)
-        == "user@example." + "a" * 24
-    )
+    assert sanitize_email("user@example." + "a" * 24) == "user@example." + "a" * 24

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,11 +1,10 @@
-import pytest
-
-from utils.email_clean import sanitize_email, dedupe_with_variants
+from utils.email_clean import dedupe_with_variants, sanitize_email
 
 
-def test_strip_leading_footnote_in_local_part():
-    assert sanitize_email("1test@site.com") == "test@site.com"
-    assert sanitize_email("55alex@example.com") == "alex@example.com"
+def test_superscript_footnote_in_local_part():
+    assert sanitize_email("0-ju@mail.ru") == "0-ju@mail.ru"
+    assert sanitize_email("¹alex@mail.ru") == "alex@mail.ru"
+    assert sanitize_email("0-\nju@mail.ru") == "0-ju@mail.ru"
 
 
 def test_trim_local_part_edges():
@@ -14,10 +13,10 @@ def test_trim_local_part_edges():
 
 
 def test_dedupe_with_variants_prefers_clean():
-    got = dedupe_with_variants(["55alex@example.com", "alex@example.com"])
+    got = dedupe_with_variants(["¹alex@example.com", "alex@example.com"])
     assert got == ["alex@example.com"]
 
 
 def test_dedupe_only_variants_keeps_shortest():
-    got = dedupe_with_variants(["123alex@example.com", "9alex@example.com"])
-    assert got == ["9alex@example.com"]
+    got = dedupe_with_variants(["¹²³alex@example.com", "⁹alex@example.com"])
+    assert got == ["alex@example.com"]


### PR DESCRIPTION
## Summary
- avoid trimming valid local-part characters by only stripping superscript footnotes
- clean superscript and circled numeric footnotes during normalization
- update dedupe logic and tests for new behavior

## Testing
- `pre-commit run --config .pre-commit-config.local.yaml --files utils/email_clean.py tests/test_sanitize.py tests/test_dedupe.py tests/test_email_clean.py tests/test_bot_handlers.py` *(fails: isort modified files)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c688c8f6c48326ad58b76f2fc7ec97