### PR TITLE
Add persistent email edit workflow for preview corrections

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -224,6 +224,22 @@ def main() -> None:
         CallbackQueryHandler(bot_handlers.preview_go_back, pattern="^preview_back$")
     )
     app.add_handler(
+        CallbackQueryHandler(bot_handlers.preview_request_edit, pattern="^preview_edit$")
+    )
+    app.add_handler(
+        CallbackQueryHandler(
+            bot_handlers.preview_show_edits, pattern="^preview_edits_show$"
+        )
+    )
+    app.add_handler(
+        CallbackQueryHandler(
+            bot_handlers.preview_reset_edits, pattern="^preview_edits_reset$"
+        )
+    )
+    app.add_handler(
+        CallbackQueryHandler(bot_handlers.preview_refresh_choice, pattern="^preview_refresh:")
+    )
+    app.add_handler(
         CallbackQueryHandler(bot_handlers.request_fix, pattern=r"^fix:\d+$")
     )
     app.add_handler(

--- a/emailbot/edit_service.py
+++ b/emailbot/edit_service.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from pathlib import Path
+
+from .history_store import _DB_PATH, init_db
+
+
+def save_edit(
+    chat_id: int, old_email: str, new_email: str, when: datetime | None = None
+) -> None:
+    init_db()
+    with sqlite3.connect(_DB_PATH) as con:
+        con.execute(
+            "INSERT INTO edits(chat_id, old_email, new_email, edited_at) VALUES (?, ?, ?, ?)",
+            (chat_id, old_email, new_email, (when or datetime.now()).isoformat()),
+        )
+        con.commit()
+
+
+def list_edits(chat_id: int) -> list[tuple[str, str, str]]:
+    init_db()
+    with sqlite3.connect(_DB_PATH) as con:
+        cur = con.execute(
+            "SELECT old_email, new_email, edited_at FROM edits WHERE chat_id=? ORDER BY edited_at DESC",
+            (chat_id,),
+        )
+        return list(cur.fetchall())
+
+
+def clear_edits(chat_id: int) -> None:
+    init_db()
+    with sqlite3.connect(_DB_PATH) as con:
+        con.execute("DELETE FROM edits WHERE chat_id=?", (chat_id,))
+        con.commit()
+
+
+def apply_edits(emails: list[str], chat_id: int) -> list[str]:
+    init_db()
+    mapping = {}
+    with sqlite3.connect(_DB_PATH) as con:
+        cur = con.execute(
+            "SELECT old_email, new_email FROM edits WHERE chat_id=?", (chat_id,)
+        )
+        mapping = {row[0].lower(): row[1] for row in cur.fetchall()}
+    out = []
+    for e in emails:
+        out.append(mapping.get(e.lower(), e))
+    return out

--- a/emailbot/handlers/__init__.py
+++ b/emailbot/handlers/__init__.py
@@ -8,7 +8,13 @@ from .manual_send import (
     proceed_to_group,
     send_all,
 )
-from .preview import go_back as preview_go_back
+from .preview import (
+    go_back as preview_go_back,
+    handle_refresh_choice as preview_refresh_choice,
+    request_edit as preview_request_edit,
+    reset_edits as preview_reset_edits,
+    show_edits as preview_show_edits,
+)
 
 __all__ = [
     "start",
@@ -17,4 +23,8 @@ __all__ = [
     "proceed_to_group",
     "send_all",
     "preview_go_back",
+    "preview_request_edit",
+    "preview_show_edits",
+    "preview_reset_edits",
+    "preview_refresh_choice",
 ]

--- a/emailbot/handlers/manual_send.py
+++ b/emailbot/handlers/manual_send.py
@@ -124,8 +124,9 @@ async def select_group(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         pass
     await query.message.reply_text(f"✅ Выбран шаблон: «{label}»\nФайл: {template_path}")
     chat_id = query.message.chat.id
+    context.chat_data["preview_source_emails"] = list(emails)
     ready, blocked_foreign, blocked_invalid, skipped_recent, digest = (
-        messaging.prepare_mass_mailing(emails, group_code)
+        messaging.prepare_mass_mailing(emails, group_code, chat_id=chat_id)
     )
     log_mass_filter_digest(
         {

--- a/emailbot/history_store.py
+++ b/emailbot/history_store.py
@@ -54,6 +54,21 @@ def init_db(path: Path = Path("var/state.db")) -> None:
                 ON sent(email, grp)
                 """
             )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS edits (
+                  chat_id INTEGER NOT NULL,
+                  old_email TEXT NOT NULL,
+                  new_email TEXT NOT NULL,
+                  edited_at TIMESTAMP NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_edits_chat_email ON edits(chat_id, old_email)
+                """
+            )
             _run_migrations(conn)
         finally:
             conn.commit()

--- a/tests/test_edit_service.py
+++ b/tests/test_edit_service.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+
+from emailbot import history_store
+from emailbot.edit_service import apply_edits, clear_edits, list_edits, save_edit
+
+
+def test_edit_service_roundtrip(tmp_path):
+    db_path = tmp_path / "state.db"
+    history_store.init_db(db_path)
+    chat_id = 90210
+    clear_edits(chat_id)
+
+    save_edit(chat_id, "old@example.com", "new@example.com", when=datetime(2024, 1, 1))
+
+    updated = apply_edits(["old@example.com", "other@example.com"], chat_id)
+    assert updated == ["new@example.com", "other@example.com"]
+
+    rows = list_edits(chat_id)
+    assert len(rows) == 1
+    assert rows[0][0] == "old@example.com"
+    assert rows[0][1] == "new@example.com"
+
+    clear_edits(chat_id)
+    assert list_edits(chat_id) == []

--- a/tests/test_preview_after_filters.py
+++ b/tests/test_preview_after_filters.py
@@ -10,7 +10,7 @@ async def test_preview_after_filters(monkeypatch, tmp_path):
     ctx = DummyContext()
     ctx.chat_data[bh.SESSION_KEY] = bh.SessionState(to_send=["user@example.com"])
 
-    def fake_prepare(emails, group):
+    def fake_prepare(emails, group, chat_id=None):
         assert emails == ["user@example.com"]
         assert group == "sport"
         return [], [], [], [], {


### PR DESCRIPTION
## Summary
- add an `edits` table and helpers to persist chat-specific email corrections
- extend preview callbacks with editing, listing, clearing, and regeneration logic that respects saved edits
- apply saved edits before N-day filtering across manual/mass flows and update tests for the new behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca6b1a1838832696a52111002b1a22