### PR TITLE
Build template keyboard from templates list

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -5,26 +5,9 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from services.templates import list_templates
 
 
-def build_templates_kb(
-    current_code: str | None = None,
-    *,
-    prefix: str = "tpl:",
-) -> InlineKeyboardMarkup:
-    rows: list[list[InlineKeyboardButton]] = []
-    normalized_current = (current_code or "").strip().lower()
-    for template in list_templates():
-        code = template.get("code", "")
-        label = str(template.get("label") or code)
-        display = label
-        if normalized_current and code.strip().lower() == normalized_current:
-            display = f"{label} • текущий"
-        rows.append([InlineKeyboardButton(display, callback_data=f"{prefix}{code}")])
-    if not rows:
-        rows.append(
-            [
-                InlineKeyboardButton(
-                    "Нет доступных шаблонов", callback_data=f"{prefix}none"
-                )
-            ]
-        )
+def build_templates_kb(current_code: str | None = None) -> InlineKeyboardMarkup:
+    rows = []
+    for t in list_templates():
+        label = t["label"] + (" • текущий" if t["code"] == current_code else "")
+        rows.append([InlineKeyboardButton(label, callback_data=f"tpl:{t['code']}")])
     return InlineKeyboardMarkup(rows)

--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -663,14 +663,11 @@ async def prompt_change_group(
 ) -> None:
     """Prompt the user to choose a mailing group."""
 
-    current = context.chat_data.get("current_template_code")
-    if not current:
-        state = context.chat_data.get(SESSION_KEY)
-        if state and getattr(state, "group", None):
-            current = state.group
     await update.message.reply_text(
-        "⬇️ Выберите направление рассылки:",
-        reply_markup=build_templates_kb(current),
+        "Выберите направление:",
+        reply_markup=build_templates_kb(
+            context.chat_data.get("current_template_code")
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- build the template selection keyboard dynamically from services.templates
- update the change group prompt to show the generated keyboard and highlight the current template

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9bd5fc84083268ce468de67fd8a4d