### PR TITLE
Remove numeric email bucket and add fix flow for dropped addresses

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -5,9 +5,13 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from services.templates import list_templates
 
 
-def build_templates_kb(current_code: str | None = None) -> InlineKeyboardMarkup:
+def build_templates_kb(
+    current_code: str | None = None, prefix: str = "tpl:"
+) -> InlineKeyboardMarkup:
     rows = []
     for t in list_templates():
         label = t["label"] + (" • текущий" if t["code"] == current_code else "")
-        rows.append([InlineKeyboardButton(label, callback_data=f"tpl:{t['code']}")])
+        rows.append(
+            [InlineKeyboardButton(label, callback_data=f"{prefix}{t['code']}")]
+        )
     return InlineKeyboardMarkup(rows)

--- a/email_bot.py
+++ b/email_bot.py
@@ -212,9 +212,6 @@ def main() -> None:
         CallbackQueryHandler(bot_handlers.report_callback, pattern="^report_")
     )
     app.add_handler(
-        CallbackQueryHandler(bot_handlers.show_numeric_list, pattern="^show_numeric$")
-    )
-    app.add_handler(
         CallbackQueryHandler(bot_handlers.show_foreign_list, pattern="^show_foreign$")
     )
     app.add_handler(
@@ -224,19 +221,7 @@ def main() -> None:
         CallbackQueryHandler(bot_handlers.refresh_preview, pattern="^refresh_preview$")
     )
     app.add_handler(
-        CallbackQueryHandler(
-            bot_handlers.ask_include_numeric, pattern="^ask_include_numeric$"
-        )
-    )
-    app.add_handler(
-        CallbackQueryHandler(
-            bot_handlers.include_numeric_emails, pattern="^confirm_include_numeric$"
-        )
-    )
-    app.add_handler(
-        CallbackQueryHandler(
-            bot_handlers.cancel_include_numeric, pattern="^cancel_include_numeric$"
-        )
+        CallbackQueryHandler(bot_handlers.request_fix, pattern=r"^fix:\d+$")
     )
     app.add_handler(
         CallbackQueryHandler(bot_handlers.apply_repairs, pattern="^apply_repairs$")

--- a/pipelines/extract_emails.py
+++ b/pipelines/extract_emails.py
@@ -29,16 +29,19 @@ def extract_emails_pipeline(text: str) -> Tuple[List[str], Dict[str, int]]:
     return unique, stats
 
 
-def run_pipeline_on_text(text: str) -> Tuple[List[str], List[str]]:
-    """Convenience helper returning final emails and dropped ones for tests."""
+def run_pipeline_on_text(text: str) -> Tuple[List[str], List[Tuple[str, str]]]:
+    """Convenience helper returning final e-mails and dropped candidates."""
 
     cleaned, meta = parse_emails_unified(text or "", return_meta=True)
     final = dedupe_with_variants(cleaned)
-    dropped = [
-        item.get("raw")
-        for item in meta.get("items", [])
-        if not item.get("sanitized")
-    ]
+    dropped: List[Tuple[str, str]] = []
+    for item in meta.get("items", []):
+        if item.get("sanitized"):
+            continue
+        candidate = str(item.get("raw") or item.get("normalized") or "")
+        reason = str(item.get("reason") or "invalid")
+        if candidate:
+            dropped.append((candidate, reason))
     return final, dropped
 
 


### PR DESCRIPTION
## Summary
- remove UI and state handling for numeric-only addresses so they are part of the regular send list
- capture dropped email candidates with reasons, show them in the preview, and add a callback flow to fix and reinstate them
- propagate fix metadata through sending so logs include the original address and extend template keyboard helper for manual mode

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9ca03e05483268584f9ff332e47ff