### PR TITLE
feat: drop trimmed email duplicates

### DIFF
--- a/bot/handlers/report.py
+++ b/bot/handlers/report.py
@@ -1,5 +1,5 @@
 import random
-from utils.email_clean import parse_emails_unified
+from utils.email_clean import parse_emails_unified, drop_leading_char_twins
 from telegram import InlineKeyboardMarkup, InlineKeyboardButton
 
 
@@ -21,6 +21,7 @@ async def send_report(update, context, extractor_result) -> None:
     cleaned, meta = parse_emails_unified(
         extractor_result.raw_text or " ", return_meta=True
     )
+    cleaned = drop_leading_char_twins(cleaned)
     unique = sorted(set(cleaned))
     suspects = sorted(set(meta.get("suspects", [])))
     examples = build_examples(unique)

--- a/tests/test_email_clean_and_stats.py
+++ b/tests/test_email_clean_and_stats.py
@@ -4,7 +4,11 @@ from pathlib import Path
 
 import pytest
 
-from utils.email_clean import sanitize_email, parse_emails_unified
+from utils.email_clean import (
+    sanitize_email,
+    parse_emails_unified,
+    drop_leading_char_twins,
+)
 from utils import send_stats
 
 
@@ -64,4 +68,21 @@ def test_send_stats_success_and_error(tmp_path, monkeypatch):
     summary = send_stats.summarize_today()
     assert summary["success"] >= 1
     assert summary["error"] >= 2
+
+
+def test_drop_leading_char_twins():
+    src = [
+        "bezuglovan@gmail.com",
+        "ezuglovan@gmail.com",
+        "bezrukov@irigs.irk.ru",
+        "ezrukov@irigs.irk.ru",
+        "ankalaeva@yandex.ru",
+        "nkalaeva@yandex.ru",
+        "solo@example.com",
+    ]
+    out = drop_leading_char_twins(src)
+    assert "bezuglovan@gmail.com" in out and "ezuglovan@gmail.com" not in out
+    assert "bezrukov@irigs.irk.ru" in out and "ezrukov@irigs.irk.ru" not in out
+    assert "ankalaeva@yandex.ru" in out and "nkalaeva@yandex.ru" not in out
+    assert "solo@example.com" in out
 


### PR DESCRIPTION
## Summary
- add drop_leading_char_twins to remove addresses where local part loses first char
- integrate filter into email extraction and manual input workflows
- cover leading-char twin removal with unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c828b5b4888326b03edb903e2b2fb8