### PR TITLE
Add Excel preview export and integrate into manual send

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -221,6 +221,9 @@ def main() -> None:
         CallbackQueryHandler(bot_handlers.refresh_preview, pattern="^refresh_preview$")
     )
     app.add_handler(
+        CallbackQueryHandler(bot_handlers.preview_go_back, pattern="^preview_back$")
+    )
+    app.add_handler(
         CallbackQueryHandler(bot_handlers.request_fix, pattern=r"^fix:\d+$")
     )
     app.add_handler(

--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -165,6 +165,7 @@ from emailbot.handlers import (
     select_group,
     proceed_to_group,
     send_all,
+    preview_go_back,
 )
 
 logger = logging.getLogger(__name__)

--- a/emailbot/handlers/__init__.py
+++ b/emailbot/handlers/__init__.py
@@ -8,6 +8,7 @@ from .manual_send import (
     proceed_to_group,
     send_all,
 )
+from .preview import go_back as preview_go_back
 
 __all__ = [
     "start",
@@ -15,4 +16,5 @@ __all__ = [
     "select_group",
     "proceed_to_group",
     "send_all",
+    "preview_go_back",
 ]

--- a/emailbot/handlers/manual_send.py
+++ b/emailbot/handlers/manual_send.py
@@ -37,6 +37,7 @@ from emailbot.utils import log_error
 from utils.smtp_client import RobustSMTP
 
 import emailbot.bot_handlers as bot_handlers_module
+from .preview import send_preview_report
 
 logger = logging.getLogger(__name__)
 
@@ -154,14 +155,15 @@ async def select_group(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
             reply_markup=None,
         )
         return
-    await query.message.reply_text(
-        (
-            f"✉️ Готово к отправке {len(ready)} писем.\n"
-            "Для запуска рассылки нажмите кнопку ниже."
-        ),
-        reply_markup=InlineKeyboardMarkup(
-            [[InlineKeyboardButton("✉️ Начать рассылку", callback_data="start_sending")]]
-        ),
+    await send_preview_report(
+        update,
+        context,
+        group_code,
+        label,
+        ready,
+        blocked_foreign,
+        blocked_invalid,
+        skipped_recent,
     )
 
 

--- a/emailbot/handlers/preview.py
+++ b/emailbot/handlers/preview.py
@@ -1,4 +1,311 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Sequence, TYPE_CHECKING
 
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
+from telegram.ext import ContextTypes
+
+from emailbot import history_service
+from emailbot.report_preview import PreviewData, build_preview_workbook
+
+if TYPE_CHECKING:  # pragma: no cover - typing helpers only
+    from emailbot.bot_handlers import SessionState
+
+
+PREVIEW_DIR = Path("var")
+_BACK_CALLBACK = "preview_back"
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _ensure_utc(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _format_dt(dt: datetime | None) -> str:
+    value = _ensure_utc(dt)
+    return value.isoformat() if value else ""
+
+
+def _days_left(last: datetime | None, rule_days: int) -> int:
+    value = _ensure_utc(last)
+    if value is None:
+        return 0
+    delta = _utc_now() - value
+    return max(0, rule_days - delta.days)
+
+
+def _fixed_map(chat_preview: dict[str, Any]) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    fixed_items = chat_preview.get("fixed") if isinstance(chat_preview, dict) else None
+    if not isinstance(fixed_items, Iterable):
+        return mapping
+    for item in fixed_items:
+        if not isinstance(item, dict):
+            continue
+        new_addr = str(item.get("to") or "").strip()
+        original = str(item.get("from") or "").strip()
+        if new_addr:
+            mapping[new_addr] = original
+    return mapping
+
+
+def _collect_valid(
+    emails: Sequence[str],
+    group: str,
+    fixed_map: dict[str, str],
+    rule_days: int,
+) -> list[dict[str, Any]]:
+    seen: set[str] = set()
+    rows: list[dict[str, Any]] = []
+    for email in emails:
+        if email in seen:
+            continue
+        seen.add(email)
+        last = history_service.get_last_sent(email, group)
+        reason_parts: list[str] = []
+        if email in fixed_map:
+            reason_parts.append(f"fixed:{fixed_map[email]}")
+        if last is None:
+            reason_parts.append("new")
+        else:
+            left = _days_left(last, rule_days)
+            if left > 0:
+                reason_parts.append(f"override:{left}d")
+            else:
+                reason_parts.append("ok")
+        rows.append(
+            {
+                "email": email,
+                "last_sent_at": _format_dt(last),
+                "reason": ", ".join(reason_parts),
+            }
+        )
+    rows.sort(key=lambda row: row.get("email", ""))
+    return rows
+
+
+def _collect_rejected(
+    emails: Iterable[str], group: str, rule_days: int
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for email in emails:
+        if email in seen:
+            continue
+        seen.add(email)
+        last = history_service.get_last_sent(email, group)
+        rows.append(
+            {
+                "email": email,
+                "last_sent_at": _format_dt(last),
+                "days_left": _days_left(last, rule_days),
+            }
+        )
+    rows.sort(key=lambda row: row.get("email", ""))
+    return rows
+
+
+def _collect_suspicious(state: SessionState | None) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not state:
+        return rows
+    seen: set[str] = set()
+    dropped = getattr(state, "dropped", []) or []
+    for item in dropped:
+        if not isinstance(item, (tuple, list)) or len(item) < 2:
+            continue
+        email = str(item[0])
+        reason = str(item[1])
+        if email in seen:
+            continue
+        seen.add(email)
+        rows.append({"email": email, "reason": reason})
+    rows.sort(key=lambda row: row.get("email", ""))
+    return rows
+
+
+def _collect_blocked(
+    blocked_foreign: Sequence[str], blocked_invalid: Sequence[str]
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for email in blocked_invalid:
+        if email in seen:
+            continue
+        seen.add(email)
+        rows.append({"email": email, "source": "suppress-list"})
+    for email in blocked_foreign:
+        if email in seen:
+            continue
+        seen.add(email)
+        rows.append({"email": email, "source": "foreign-domain"})
+    rows.sort(key=lambda row: row.get("email", ""))
+    return rows
+
+
+def _normalise_sources(value: Any) -> Any:
+    if isinstance(value, (list, tuple, set)):
+        return ", ".join(str(item) for item in value if item)
+    return value
+
+
+def _collect_duplicates(context: ContextTypes.DEFAULT_TYPE) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    raw_candidates: list[Any] = []
+    for key in ("preview_duplicates", "duplicates", "duplicates_preview"):
+        value = context.chat_data.get(key)
+        if not value:
+            continue
+        if isinstance(value, list):
+            raw_candidates.extend(value)
+        else:
+            raw_candidates.append(value)
+    for item in raw_candidates:
+        if not isinstance(item, dict):
+            continue
+        email = str(item.get("email") or "").strip()
+        if not email:
+            continue
+        rows.append(
+            {
+                "email": email,
+                "occurrences": item.get("occurrences"),
+                "source_files": _normalise_sources(item.get("source_files")),
+            }
+        )
+    rows.sort(key=lambda row: row.get("email", ""))
+    return rows
+
+
+def _get_state(context: ContextTypes.DEFAULT_TYPE) -> SessionState | None:
+    from emailbot import bot_handlers as bot_handlers_module  # local import to avoid cycles
+
+    key = bot_handlers_module.SESSION_KEY
+    state = context.chat_data.get(key)
+    return state if isinstance(state, bot_handlers_module.SessionState) else state
+
+
+def _build_preview_data(
+    context: ContextTypes.DEFAULT_TYPE,
+    group_code: str,
+    group_label: str,
+    ready: Sequence[str],
+    blocked_foreign: Sequence[str],
+    blocked_invalid: Sequence[str],
+    skipped_recent: Sequence[str],
+    rule_days: int,
+) -> PreviewData:
+    state = _get_state(context)
+    preview_chat = context.chat_data.get("send_preview") or {}
+    fixed_map = _fixed_map(preview_chat if isinstance(preview_chat, dict) else {})
+    valid_rows = _collect_valid(ready, group_code, fixed_map, rule_days)
+    rejected_rows = _collect_rejected(skipped_recent, group_code, rule_days)
+    suspicious_rows = _collect_suspicious(state)
+    blocked_rows = _collect_blocked(blocked_foreign, blocked_invalid)
+    duplicates_rows = _collect_duplicates(context)
+    group_name = group_label or group_code or getattr(state, "group", "") or ""
+    return PreviewData(
+        group=group_name,
+        valid=valid_rows,
+        rejected_180d=rejected_rows,
+        suspicious=suspicious_rows,
+        blocked=blocked_rows,
+        duplicates=duplicates_rows,
+    )
+
+
+def _compose_caption(data: PreviewData, rule_days: int) -> str:
+    lines = [f"✉️ Готово к отправке: {len(data.valid)} адресов."]
+    if data.rejected_180d:
+        lines.append(f"⏳ Отложено по правилу {rule_days} дн.: {len(data.rejected_180d)}")
+    if data.blocked:
+        lines.append(f"🚫 В исключениях/блок-листах: {len(data.blocked)}")
+    if data.suspicious:
+        lines.append(f"⚠️ Требует проверки: {len(data.suspicious)}")
+    if data.duplicates:
+        lines.append(f"🔁 Возможные дубликаты: {len(data.duplicates)}")
+    lines.append("Файл-предпросмотр: подробности внутри.")
+    return "\n".join(lines)
+
+
+def _preview_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton("Отправить", callback_data="start_sending"),
+                InlineKeyboardButton("Вернуться / Править", callback_data=_BACK_CALLBACK),
+            ]
+        ]
+    )
+
+
+async def send_preview_report(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    group_code: str,
+    group_label: str,
+    ready: Sequence[str],
+    blocked_foreign: Sequence[str],
+    blocked_invalid: Sequence[str],
+    skipped_recent: Sequence[str],
+) -> None:
+    """Generate an XLSX preview report and send it to the user."""
+
+    rule_days = history_service.get_days_rule_default()
+    data = _build_preview_data(
+        context,
+        group_code,
+        group_label,
+        ready,
+        blocked_foreign,
+        blocked_invalid,
+        skipped_recent,
+        rule_days,
+    )
+    chat = update.effective_chat
+    chat_id = chat.id if chat else 0
+    path = PREVIEW_DIR / f"preview_{chat_id}.xlsx"
+    build_preview_workbook(data, path)
+    caption = _compose_caption(data, rule_days)
+    keyboard = _preview_keyboard()
+    with path.open("rb") as fh:
+        await update.callback_query.message.reply_document(
+            document=fh,
+            filename=path.name,
+            caption=caption,
+            reply_markup=keyboard,
+        )
+
+
+async def go_back(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle the "Вернуться / Править" button press."""
+
+    query = update.callback_query
+    await query.answer()
+    preview = context.chat_data.get("send_preview") or {}
+    dropped = []
+    if isinstance(preview, dict):
+        dropped = preview.get("dropped", []) or []
+    lines = [
+        "Можно вернуться к редактированию списка.",
+        "Используйте кнопки «✏️ Исправить №…» в сообщении с анализом выше.",
+    ]
+    if dropped:
+        preview_lines = [
+            "", "⚠️ Текущие подозрительные:",
+            *(
+                f"{idx + 1}) {addr} — {reason}" for idx, (addr, reason) in enumerate(dropped[:10])
+            ),
+        ]
+        lines.extend(preview_lines)
+    await query.message.reply_text("\n".join(lines))

--- a/emailbot/report_preview.py
+++ b/emailbot/report_preview.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from collections import Counter
+from pathlib import Path
+from typing import Iterable
+from openpyxl import Workbook
+from openpyxl.utils import get_column_letter
+
+
+@dataclass
+class PreviewData:
+    group: str
+    valid: list[dict]            # dict: {"email":..., "last_sent_at":..., "reason":...}
+    rejected_180d: list[dict]    # {"email":..., "last_sent_at":..., "days_left":...}
+    suspicious: list[dict]       # {"email":..., "reason":...}
+    blocked: list[dict]          # {"email":..., "source":...}
+    duplicates: list[dict]       # {"email":..., "occurrences":..., "source_files":...}
+
+
+def _autosize(ws):
+    for col in ws.columns:
+        max_len = 3
+        col_letter = get_column_letter(col[0].column)
+        for cell in col:
+            v = str(cell.value) if cell.value is not None else ""
+            if len(v) > max_len:
+                max_len = len(v)
+        ws.column_dimensions[col_letter].width = min(max_len + 2, 80)
+
+
+def _top_domains(emails: Iterable[str], k: int = 5):
+    c = Counter(e.split("@")[-1].lower() for e in emails if "@" in e)
+    return c.most_common(k)
+
+
+def build_preview_workbook(data: PreviewData, path: Path) -> Path:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "summary"
+
+    total = sum(len(getattr(data, x)) for x in ["valid", "rejected_180d", "suspicious", "blocked", "duplicates"])
+    ws.append(["group", data.group])
+    ws.append(["total_found", total])
+    ws.append(["valid", len(data.valid)])
+    ws.append(["rejected_180d", len(data.rejected_180d)])
+    ws.append(["suspicious", len(data.suspicious)])
+    ws.append(["blocked", len(data.blocked)])
+    ws.append(["duplicates", len(data.duplicates)])
+    ws.append([])
+    ws.append(["top_domains(valid)"])
+    for d, cnt in _top_domains([x["email"] for x in data.valid]):
+        ws.append([d, cnt])
+    _autosize(ws)
+
+    def add_sheet(name: str, rows: list[dict], columns: list[str]):
+        wsx = wb.create_sheet(name)
+        wsx.append(columns)
+        for r in rows:
+            wsx.append([r.get(col) for col in columns])
+        _autosize(wsx)
+
+    add_sheet("valid", data.valid, ["email", "last_sent_at", "reason"])
+    add_sheet("rejected_180d", data.rejected_180d, ["email", "last_sent_at", "days_left"])
+    add_sheet("suspicious", data.suspicious, ["email", "reason"])
+    add_sheet("blocked", data.blocked, ["email", "source"])
+    add_sheet("duplicates", data.duplicates, ["email", "occurrences", "source_files"])
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    wb.save(path)
+    return path

--- a/tests/test_preview_after_filters.py
+++ b/tests/test_preview_after_filters.py
@@ -10,8 +10,9 @@ async def test_preview_after_filters(monkeypatch, tmp_path):
     ctx = DummyContext()
     ctx.chat_data[bh.SESSION_KEY] = bh.SessionState(to_send=["user@example.com"])
 
-    def fake_prepare(emails):
+    def fake_prepare(emails, group):
         assert emails == ["user@example.com"]
+        assert group == "sport"
         return [], [], [], [], {
             "input_total": 1,
             "after_suppress": 0,

--- a/tests/test_report_preview.py
+++ b/tests/test_report_preview.py
@@ -1,0 +1,59 @@
+from openpyxl import load_workbook
+
+from emailbot.report_preview import PreviewData, build_preview_workbook
+
+
+def test_build_preview_workbook_creates_expected_sheets(tmp_path):
+    data = PreviewData(
+        group="demo",
+        valid=[
+            {
+                "email": "user@example.com",
+                "last_sent_at": "2024-01-01T00:00:00+00:00",
+                "reason": "new",
+            }
+        ],
+        rejected_180d=[
+            {
+                "email": "recent@example.com",
+                "last_sent_at": "2024-05-20T00:00:00+00:00",
+                "days_left": 42,
+            }
+        ],
+        suspicious=[{"email": "suspect@example.com", "reason": "typo"}],
+        blocked=[{"email": "blocked@example.com", "source": "suppress-list"}],
+        duplicates=[
+            {
+                "email": "dup@example.com",
+                "occurrences": 2,
+                "source_files": "file1.xlsx",
+            }
+        ],
+    )
+    out_path = tmp_path / "preview.xlsx"
+    result = build_preview_workbook(data, out_path)
+    assert result == out_path
+    assert out_path.exists()
+
+    wb = load_workbook(out_path)
+    expected_sheets = {
+        "summary",
+        "valid",
+        "rejected_180d",
+        "suspicious",
+        "blocked",
+        "duplicates",
+    }
+    assert expected_sheets.issubset(set(wb.sheetnames))
+
+    valid_sheet = wb["valid"]
+    assert [cell.value for cell in next(valid_sheet.iter_rows(max_row=1))] == [
+        "email",
+        "last_sent_at",
+        "reason",
+    ]
+    summary = wb["summary"]
+    summary_values = {(row[0].value, row[1].value) for row in summary.iter_rows(min_row=2, max_row=7)}
+    assert ("valid", 1) in summary_values
+    assert ("rejected_180d", 1) in summary_values
+    wb.close()


### PR DESCRIPTION
## Summary
- add a reusable report_preview module that builds an Excel workbook with summary and detail sheets for preview data
- implement preview handlers that collect mailing results, send the workbook to Telegram users, and provide a go-back action
- update manual send flow and tests to verify the new preview document and workbook builder

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca644a90b483269abf58a5d09ddc2c