### PR TITLE
Add bounce tracking and service headers

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -175,6 +175,11 @@ def main() -> None:
     )
     app.add_handler(
         MessageHandler(
+            filters.TEXT & filters.Regex("^🔁"), bot_handlers.sync_bounces_command
+        )
+    )
+    app.add_handler(
+        MessageHandler(
             filters.TEXT & filters.Regex("^🚀"), bot_handlers.force_send_command
         )
     )

--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -36,6 +36,7 @@ from utils.email_clean import (
 )
 from utils.send_stats import summarize_today, summarize_week, current_tz_label
 from utils.send_stats import _stats_path  # только для отображения пути
+from utils.bounce import sync_bounces
 
 STATS_PATH = str(_stats_path())
 
@@ -561,6 +562,7 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         ["🚫 Добавить в исключения", "🧾 О боте"],
         ["🧭 Сменить группу", "📈 Отчёты"],
         ["🔄 Синхронизировать с сервером", "🚀 Игнорировать лимит"],
+        ["🔁 Синхронизировать бонсы"],
     ]
     markup = ReplyKeyboardMarkup(keyboard, resize_keyboard=True)
     await update.message.reply_text("Можно загрузить данные", reply_markup=markup)
@@ -918,6 +920,18 @@ async def sync_imap_command(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         )
     except Exception as e:
         await update.message.reply_text(f"❌ Ошибка синхронизации: {e}")
+
+
+async def sync_bounces_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Check INBOX for bounce messages and log them."""
+    await update.message.reply_text("⏳ Проверяю INBOX на бонсы...")
+    try:
+        n = sync_bounces()
+        await update.message.reply_text(
+            f"✅ Найдено и добавлено в отчёты: {n} bounce-сообщений."
+        )
+    except Exception as e:  # pragma: no cover - best effort
+        await update.message.reply_text(f"❌ Ошибка при синхронизации бонсов: {e}")
 
 
 async def retry_last_command(
@@ -2051,6 +2065,7 @@ __all__ = [
     "report_command",
     "report_callback",
     "sync_imap_command",
+    "sync_bounces_command",
     "reset_email_list",
     "diag",
     "dedupe_log_command",

--- a/tests/test_email_clean_and_stats.py
+++ b/tests/test_email_clean_and_stats.py
@@ -47,6 +47,8 @@ def test_send_stats_success_and_error(tmp_path, monkeypatch):
     send_stats.log_success("ok@example.com", "sport")
     # Логируем ошибку
     send_stats.log_error("fail@example.com", "sport", "550 user not found")
+    # Логируем bounce
+    send_stats.log_bounce("bounce@example.com", "user unknown", uuid="u1", message_id="m1")
 
     data = [json.loads(line) for line in stats_path.read_text().splitlines()]
     emails = {d["email"]: d for d in data}
@@ -55,9 +57,11 @@ def test_send_stats_success_and_error(tmp_path, monkeypatch):
     assert emails["ok@example.com"]["status"] == "success"
     assert "fail@example.com" in emails
     assert emails["fail@example.com"]["status"] == "error"
+    assert "bounce@example.com" in emails
+    assert emails["bounce@example.com"]["status"] == "bounce"
 
     # Проверим агрегатор
     summary = send_stats.summarize_today()
     assert summary["success"] >= 1
-    assert summary["error"] >= 1
+    assert summary["error"] >= 2
 

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -118,7 +118,7 @@ def test_build_message_adds_signature_and_unsubscribe(tmp_path, monkeypatch):
     monkeypatch.setattr(messaging, "EMAIL_ADDRESS", "sender@example.com")
     token_host = "example.com"
     monkeypatch.setenv("HOST", token_host)
-    msg, token = messaging.build_message(
+    msg, token, _ = messaging.build_message(
         "recipient@example.com", str(html_file), "Subject"
     )
     assert token
@@ -147,7 +147,7 @@ def test_build_message_logo_toggle(tmp_path, monkeypatch):
     monkeypatch.setattr(messaging, "EMAIL_ADDRESS", "sender@example.com")
 
     monkeypatch.setenv("INLINE_LOGO", "1")
-    msg, _ = messaging.build_message(
+    msg, _, _ = messaging.build_message(
         "r@example.com", str(html_file), "Subj"
     )
     html = msg.get_body("html").get_content()
@@ -155,7 +155,7 @@ def test_build_message_logo_toggle(tmp_path, monkeypatch):
     assert html.count("<img") == 1
 
     monkeypatch.setenv("INLINE_LOGO", "0")
-    msg2, _ = messaging.build_message(
+    msg2, _, _ = messaging.build_message(
         "r@example.com", str(html_file), "Subj"
     )
     html2 = msg2.get_body("html").get_content()
@@ -172,13 +172,13 @@ def test_repository_templates_logo_toggle(monkeypatch, tmp_path):
     monkeypatch.setattr(messaging, "EMAIL_ADDRESS", "sender@example.com")
 
     monkeypatch.setenv("INLINE_LOGO", "1")
-    msg, _ = messaging.build_message("u@example.com", str(template_path), "Subj")
+    msg, _, _ = messaging.build_message("u@example.com", str(template_path), "Subj")
     html = msg.get_body("html").get_content()
     assert html.count("cid:logo") == 1
     assert html.count("<img") == 1
 
     monkeypatch.setenv("INLINE_LOGO", "0")
-    msg2, _ = messaging.build_message("u@example.com", str(template_path), "Subj")
+    msg2, _, _ = messaging.build_message("u@example.com", str(template_path), "Subj")
     html2 = msg2.get_body("html").get_content()
     assert "cid:logo" not in html2
     assert "<img" not in html2

--- a/tests/test_messaging_signature.py
+++ b/tests/test_messaging_signature.py
@@ -18,7 +18,7 @@ def test_logo_inline_and_signature_styles(tmp_path, monkeypatch):
     monkeypatch.setattr(messaging, "EMAIL_ADDRESS", "sender@example.com")
 
     monkeypatch.setenv("INLINE_LOGO", "1")
-    msg, _ = messaging.build_message("r@example.com", str(html_file), "Subj")
+    msg, _, _ = messaging.build_message("r@example.com", str(html_file), "Subj")
     container = msg.get_payload()[-1]
     content = container.get_payload()[0].get_content()
     assert content.count("cid:logo") == 1
@@ -39,7 +39,7 @@ def test_logo_inline_and_signature_styles(tmp_path, monkeypatch):
     assert "cid:logo" not in signature_block and "<img" not in signature_block
 
     monkeypatch.setenv("INLINE_LOGO", "0")
-    msg2, _ = messaging.build_message("r@example.com", str(html_file), "Subj")
+    msg2, _, _ = messaging.build_message("r@example.com", str(html_file), "Subj")
     html_part2 = msg2.get_body("html")
     content2 = html_part2.get_content()
     assert "cid:logo" not in content2

--- a/utils/bounce.py
+++ b/utils/bounce.py
@@ -1,0 +1,96 @@
+import os, re, ssl, socket, imaplib, email
+from datetime import datetime, timedelta, timezone
+from .send_stats import log_bounce
+
+BOUNCE_SINCE_DAYS = int(os.getenv("BOUNCE_SINCE_DAYS","7"))
+INBOX_MAILBOX = os.getenv("INBOX_MAILBOX","INBOX")
+IMAP_HOST = os.getenv("IMAP_HOST")
+IMAP_PORT = int(os.getenv("IMAP_PORT","993"))
+EMAIL_ADDRESS = os.getenv("EMAIL_ADDRESS")
+EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD")
+IMAP_TIMEOUT = int(os.getenv("IMAP_TIMEOUT","15"))
+IMAP_RETRIES = int(os.getenv("IMAP_RETRIES","3"))
+PREFER_IPV4 = os.getenv("IMAP_IPV4_ONLY","0") == "1"
+
+BOUNCE_FROM = re.compile(r"(mailer-daemon|postmaster)@", re.I)
+
+def _imap_connect():
+    addrinfos = socket.getaddrinfo(IMAP_HOST, IMAP_PORT, 0, socket.SOCK_STREAM)
+    if PREFER_IPV4:
+        addrinfos = [ai for ai in addrinfos if ai[0] == socket.AF_INET] or addrinfos
+    last = None
+    for family, socktype, proto, canonname, sockaddr in addrinfos:
+        try:
+            s = socket.socket(family, socktype, proto)
+            s.settimeout(IMAP_TIMEOUT)
+            s.connect(sockaddr)
+            ctx = ssl.create_default_context()
+            return imaplib.IMAP4_SSL(host=None, port=None, ssl_context=ctx, sock=s)
+        except Exception as e:
+            last = e
+            continue
+    raise last or OSError("IMAP connect failed")
+
+def sync_bounces():
+    """Сканирует INBOX, находит bounce, логирует их в send_stats как status='bounce'."""
+    # Подключение с ретраями
+    attempt = 0
+    while True:
+        try:
+            imap = _imap_connect()
+            imap.login(EMAIL_ADDRESS, EMAIL_PASSWORD)
+            break
+        except Exception as e:
+            attempt += 1
+            if attempt >= IMAP_RETRIES:
+                raise
+    imap.select(INBOX_MAILBOX)
+
+    since = (datetime.now(timezone.utc) - timedelta(days=BOUNCE_SINCE_DAYS)).strftime("%d-%b-%Y")
+    typ, data = imap.search(None, 'SINCE', since)
+    if typ != "OK":
+        imap.logout()
+        return 0
+
+    count = 0
+    uids = data[0].split() if data and data[0] else []
+    for uid in uids:
+        typ, msgd = imap.fetch(uid, '(RFC822)')
+        if typ != "OK" or not msgd:
+            continue
+        m = email.message_from_bytes(msgd[0][1])
+        if not BOUNCE_FROM.search(m.get('From','')):
+            continue
+
+        # Ищем вложенный оригинал
+        orig = None
+        for part in m.walk():
+            ctype = part.get_content_type()
+            if ctype == 'message/rfc822':
+                try:
+                    payload = part.get_payload(decode=True)
+                    if payload:
+                        orig = email.message_from_bytes(payload)
+                        break
+                except Exception:
+                    pass
+
+        if not orig:
+            # fallback: иногда поле Diagnostic-Code в тексте даёт получателя
+            rcpt = m.get('Final-Recipient','') or m.get('Original-Recipient','')
+            if rcpt:
+                rcpt = rcpt.split(';')[-1].strip()
+                log_bounce(rcpt, m.get('Subject','(bounce)'))
+                count += 1
+            continue
+
+        uuid = orig.get('X-EBOT-UUID','')
+        rcpt = orig.get('X-EBOT-Recipient','') or orig.get('To','')
+        mid  = orig.get('Message-ID','')
+        reason = m.get('Subject','(bounce)')
+        if rcpt:
+            log_bounce(rcpt, reason, uuid=uuid, message_id=mid)
+            count += 1
+
+    imap.logout()
+    return count


### PR DESCRIPTION
## Summary
- add X-EBOT headers and UUID tracking in messages and logs
- record bounce events in stats and expose sync command in bot
- implement bounce parser for IMAP INBOX

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c80f0305788326b178062e98da02b6