### PR TITLE
Add SQLite history service for send idempotency

### DIFF
--- a/emailbot/history_service.py
+++ b/emailbot/history_service.py
@@ -1,0 +1,148 @@
+"""Service-level helpers for send history storage."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import Lock
+from typing import Iterable
+
+from .extraction_common import normalize_email as _normalize_email
+from . import history_store
+
+_LOCK = Lock()
+_INITIALIZED_PATH: Path | None = None
+_DEFAULT_DB_PATH = Path("var/state.db")
+
+
+def _resolve_path() -> Path:
+    raw = os.getenv("HISTORY_DB_PATH")
+    if raw:
+        path = Path(raw).expanduser()
+        if not path.is_absolute():
+            path = Path.cwd() / path
+        return path
+    return _DEFAULT_DB_PATH
+
+
+def ensure_initialized() -> None:
+    """Initialise the underlying SQLite database if needed."""
+
+    global _INITIALIZED_PATH
+    path = _resolve_path()
+    with _LOCK:
+        if _INITIALIZED_PATH != path:
+            history_store.init_db(path)
+            _INITIALIZED_PATH = path
+
+
+def _canonical_email(email: str) -> str:
+    email = (email or "").strip()
+    if not email:
+        return ""
+    try:
+        return _normalize_email(email)
+    except Exception:
+        return email.lower()
+
+
+def _canonical_group(group: str) -> str:
+    return (group or "").strip().lower()
+
+
+def _ensure_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def get_days_rule_default() -> int:
+    """Return the default number of days for the history rule."""
+
+    for name in ("DAYS_RULE_DEFAULT", "EMAIL_LOOKBACK_DAYS"):
+        raw = os.getenv(name)
+        if raw is None:
+            continue
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            value = int(raw)
+        except ValueError:
+            continue
+        return max(0, value)
+    return 180
+
+
+def mark_sent(email: str, group: str, msg_id: str | None, sent_at: datetime) -> None:
+    """Record a successful send event."""
+
+    ensure_initialized()
+    norm_email = _canonical_email(email)
+    if not norm_email:
+        return
+    norm_group = _canonical_group(group)
+    history_store.record_sent(norm_email, norm_group, msg_id, _ensure_utc(sent_at))
+
+
+def was_sent_within_days(email: str, group: str, days: int) -> bool:
+    """Return ``True`` if the address was contacted within ``days`` days."""
+
+    ensure_initialized()
+    if days <= 0:
+        return False
+    norm_email = _canonical_email(email)
+    if not norm_email:
+        return False
+    norm_group = _canonical_group(group)
+    return history_store.was_sent_within(norm_email, norm_group, days)
+
+
+def get_last_sent(email: str, group: str) -> datetime | None:
+    """Return the last send timestamp for the address/group pair."""
+
+    ensure_initialized()
+    norm_email = _canonical_email(email)
+    if not norm_email:
+        return None
+    norm_group = _canonical_group(group)
+    return history_store.get_last_sent(norm_email, norm_group)
+
+
+def filter_by_days(
+    emails: Iterable[str], group: str, days: int
+) -> tuple[list[str], list[str]]:
+    """Split ``emails`` into allowed and rejected based on the N-day rule."""
+
+    ensure_initialized()
+    if days <= 0:
+        return list(emails), []
+    norm_group = _canonical_group(group)
+    allowed: list[str] = []
+    rejected: list[str] = []
+    cache: dict[str, bool] = {}
+    for email in emails:
+        norm_email = _canonical_email(email)
+        if not norm_email:
+            allowed.append(email)
+            continue
+        cached = cache.get(norm_email)
+        if cached is None:
+            cached = history_store.was_sent_within(norm_email, norm_group, days)
+            cache[norm_email] = cached
+        if cached:
+            rejected.append(email)
+        else:
+            allowed.append(email)
+    return allowed, rejected
+
+
+__all__ = [
+    "ensure_initialized",
+    "mark_sent",
+    "was_sent_within_days",
+    "filter_by_days",
+    "get_last_sent",
+    "get_days_rule_default",
+]

--- a/emailbot/history_store.py
+++ b/emailbot/history_store.py
@@ -1,0 +1,286 @@
+"""SQLite-backed storage for send history."""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import os
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from threading import Lock
+from typing import Iterable
+
+from .extraction_common import normalize_email as _normalize_email
+
+logger = logging.getLogger(__name__)
+
+_DB_PATH: Path = Path("var/state.db")
+_INITIALIZED = False
+_LOCK = Lock()
+
+
+def _ensure_path(path: Path) -> Path:
+    path = Path(path)
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    return path
+
+
+def init_db(path: Path = Path("var/state.db")) -> None:
+    """Initialise the SQLite database and run legacy migrations."""
+
+    global _DB_PATH, _INITIALIZED
+    resolved = _ensure_path(path)
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    with _LOCK:
+        conn = sqlite3.connect(resolved)
+        try:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS sent (
+                  email TEXT NOT NULL,
+                  grp   TEXT NOT NULL,
+                  msg_id TEXT,
+                  sent_at TEXT NOT NULL,
+                  PRIMARY KEY (email, grp, sent_at)
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_sent_email_grp
+                ON sent(email, grp)
+                """
+            )
+            _run_migrations(conn)
+        finally:
+            conn.commit()
+            conn.close()
+        _DB_PATH = resolved
+        _INITIALIZED = True
+
+
+def _ensure_initialized() -> None:
+    if not _INITIALIZED:
+        init_db(_DB_PATH)
+
+
+def _open() -> sqlite3.Connection:
+    _ensure_initialized()
+    conn = sqlite3.connect(_DB_PATH)
+    return conn
+
+
+def _canonical_email(email: str) -> str:
+    email = (email or "").strip()
+    if not email:
+        return ""
+    try:
+        return _normalize_email(email)
+    except Exception:
+        return email.lower()
+
+
+def _canonical_group(grp: str) -> str:
+    return (grp or "").strip().lower()
+
+
+def _ensure_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _isoformat(dt: datetime) -> str:
+    return _ensure_utc(dt).isoformat()
+
+
+def _parse_datetime(value) -> datetime | None:
+    if isinstance(value, datetime):
+        return _ensure_utc(value)
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return _ensure_utc(dt)
+
+
+def _prepare_row(
+    email: str, grp: str, msg_id: str | None, sent_at: datetime | None
+) -> tuple[str, str, str | None, str] | None:
+    if sent_at is None:
+        return None
+    email_norm = _canonical_email(email)
+    if not email_norm:
+        return None
+    grp_norm = _canonical_group(grp)
+    msg_norm = (msg_id or "").strip() or None
+    return email_norm, grp_norm, msg_norm, _isoformat(sent_at)
+
+
+def record_sent(email: str, grp: str, msg_id: str | None, sent_at: datetime) -> None:
+    """Persist a new send event."""
+
+    row = _prepare_row(email, grp, msg_id, sent_at)
+    if row is None:
+        return
+    with _open() as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO sent(email, grp, msg_id, sent_at) VALUES (?, ?, ?, ?)",
+            row,
+        )
+        conn.commit()
+
+
+def was_sent_within(email: str, grp: str, days: int) -> bool:
+    """Return ``True`` if ``email`` was sent to within ``days`` days for ``grp``."""
+
+    if days <= 0:
+        return False
+    email_norm = _canonical_email(email)
+    if not email_norm:
+        return False
+    grp_norm = _canonical_group(grp)
+    now = datetime.now(timezone.utc)
+    cutoff_iso = _isoformat(now - timedelta(days=days))
+    with _open() as conn:
+        cur = conn.execute(
+            "SELECT 1 FROM sent WHERE email=? AND grp=? AND sent_at >= ? LIMIT 1",
+            (email_norm, grp_norm, cutoff_iso),
+        )
+        return cur.fetchone() is not None
+
+
+def get_last_sent(email: str, grp: str) -> datetime | None:
+    """Return the most recent send timestamp for ``email``/``grp`` if present."""
+
+    email_norm = _canonical_email(email)
+    if not email_norm:
+        return None
+    grp_norm = _canonical_group(grp)
+    with _open() as conn:
+        cur = conn.execute(
+            "SELECT sent_at FROM sent WHERE email=? AND grp=? ORDER BY sent_at DESC LIMIT 1",
+            (email_norm, grp_norm),
+        )
+        row = cur.fetchone()
+    if not row:
+        return None
+    value = row[0]
+    return _parse_datetime(value)
+
+
+def _legacy_stats_paths() -> Iterable[Path]:
+    seen: set[Path] = set()
+    candidates = []
+    env = os.getenv("SEND_STATS_PATH")
+    if env:
+        candidates.append(Path(env))
+    candidates.extend([Path("var/send_stats.jsonl")])
+    for path in candidates:
+        if not path:
+            continue
+        resolved = _ensure_path(path)
+        if resolved in seen or not resolved.exists():
+            continue
+        seen.add(resolved)
+        yield resolved
+
+
+def _legacy_sent_log_paths() -> Iterable[Path]:
+    seen: set[Path] = set()
+    env = os.getenv("LEGACY_SENT_LOG_PATH")
+    if env:
+        seen.add(_ensure_path(Path(env)))
+    defaults = [Path("/mnt/data/sent_log.csv"), Path("var/sent_log.csv")]
+    for path in list(seen) + defaults:
+        resolved = _ensure_path(path)
+        if resolved in seen or not resolved.exists():
+            continue
+        seen.add(resolved)
+        yield resolved
+
+
+def _migrate_send_stats(conn: sqlite3.Connection) -> None:
+    for path in _legacy_stats_paths():
+        try:
+            with path.open(encoding="utf-8") as fh:
+                for line in fh:
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if rec.get("status") not in {"success", "ok", "sent"}:
+                        continue
+                    email = rec.get("email") or ""
+                    grp = rec.get("group") or rec.get("source") or ""
+                    ts = rec.get("ts")
+                    dt = _parse_datetime(ts)
+                    if dt is None:
+                        try:
+                            dt = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+                        except Exception:
+                            dt = datetime.now(timezone.utc)
+                    msg_id = rec.get("message_id") or rec.get("msg_id")
+                    row = _prepare_row(email, grp, msg_id, dt)
+                    if row is None:
+                        continue
+                    conn.execute(
+                        "INSERT OR REPLACE INTO sent(email, grp, msg_id, sent_at) VALUES (?, ?, ?, ?)",
+                        row,
+                    )
+        except FileNotFoundError:
+            continue
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.debug("send_stats migration skipped for %s: %s", path, exc)
+
+
+def _migrate_sent_log(conn: sqlite3.Connection) -> None:
+    for path in _legacy_sent_log_paths():
+        try:
+            with path.open(encoding="utf-8") as fh:
+                reader = csv.DictReader(fh)
+                for row in reader:
+                    email = row.get("email") or row.get("key") or ""
+                    grp = row.get("source") or row.get("group") or ""
+                    ts = row.get("last_sent_at")
+                    dt = _parse_datetime(ts)
+                    if dt is None:
+                        continue
+                    msg_id = row.get("message_id") or row.get("msg_id")
+                    prepared = _prepare_row(email, grp, msg_id, dt)
+                    if prepared is None:
+                        continue
+                    conn.execute(
+                        "INSERT OR REPLACE INTO sent(email, grp, msg_id, sent_at) VALUES (?, ?, ?, ?)",
+                        prepared,
+                    )
+        except FileNotFoundError:
+            continue
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.debug("sent_log migration skipped for %s: %s", path, exc)
+
+
+def _run_migrations(conn: sqlite3.Connection) -> None:
+    try:
+        _migrate_send_stats(conn)
+        _migrate_sent_log(conn)
+    except Exception as exc:  # pragma: no cover - defensive logging
+        logger.debug("history_store migrations failed: %s", exc)
+
+
+__all__ = [
+    "init_db",
+    "record_sent",
+    "was_sent_within",
+    "get_last_sent",
+]

--- a/emailbot/messaging_utils.py
+++ b/emailbot/messaging_utils.py
@@ -474,9 +474,9 @@ def log_sent(email: str, *args, **kwargs):
 def was_sent_within(email: str, days: int = 180) -> bool:
     """Check recent sends."""
 
-    from . import messaging as _messaging
+    from . import history_service as _history_service
 
-    return _messaging.was_sent_within(email, days=days)
+    return _history_service.was_sent_within_days(email, "", days)
 
 
 def add_bounce(email: str, code: int | None, msg: str, phase: str) -> None:

--- a/tests/test_history_integration.py
+++ b/tests/test_history_integration.py
@@ -1,0 +1,39 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from emailbot import history_service, messaging
+
+
+@pytest.fixture(autouse=True)
+def _prepare_messaging(monkeypatch, tmp_path):
+    monkeypatch.setattr(messaging, "LOG_FILE", str(tmp_path / "log.csv"))
+    monkeypatch.setattr(messaging, "BLOCKED_FILE", str(tmp_path / "blocked.txt"))
+    monkeypatch.setattr(messaging, "is_foreign", lambda _: False)
+    monkeypatch.setattr(messaging, "is_suppressed", lambda _: False)
+
+
+def test_prepare_mass_mailing_respects_history():
+    history_service.ensure_initialized()
+    emails = ["user@example.com"]
+
+    ready, blocked_foreign, blocked_invalid, skipped_recent, _ = (
+        messaging.prepare_mass_mailing(emails, group="grp")
+    )
+    assert ready == ["user@example.com"]
+    assert blocked_foreign == []
+    assert blocked_invalid == []
+    assert skipped_recent == []
+
+    history_service.mark_sent(
+        "user@example.com",
+        "grp",
+        "msg-1",
+        datetime.now(timezone.utc),
+    )
+
+    ready2, _, _, skipped_recent2, _ = messaging.prepare_mass_mailing(
+        emails, group="grp"
+    )
+    assert ready2 == []
+    assert skipped_recent2 == ["user@example.com"]

--- a/tests/test_history_service.py
+++ b/tests/test_history_service.py
@@ -1,0 +1,43 @@
+from datetime import datetime, timedelta, timezone
+
+from emailbot import history_service, history_store
+
+
+def test_mark_and_filter(monkeypatch):
+    history_service.ensure_initialized()
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+
+    history_service.mark_sent("user@example.com", "grp", "m1", now)
+    assert history_service.was_sent_within_days("user@example.com", "grp", 1) is True
+
+    allowed, rejected = history_service.filter_by_days(
+        ["user@example.com", "other@example.com"], "grp", 30
+    )
+    assert allowed == ["other@example.com"]
+    assert rejected == ["user@example.com"]
+
+    # Different group is treated independently
+    allowed_alt, rejected_alt = history_service.filter_by_days(
+        ["user@example.com"], "other", 30
+    )
+    assert allowed_alt == ["user@example.com"]
+    assert rejected_alt == []
+
+    # Expired record no longer blocks
+    old_dt = now - timedelta(days=40)
+    history_store.record_sent("ancient@example.com", "grp", None, old_dt)
+    assert history_service.was_sent_within_days("ancient@example.com", "grp", 30) is False
+    assert history_service.was_sent_within_days("ancient@example.com", "grp", 60) is True
+
+
+def test_get_last_sent(monkeypatch):
+    history_service.ensure_initialized()
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    earlier = now - timedelta(days=1)
+
+    history_service.mark_sent("rec@example.com", "grp", "m0", earlier)
+    history_service.mark_sent("rec@example.com", "grp", "m1", now)
+
+    last = history_service.get_last_sent("rec@example.com", "grp")
+    assert last is not None
+    assert abs((last - now).total_seconds()) < 1

--- a/tests/test_history_store.py
+++ b/tests/test_history_store.py
@@ -1,0 +1,34 @@
+from datetime import datetime, timedelta, timezone
+
+from emailbot import history_store
+
+
+def test_record_and_query(tmp_path):
+    db = tmp_path / "state.db"
+    history_store.init_db(db)
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    earlier = now - timedelta(days=5)
+
+    history_store.record_sent("User@Example.com", "GroupA", "msg1", earlier)
+
+    assert history_store.was_sent_within("user@example.com", "groupa", 10) is True
+    assert history_store.was_sent_within("user@example.com", "groupa", 3) is False
+
+    history_store.record_sent("user@example.com", "GroupA", "msg2", now)
+    assert history_store.was_sent_within("USER@example.com", "GROUPA", 1) is True
+
+
+def test_get_last_sent_returns_latest(tmp_path):
+    db = tmp_path / "state.db"
+    history_store.init_db(db)
+    now = datetime.now(timezone.utc).replace(microsecond=0)
+    older = now - timedelta(days=30)
+
+    history_store.record_sent("user@example.com", "grp", "m-old", older)
+    history_store.record_sent("user@example.com", "grp", "m-new", now)
+
+    last = history_store.get_last_sent("user@example.com", "grp")
+    assert last is not None
+    assert abs((last - now).total_seconds()) < 1
+
+    assert history_store.get_last_sent("absent@example.com", "grp") is None

--- a/tests/test_messaging_utils.py
+++ b/tests/test_messaging_utils.py
@@ -54,7 +54,15 @@ def test_bounce_code_parsing():
 def test_gmail_canonicalization_for_180_days(tmp_path, monkeypatch):
     log = tmp_path / "log.csv"
     monkeypatch.setattr(messaging, "LOG_FILE", str(log))
-    mu.log_sent("user.name+tag@gmail.com", "g")
+    from emailbot import history_service
+    from datetime import datetime, timezone
+
+    history_service.mark_sent(
+        "user.name+tag@gmail.com",
+        "",
+        None,
+        datetime.now(timezone.utc),
+    )
     assert mu.was_sent_within("username@gmail.com") is True
 
 


### PR DESCRIPTION
## Summary
- add history_store and history_service modules to persist send history in SQLite and migrate legacy logs
- update messaging flows and bot handlers to rely on the shared history service for the N-day rule and mark send events
- isolate the history database per test run and add unit and integration coverage for the new storage/service layers

## Testing
- pytest tests/test_history*.py -q
- pytest tests/test_idempotency.py tests/test_messaging_utils.py tests/test_bot_handlers.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ca5ad91fa8832680ba6a66f6303647