### PR TITLE
Implement dynamic template discovery and selection

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+from services.templates import list_templates
+
+
+def build_templates_kb(
+    current_code: str | None = None,
+    *,
+    prefix: str = "tpl:",
+) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = []
+    normalized_current = (current_code or "").strip().lower()
+    for template in list_templates():
+        code = template.get("code", "")
+        label = str(template.get("label") or code)
+        display = label
+        if normalized_current and code.strip().lower() == normalized_current:
+            display = f"{label} • текущий"
+        rows.append([InlineKeyboardButton(display, callback_data=f"{prefix}{code}")])
+    if not rows:
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    "Нет доступных шаблонов", callback_data=f"{prefix}none"
+                )
+            ]
+        )
+    return InlineKeyboardMarkup(rows)

--- a/email_bot.py
+++ b/email_bot.py
@@ -199,12 +199,12 @@ def main() -> None:
         CallbackQueryHandler(bot_handlers.manual_reset, pattern="^manual_reset$")
     )
     app.add_handler(
-        CallbackQueryHandler(bot_handlers.send_manual_email, pattern="^manual_group_")
+        CallbackQueryHandler(bot_handlers.send_manual_email, pattern="^manual_tpl:")
     )
     app.add_handler(
         CallbackQueryHandler(bot_handlers.proceed_to_group, pattern="^proceed_group$")
     )
-    app.add_handler(CallbackQueryHandler(bot_handlers.select_group, pattern="^group_"))
+    app.add_handler(CallbackQueryHandler(bot_handlers.select_group, pattern="^tpl:"))
     app.add_handler(
         CallbackQueryHandler(bot_handlers.send_all, pattern="^start_sending")
     )

--- a/services/templates.py
+++ b/services/templates.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import os
+from typing import Any, Dict, Iterable
+
+
+def _allowed_exts() -> tuple[str, ...]:
+    parts = [
+        ext.strip().lower().lstrip(".")
+        for ext in os.getenv("TEMPLATE_EXTS", "html,htm").split(",")
+        if ext.strip()
+    ]
+    return tuple(f".{ext}" for ext in parts) or (".html", ".htm")
+
+
+def _base_dir() -> Path:
+    base = Path(os.getenv("TEMPLATES_DIR", "templates")).expanduser()
+    if not base.is_absolute():
+        base = (Path.cwd() / base).resolve()
+    else:
+        base = base.resolve()
+    return base
+
+
+def _labels_path(base: Path) -> Path:
+    return base / "_labels.json"
+
+
+def _exclude_dirs(base: Path) -> list[Path]:
+    raw = os.getenv("TEMPLATES_EXCLUDE", "templates/examples")
+    dirs: list[Path] = []
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        path = Path(part).expanduser()
+        if not path.is_absolute():
+            path = (base / path).resolve()
+        else:
+            path = path.resolve()
+        dirs.append(path)
+    return dirs
+
+
+def _humanize(code: str) -> str:
+    return code.replace("_", " ").replace("-", " ").strip().title()
+
+
+def _load_labels(base: Path) -> Dict[str, Any]:
+    labels_file = _labels_path(base)
+    if not labels_file.exists():
+        return {}
+    try:
+        data = json.loads(labels_file.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _normalize_code(code: str) -> str:
+    return (code or "").strip().lower()
+
+
+def _iter_template_files(base: Path) -> Iterable[Path]:
+    if not base.exists() or not base.is_dir():
+        return []
+    excludes = _exclude_dirs(base)
+    exts = _allowed_exts()
+    files: list[Path] = []
+    for path in base.rglob("*"):
+        if not path.is_file():
+            continue
+        suffix = path.suffix.lower()
+        if suffix not in exts:
+            continue
+        resolved = path.resolve()
+        excluded = False
+        for ex_dir in excludes:
+            if not ex_dir.exists():
+                continue
+            try:
+                resolved.relative_to(ex_dir)
+            except ValueError:
+                continue
+            else:
+                excluded = True
+                break
+        if excluded:
+            continue
+        files.append(resolved)
+    return files
+
+
+def list_templates() -> list[dict[str, Any]]:
+    base = _base_dir()
+    labels = _load_labels(base)
+    templates: list[dict[str, Any]] = []
+    for file_path in _iter_template_files(base):
+        code = file_path.stem
+        label_entry = labels.get(code)
+        extra: Dict[str, Any]
+        if isinstance(label_entry, dict):
+            label = str(label_entry.get("label") or _humanize(code))
+            extra = {k: v for k, v in label_entry.items() if k != "label"}
+        elif isinstance(label_entry, str):
+            label = label_entry
+            extra = {}
+        else:
+            label = _humanize(code)
+            extra = {}
+        tpl: Dict[str, Any] = {"code": code, "label": label, "path": str(file_path)}
+        tpl.update(extra)
+        templates.append(tpl)
+    return sorted(templates, key=lambda x: x.get("label", ""))
+
+
+def get_template(code: str) -> dict[str, Any] | None:
+    normalized = _normalize_code(code)
+    if not normalized:
+        return None
+    for tpl in list_templates():
+        if _normalize_code(tpl.get("code")) == normalized:
+            return tpl
+    return None
+
+
+def get_template_by_path(path: str | Path) -> dict[str, Any] | None:
+    try:
+        resolved = Path(path).resolve()
+    except Exception:
+        return None
+    for tpl in list_templates():
+        try:
+            tpl_path = Path(tpl.get("path", "")).resolve()
+        except Exception:
+            continue
+        if tpl_path == resolved:
+            return tpl
+    return None

--- a/templates/_labels.json
+++ b/templates/_labels.json
@@ -1,0 +1,8 @@
+{
+  "bioinformatics": {"label": "Биоинформатика", "signature": "new"},
+  "geography": {"label": "География", "signature": "new"},
+  "medicine": {"label": "Медицина", "signature": "old"},
+  "psychology": {"label": "Психология", "signature": "new"},
+  "sport": {"label": "Спорт", "signature": "old"},
+  "tourism": {"label": "Туризм", "signature": "old"}
+}

--- a/tests/test_messaging_from.py
+++ b/tests/test_messaging_from.py
@@ -10,16 +10,33 @@ from emailbot import messaging
 @pytest.mark.parametrize(
     "group, expected",
     [
-        ("медицина", "Редакция литературы по медицине, спорту и туризму"),
-        ("спорт", "Редакция литературы по медицине, спорту и туризму"),
-        ("туризм", "Редакция литературы по медицине, спорту и туризму"),
-        ("психология", "Редакция литературы"),
-        ("география", "Редакция литературы"),
-        ("биоинформатика", "Редакция литературы"),
+        ("medicine", "Редакция литературы по медицине, спорту и туризму"),
+        ("sport", "Редакция литературы по медицине, спорту и туризму"),
+        ("tourism", "Редакция литературы по медицине, спорту и туризму"),
+        ("psychology", "Редакция литературы"),
+        ("geography", "Редакция литературы"),
+        ("bioinformatics", "Редакция литературы"),
     ],
 )
-def test_choose_from_header(monkeypatch, group, expected):
+def test_choose_from_header(monkeypatch, group, expected, tmp_path):
     monkeypatch.setenv("EMAIL_ADDRESS", "test@lanbook.ru")
+
+    tpl_path = tmp_path / f"{group}.html"
+    tpl_path.write_text("<html><body>{{SIGNATURE}}</body></html>", encoding="utf-8")
+
+    def fake_get_template(code):
+        if code == group:
+            signature = "new" if code in {"psychology", "geography", "bioinformatics"} else "old"
+            return {
+                "code": code,
+                "label": code.title(),
+                "path": str(tpl_path),
+                "signature": signature,
+            }
+        return None
+
+    monkeypatch.setattr(messaging, "get_template", fake_get_template)
+
     msgs = messaging.build_messages_for_group(group, ["rcpt@example.com"], {})
     assert len(msgs) == 1
     msg = msgs[0]
@@ -43,7 +60,7 @@ def test_apply_from_trims(monkeypatch):
 
     msg = EmailMessage()
     msg["From"] = "Whatever <old@example.com>"
-    messaging._apply_from(msg, "психология")
+    messaging._apply_from(msg, "psychology")
 
     name, addr = parseaddr(str(msg["From"]))
     assert name == "Редакция литературы"

--- a/tests/test_templates_discovery.py
+++ b/tests/test_templates_discovery.py
@@ -1,0 +1,11 @@
+from services.templates import list_templates
+
+
+def test_discovery_honors_exts_and_labels(tmp_path, monkeypatch):
+    base = tmp_path / "templates"
+    base.mkdir()
+    (base / "sport.html").write_text("x", encoding="utf-8")
+    (base / "_labels.json").write_text('{"sport":"Спорт"}', encoding="utf-8")
+    monkeypatch.setenv("TEMPLATES_DIR", str(base))
+    res = list_templates()
+    assert any(x["label"] == "Спорт" and x["code"] == "sport" for x in res)


### PR DESCRIPTION
## Summary
- add a template discovery service that reads environment overrides, label metadata and provides lookup helpers
- build inline keyboards from discovered templates and update handlers to store selection state, validate files and refresh callback patterns
- resolve templates dynamically when rendering e-mails, include localized labels/signature hints, and cover the behaviour with new/updated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9b2ac149c8326bd45103b45ef90fe