### PR TITLE
Enhance deobfuscation and Unicode email normalization

### DIFF
--- a/tests/test_confusables.py
+++ b/tests/test_confusables.py
@@ -1,0 +1,17 @@
+import pytest
+
+import config
+import utils.email_clean as email_clean
+from pipelines.extract_emails import run_pipeline_on_text
+
+
+@pytest.fixture(autouse=True)
+def enable_confusables(monkeypatch):
+    monkeypatch.setattr(config, "CONFUSABLES_NORMALIZE", True, raising=False)
+    monkeypatch.setattr(email_clean, "CONFUSABLES_NORMALIZE", True, raising=False)
+
+
+def test_cyrillic_lookalikes_fixed():
+    raw = "mail: mariа-smith@yаndex.ru"
+    final, _ = run_pipeline_on_text(raw)
+    assert "maria-smith@yandex.ru" in final

--- a/tests/test_dirty_fragments.py
+++ b/tests/test_dirty_fragments.py
@@ -1,13 +1,26 @@
 import pytest
 
+import config
+import utils.email_clean as email_clean
 from pipelines.extract_emails import run_pipeline_on_text
 
 
-@pytest.mark.parametrize("raw,expected", [
-    ("RCPT TO:<russiavera.kidyaeva@yandex.ru>:", ["russiavera.kidyaeva@yandex.ru"]),
-    ("... tsibulnikova2011@yandex.ru> 550 5.7.1 ...", ["tsibulnikova2011@yandex.ru"]),
-    ("(a) anton-belousov0@rambler.ru", ["anton-belousov0@rambler.ru"]),
-])
+@pytest.fixture(autouse=True)
+def enable_obfuscation(monkeypatch):
+    monkeypatch.setattr(config, "OBFUSCATION_ENABLE", True, raising=False)
+    monkeypatch.setattr(email_clean, "OBFUSCATION_ENABLE", True, raising=False)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("(a) anton-belousov0@rambler.ru", ["anton-belousov0@rambler.ru"]),
+        ("RCPT TO:<russiavera.kidyaeva@yandex.ru>:", ["russiavera.kidyaeva@yandex.ru"]),
+        ("... tsibulnikova2011@yandex.ru> 550 5.7.1 ...", ["tsibulnikova2011@yandex.ru"]),
+        ("словоanton-belousov0@rambler.ru", ["anton-belousov0@rambler.ru"]),
+        ("name(at)domain(dot)com", ["name@domain.com"]),
+    ],
+)
 def test_trim_and_footnotes(raw, expected):
     final, dropped = run_pipeline_on_text(raw)
     assert sorted(final) == sorted(expected)

--- a/tests/test_email_deobfuscate.py
+++ b/tests/test_email_deobfuscate.py
@@ -1,24 +1,29 @@
-from utils.email_deobfuscate import deobfuscate_text
+import pytest
+
+import config
+import utils.email_clean as email_clean
+from pipelines.extract_emails import run_pipeline_on_text
 
 
-def test_russian_markers():
-    text = "ivan (собака) yandex (точка) ru"
-    result = deobfuscate_text(text)
-    assert result == "ivan@yandex.ru"
-    assert set(deobfuscate_text.last_rules) == {"at", "dot"}
+@pytest.fixture(autouse=True)
+def enable_obfuscation(monkeypatch):
+    monkeypatch.setattr(config, "OBFUSCATION_ENABLE", True, raising=False)
+    monkeypatch.setattr(email_clean, "OBFUSCATION_ENABLE", True, raising=False)
 
 
-def test_bracketed_markers():
-    text = "support [at] uni [dot] edu"
-    result = deobfuscate_text(text)
-    assert result == "support@uni.edu"
+def test_obfuscated_russian_words():
+    raw = "Иван (собака) yandex (точка) ru"
+    final, _ = run_pipeline_on_text(raw)
+    assert "Иван@yandex.ru".lower() in [e.lower() for e in final]
 
 
-def test_word_without_context():
-    text = "Напишите на собака"
-    assert deobfuscate_text(text) == text
+def test_obfuscated_english_words():
+    raw = "support [at] uni [dot] edu"
+    final, _ = run_pipeline_on_text(raw)
+    assert "support@uni.edu" in final
 
 
-def test_inline_markers():
-    text = "name(at)domain(dot)com"
-    assert deobfuscate_text(text) == "name@domain.com"
+def test_no_false_positive():
+    raw = "Напишите слово собака в ответ"
+    final, dropped = run_pipeline_on_text(raw)
+    assert len(final) == 0


### PR DESCRIPTION
## Summary
- expand the deobfuscation helper to normalise spaced-out at/dot markers and track applied rules
- relax the strict email matcher to handle Cyrillic locals while keeping heuristics for glued tails and rejecting mixed scripts
- add regression tests covering confusable glyphs, dirty fragments and obfuscated wording

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9ab1c48e48326a95446dda298e6b7