### PR TITLE
Implement robust SMTP client with auto reconnect

### DIFF
--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -200,14 +200,11 @@ def test_send_manual_email_uses_html_template(monkeypatch):
         def logout(self):
             return
 
-    class DummyClient:
-        def __enter__(self):
-            return self
+    class DummySMTP:
+        def close(self):
+            return None
 
-        def __exit__(self, *a):
-            return False
-
-    monkeypatch.setattr(bh, "SmtpClient", lambda *a, **k: DummyClient())
+    monkeypatch.setattr(bh, "RobustSMTP", lambda *a, **k: DummySMTP())
     monkeypatch.setattr(
         bh, "imaplib", types.SimpleNamespace(IMAP4_SSL=lambda *a, **k: DummyImap())
     )

--- a/tests/test_send_reports_integration.py
+++ b/tests/test_send_reports_integration.py
@@ -11,14 +11,14 @@ class _FakeSMTP:
     def __init__(self, *a, **k):
         pass
 
-    def __enter__(self):
-        return self
+    def send(self, msg):
+        return None
 
-    def __exit__(self, *a):
-        return False
+    def ensure(self):
+        return None
 
-    def send(self, from_addr, to_addr, raw):
-        return
+    def close(self):
+        return None
 
 
 @pytest.fixture(autouse=True)
@@ -28,7 +28,10 @@ def _env_tmp_stats(tmp_path, monkeypatch):
     # подменяем SMTP-клиент на фейковый
     import emailbot.messaging as m
     fake = _FakeSMTP
-    monkeypatch.setattr(m, "SmtpClient", fake, raising=True)
+    monkeypatch.setattr(m, "RobustSMTP", lambda *a, **k: fake(), raising=True)
+    monkeypatch.setattr(
+        m, "send_with_retry", lambda smtp, msg, retries=3, backoff=1.0: smtp.send(msg)
+    )
     yield
 
 

--- a/utils/smtp_client.py
+++ b/utils/smtp_client.py
@@ -1,0 +1,101 @@
+import logging
+import os
+import smtplib
+import time
+from email.message import EmailMessage
+from typing import Optional
+
+
+logger = logging.getLogger(__name__)
+
+
+class RobustSMTP:
+    """SMTP клиент с автоматическим переподключением."""
+
+    def __init__(self) -> None:
+        self.host = os.getenv("SMTP_HOST", "smtp.mail.ru")
+        try:
+            self.port = int(os.getenv("SMTP_PORT", "465"))
+        except Exception:
+            self.port = 465
+        self.ssl = os.getenv("SMTP_SSL", "1") == "1"
+        try:
+            self.timeout = int(os.getenv("SMTP_TIMEOUT", "45"))
+        except Exception:
+            self.timeout = 45
+        self.user = os.getenv("EMAIL_ADDRESS")
+        self.pwd = os.getenv("EMAIL_PASSWORD")
+        self._smtp: Optional[smtplib.SMTP] = None
+        self._logged_config = False
+
+    def _log_config(self) -> None:
+        if not self._logged_config:
+            logger.info(
+                "SMTP connect config host=%s port=%s ssl=%s timeout=%s",
+                self.host,
+                self.port,
+                self.ssl,
+                self.timeout,
+            )
+            self._logged_config = True
+
+    def connect(self) -> None:
+        self._log_config()
+        if self.ssl:
+            smtp: smtplib.SMTP = smtplib.SMTP_SSL(
+                self.host, self.port, timeout=self.timeout
+            )
+            smtp.ehlo()
+        else:
+            smtp = smtplib.SMTP(self.host, self.port, timeout=self.timeout)
+            smtp.ehlo()
+            smtp.starttls()
+            smtp.ehlo()
+        smtp.login(self.user, self.pwd)
+        self._smtp = smtp
+
+    def ensure(self) -> None:
+        try:
+            if self._smtp is None:
+                self.connect()
+            else:
+                self._smtp.noop()
+        except Exception:
+            try:
+                self.close()
+            except Exception:
+                pass
+            self.connect()
+
+    def send(self, msg: EmailMessage):
+        self.ensure()
+        assert self._smtp is not None
+        return self._smtp.send_message(msg)
+
+    def close(self) -> None:
+        if self._smtp is not None:
+            try:
+                self._smtp.quit()
+            finally:
+                self._smtp = None
+
+
+def send_with_retry(
+    smtp: RobustSMTP, msg: EmailMessage, retries: int = 3, backoff: float = 1.0
+):
+    for attempt in range(retries):
+        try:
+            return smtp.send(msg)
+        except (
+            smtplib.SMTPServerDisconnected,
+            smtplib.SMTPConnectError,
+            TimeoutError,
+        ):
+            if attempt == retries - 1:
+                raise
+            time.sleep(backoff)
+            backoff *= 2
+            smtp.ensure()
+
+
+__all__ = ["RobustSMTP", "send_with_retry"]


### PR DESCRIPTION
## Summary
- add a robust SMTP helper that reconnects automatically and retries transient network failures
- refactor message sending to use the new helper and normalize logged error reasons
- update handlers and tests to work with the resilient SMTP workflow

## Testing
- pytest tests/test_messaging.py tests/test_bot_handlers.py tests/test_send_reports_integration.py tests/test_smtp_client_env.py

------
https://chatgpt.com/codex/tasks/task_e_68c92781c060832681610b0f3493d8cb