### PR TITLE
Add confusable normalization and deobfuscation pipeline

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,19 @@
+import os
+
+__all__ = ["CONFUSABLES_NORMALIZE", "OBFUSCATION_ENABLE", "get_bool"]
+
+
+def get_bool(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    value = value.strip().lower()
+    if value in {"1", "true", "yes", "on"}:
+        return True
+    if value in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+CONFUSABLES_NORMALIZE = get_bool("CONFUSABLES_NORMALIZE", False)
+OBFUSCATION_ENABLE = get_bool("OBFUSCATION_ENABLE", False)

--- a/pipelines/extract_emails.py
+++ b/pipelines/extract_emails.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+from utils.email_clean import dedupe_with_variants, parse_emails_unified
+
+
+def extract_emails_pipeline(text: str) -> Tuple[List[str], Dict[str, int]]:
+    """High-level pipeline that applies deobfuscation, normalization and dedupe."""
+
+    cleaned, meta = parse_emails_unified(text or "", return_meta=True)
+    unique = dedupe_with_variants(cleaned)
+
+    items = meta.get("items", [])
+    deobf_count = meta.get("deobfuscated_count", 0)
+    conf_count = meta.get("confusables_fixed", 0)
+    dropped = sum(1 for item in items if not item.get("sanitized"))
+
+    stats = {
+        "found_raw": len(items),
+        "after_deobfuscation": deobf_count,
+        "normalized_confusables": conf_count,
+        "final_unique": len(unique),
+        "dropped": dropped,
+        "deobfuscated_count": deobf_count,
+        "confusables_fixed": conf_count,
+    }
+
+    return unique, stats
+
+
+__all__ = ["extract_emails_pipeline"]

--- a/pipelines/ingest.py
+++ b/pipelines/ingest.py
@@ -2,7 +2,7 @@ from utils.email_clean import sanitize_email, dedupe_with_variants, _strip_leadi
 
 
 def ingest(all_extracted_emails: list[str]) -> tuple[list[str], str]:
-    cleaned = [sanitize_email(e) for e in all_extracted_emails]
+    cleaned = [sanitize_email(e)[0] for e in all_extracted_emails]
     rejected_non_ascii = sum(1 for e in cleaned if not e)
     cleaned = [e for e in cleaned if e]  # убираем невалидные
     emails = dedupe_with_variants(cleaned)

--- a/tests/test_deobfuscate.py
+++ b/tests/test_deobfuscate.py
@@ -1,6 +1,19 @@
 from utils.email_clean import extract_emails, dedupe_with_variants
 
 
+import pytest
+
+import config
+import utils.email_clean as email_clean
+from utils.email_clean import dedupe_with_variants, extract_emails
+
+
+@pytest.fixture(autouse=True)
+def enable_obfuscation(monkeypatch):
+    monkeypatch.setattr(config, "OBFUSCATION_ENABLE", True, raising=False)
+    monkeypatch.setattr(email_clean, "OBFUSCATION_ENABLE", True, raising=False)
+
+
 def test_english_obfuscation():
     src = "Write me: ivan.petrov [at] gmail [dot] com"
     assert extract_emails(src) == ["ivan.petrov@gmail.com"]

--- a/tests/test_email_clean.py
+++ b/tests/test_email_clean.py
@@ -1,11 +1,17 @@
 import pytest
 
+import config
+import utils.email_clean as email_clean
 from utils.email_clean import (
     dedupe_with_variants,
     extract_emails,
     parse_emails_unified,
-    sanitize_email,
+    sanitize_email as _sanitize_email,
 )
+
+
+def sanitize_email(value: str, strip_footnote: bool = True) -> str:
+    return _sanitize_email(value, strip_footnote)[0]
 
 
 @pytest.mark.parametrize(
@@ -92,7 +98,9 @@ def test_question_mark_anchor_trimming():
     assert not any("param=" in x for x in got)
 
 
-def test_deobfuscation_variants():
+def test_deobfuscation_variants(monkeypatch):
+    monkeypatch.setattr(config, "OBFUSCATION_ENABLE", True, raising=False)
+    monkeypatch.setattr(email_clean, "OBFUSCATION_ENABLE", True, raising=False)
     src = "user [at] site [dot] ru и user собака site точка ru"
     got = extract_emails(src)
     assert {"user@site.ru"} == set(got)

--- a/tests/test_email_clean_and_stats.py
+++ b/tests/test_email_clean_and_stats.py
@@ -5,11 +5,15 @@ from pathlib import Path
 import pytest
 
 from utils.email_clean import (
-    sanitize_email,
+    sanitize_email as _sanitize_email,
     parse_emails_unified,
     drop_leading_char_twins,
 )
 from utils import send_stats
+
+
+def sanitize_email(value: str, strip_footnote: bool = True) -> str:
+    return _sanitize_email(value, strip_footnote)[0]
 
 
 def test_leading_letters_and_digits_preserved():

--- a/tests/test_email_clean_digits.py
+++ b/tests/test_email_clean_digits.py
@@ -1,8 +1,12 @@
 import os
 import pytest
 
-from utils.email_clean import sanitize_email
+from utils.email_clean import sanitize_email as _sanitize_email
 from utils.email_clean import parse_emails_unified  # если другой путь — поправить импорт
+
+
+def sanitize_email(value: str, strip_footnote: bool = True) -> str:
+    return _sanitize_email(value, strip_footnote)[0]
 
 
 def test_sanitize_email_keeps_leading_digit_and_dash():

--- a/tests/test_email_confusables.py
+++ b/tests/test_email_confusables.py
@@ -1,0 +1,51 @@
+import importlib
+
+import pytest
+
+import config
+import utils.email_clean as email_clean
+
+
+@pytest.fixture(autouse=True)
+def reset_flags(monkeypatch):
+    monkeypatch.setattr(config, "CONFUSABLES_NORMALIZE", True, raising=False)
+    monkeypatch.setattr(email_clean, "CONFUSABLES_NORMALIZE", True, raising=False)
+
+
+def test_confusable_domain_label(monkeypatch):
+    emails, meta = email_clean.parse_emails_unified(
+        "ivan.petrov@maiл.ru", return_meta=True
+    )
+    assert emails == ["ivan.petrov@mail.ru"]
+    assert meta["items"][0]["reason"] == "confusables-normalized"
+
+
+def test_confusable_local_letters(monkeypatch):
+    emails, meta = email_clean.parse_emails_unified(
+        "mariа-smith@yаndex.ru", return_meta=True
+    )
+    assert emails == ["maria-smith@yandex.ru"]
+    assert meta["items"][0]["reason"] == "confusables-normalized"
+
+
+def test_punycode_domain_not_changed(monkeypatch):
+    local, domain, changed = email_clean.normalize_confusables("sergey", "xn--80asehdb")
+    assert (local, domain, changed) == ("sergey", "xn--80asehdb", False)
+
+
+def test_confusable_fallback_on_idna_failure(monkeypatch):
+    original = email_clean.normalize_domain
+
+    def fake_normalize(domain: str):
+        if domain == "mail.ru":
+            return "", "invalid-idna"
+        return original(domain)
+
+    monkeypatch.setattr(email_clean, "normalize_domain", fake_normalize)
+
+    emails, meta = email_clean.parse_emails_unified(
+        "ivan.petrov@maiл.ru", return_meta=True
+    )
+    assert emails == ["ivan.petrov@xn--mai-ied.ru"]
+    assert meta["items"][0]["reverted"] is True
+    assert meta["items"][0]["reason"] is None

--- a/tests/test_email_deobfuscate.py
+++ b/tests/test_email_deobfuscate.py
@@ -1,0 +1,24 @@
+from utils.email_deobfuscate import deobfuscate_text
+
+
+def test_russian_markers():
+    text = "ivan (собака) yandex (точка) ru"
+    result = deobfuscate_text(text)
+    assert result == "ivan@yandex.ru"
+    assert set(deobfuscate_text.last_rules) == {"at", "dot"}
+
+
+def test_bracketed_markers():
+    text = "support [at] uni [dot] edu"
+    result = deobfuscate_text(text)
+    assert result == "support@uni.edu"
+
+
+def test_word_without_context():
+    text = "Напишите на собака"
+    assert deobfuscate_text(text) == text
+
+
+def test_inline_markers():
+    text = "name(at)domain(dot)com"
+    assert deobfuscate_text(text) == "name@domain.com"

--- a/tests/test_idna.py
+++ b/tests/test_idna.py
@@ -1,11 +1,29 @@
 import unicodedata
 
-from utils.email_clean import sanitize_email
+from utils.email_clean import sanitize_email as _sanitize_email
 
 
 def test_unicode_domain_punycode_local_nfc():
     # регресс: домен должен кодироваться как IDNA без подмен букв
-    raw = "test@тест.рф"
-    got = sanitize_email(raw)
+    got, reason = _sanitize_email("test@тест.рф")
+    assert reason is None
     assert got == "test@xn--e1aybc.xn--p1ai"
     assert unicodedata.is_normalized("NFC", got.split("@", 1)[0])
+
+
+def test_cyrillic_domain_to_punycode():
+    got, reason = _sanitize_email("login@почта.рф")
+    assert reason is None
+    assert got == "login@xn--80a1acny.xn--p1ai"
+
+
+def test_mixed_domain_idna():
+    got, reason = _sanitize_email("user@пример.com")
+    assert reason is None
+    assert got == "user@xn--e1afmkfd.com"
+
+
+def test_idna_failure_returns_reason():
+    got, reason = _sanitize_email("user@пример-.com")
+    assert got == ""
+    assert reason == "invalid-idna"

--- a/tests/test_parsing_edges.py
+++ b/tests/test_parsing_edges.py
@@ -1,4 +1,8 @@
-from utils.email_clean import parse_emails_unified, sanitize_email
+from utils.email_clean import parse_emails_unified, sanitize_email as _sanitize_email
+
+
+def sanitize_email(value: str, strip_footnote: bool = True) -> str:
+    return _sanitize_email(value, strip_footnote)[0]
 
 def test_trailing_glue_after_tld_is_cut():
     s = "omgma-obschim@mail.ruSysoev"

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -1,4 +1,8 @@
-from utils.email_clean import dedupe_with_variants, sanitize_email
+from utils.email_clean import dedupe_with_variants, sanitize_email as _sanitize_email
+
+
+def sanitize_email(value: str, strip_footnote: bool = True) -> str:
+    return _sanitize_email(value, strip_footnote)[0]
 
 
 def test_strip_leading_superscript_footnote_only():

--- a/tests/test_unicode_local_rejected.py
+++ b/tests/test_unicode_local_rejected.py
@@ -1,4 +1,8 @@
-from utils.email_clean import sanitize_email
+from utils.email_clean import sanitize_email as _sanitize_email
+
+
+def sanitize_email(value: str, strip_footnote: bool = True) -> str:
+    return _sanitize_email(value, strip_footnote)[0]
 
 
 def test_mixed_script_local_is_rejected():

--- a/tests/test_unified_parser.py
+++ b/tests/test_unified_parser.py
@@ -1,6 +1,16 @@
 import pytest
 
+import pytest
+
+import config
+import utils.email_clean as email_clean
 from utils.email_clean import dedupe_keep_original, parse_emails_unified
+
+
+@pytest.fixture(autouse=True)
+def enable_obfuscation(monkeypatch):
+    monkeypatch.setattr(config, "OBFUSCATION_ENABLE", True, raising=False)
+    monkeypatch.setattr(email_clean, "OBFUSCATION_ENABLE", True, raising=False)
 
 
 def test_simple_space_delimited():

--- a/utils/email_deobfuscate.py
+++ b/utils/email_deobfuscate.py
@@ -1,0 +1,71 @@
+import re
+
+__all__ = ["deobfuscate_text"]
+
+_LOCAL_FRAGMENT = r"[A-Za-z0-9._%+-]{1,64}"
+_DOMAIN_LABEL = r"[A-Za-z0-9-]{1,63}"
+_DOMAIN_FRAGMENT = rf"(?:{_DOMAIN_LABEL}\.)+[A-Za-z]{{2,24}}"
+_LETTER_CLASS = "A-Za-zА-Яа-яЁё"
+_GAP = rf"(?:[^{_LETTER_CLASS}])?"
+
+
+def _spaced(word: str) -> str:
+    if not word:
+        return ""
+    parts = [re.escape(word[0])]
+    for ch in word[1:]:
+        parts.append(_GAP)
+        parts.append(re.escape(ch))
+    return "".join(parts)
+
+
+_AT_WORD = rf"(?:{_spaced('at')}|{_spaced('собака')})"
+_DOT_WORD = rf"(?:{_spaced('dot')}|{_spaced('точка')})"
+_AT_WRAPPED = rf"[\(\[\{{]?\s*{_AT_WORD}\s*[\)\]\}}]?"
+_DOT_WRAPPED = rf"[\(\[\{{]?\s*{_DOT_WORD}\s*[\)\]\}}]?"
+
+_DOT_PATTERN = re.compile(
+    rf"(?<![A-Za-z0-9-])(?P<left>{_DOMAIN_LABEL})\s*{_DOT_WRAPPED}\s*(?P<right>{_DOMAIN_LABEL})(?![A-Za-z0-9-])",
+    re.IGNORECASE,
+)
+
+_AT_PATTERN = re.compile(
+    rf"(?<![A-Za-z0-9._%+-])(?P<local>{_LOCAL_FRAGMENT})\s*{_AT_WRAPPED}\s*(?P<domain>{_DOMAIN_FRAGMENT})(?![A-Za-z0-9-])",
+    re.IGNORECASE,
+)
+
+
+def deobfuscate_text(text: str) -> str:
+    """Return text with simple e-mail obfuscations normalised."""
+
+    if not text:
+        deobfuscate_text.last_rules = []
+        return text
+
+    rules: set[str] = set()
+    current = text
+
+    def _dot_repl(match: re.Match) -> str:
+        rules.add("dot")
+        return f"{match.group('left')}.{match.group('right')}"
+
+    def _at_repl(match: re.Match) -> str:
+        rules.add("at")
+        return f"{match.group('local')}@{match.group('domain')}"
+
+    while True:
+        current, count = _DOT_PATTERN.subn(_dot_repl, current)
+        if count == 0:
+            break
+
+    current, _ = _AT_PATTERN.subn(_at_repl, current)
+
+    deobfuscate_text.last_rules = sorted(rules)
+    return current
+
+
+# Attach default attribute for introspection
+try:
+    deobfuscate_text.last_rules = []  # type: ignore[attr-defined]
+except Exception:
+    pass


### PR DESCRIPTION
## Summary
- add configuration flags for obfuscation and confusable normalization and expose the new high-level extraction pipeline
- normalize confusable Cyrillic glyphs, perform strict IDNA validation, and return reasons from email sanitization with enhanced metadata
- implement robust text deobfuscation helpers and expand the test suite with confusable, deobfuscation, and IDNA cases

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c940286be4832689c57210a28db393