### PR TITLE
Deduplicate template keyboard entries

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -1,17 +1,60 @@
 from __future__ import annotations
 
+from collections import OrderedDict
+from typing import Dict
+
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+from telegram.ext import ContextTypes
 
 from services.templates import list_templates
 
 
+def _normalize_code(code: str | None) -> str:
+    return (code or "").strip().casefold()
+
+
 def build_templates_kb(
-    current_code: str | None = None, prefix: str = "tpl:"
+    context: ContextTypes.DEFAULT_TYPE,
+    current_code: str | None = None,
+    prefix: str = "tpl:",
+    map_name: str = "groups_map",
 ) -> InlineKeyboardMarkup:
+    """Build inline keyboard with templates deduplicated by code."""
+
+    templates = list_templates()
+    deduped: "OrderedDict[str, Dict[str, str]]" = OrderedDict()
+    for tpl in templates:
+        code = str(tpl.get("code") or "").strip()
+        key = _normalize_code(code)
+        if not key or key in deduped:
+            continue
+        label = str(tpl.get("label") or code or key).strip()
+        path = str(tpl.get("path") or "")
+        info: Dict[str, str] = {
+            "code": code,
+            "label": label,
+            "path": path,
+        }
+        for extra_key, extra_value in tpl.items():
+            if extra_key in info:
+                continue
+            info[extra_key] = extra_value
+        deduped[key] = info
+
+    normalized_current = _normalize_code(current_code)
     rows = []
-    for t in list_templates():
-        label = t["label"] + (" • текущий" if t["code"] == current_code else "")
+    mapping: Dict[str, Dict[str, str]] = {}
+    for key, info in deduped.items():
+        label = info.get("label") or info.get("code") or key
+        if normalized_current and key == normalized_current:
+            label = f"{label} • текущий"
         rows.append(
-            [InlineKeyboardButton(label, callback_data=f"{prefix}{t['code']}")]
+            [InlineKeyboardButton(str(label), callback_data=f"{prefix}{key}")]
         )
+        mapping[key] = dict(info)
+
+    if context is not None:
+        storage = context.user_data.setdefault(map_name, {})
+        storage[prefix] = mapping
+
     return InlineKeyboardMarkup(rows)

--- a/emailbot/handlers/manual_send.py
+++ b/emailbot/handlers/manual_send.py
@@ -89,7 +89,9 @@ async def proceed_to_group(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             current = state.group
     await query.message.reply_text(
         "⬇️ Выберите направление рассылки:",
-        reply_markup=build_templates_kb(current),
+        reply_markup=build_templates_kb(
+            context, current_code=current
+        ),
     )
 
 
@@ -99,15 +101,32 @@ async def select_group(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     query = update.callback_query
     await query.answer()
     data = query.data or ""
-    _, _, group_raw = data.partition(":")
-    group_code = bot_handlers_module._normalize_template_code(group_raw)
-    template_info = bot_handlers_module.get_template(group_code)
-    template_path_obj = bot_handlers_module._template_path(template_info)
-    if not template_info or not template_path_obj or not template_path_obj.exists():
+    if ":" not in data:
         await query.message.reply_text(
-            "⚠️ Шаблон не найден или файл отсутствует. Обновите список и попробуйте снова."
+            "⚠️ Некорректный выбор шаблона. Обновите список и попробуйте снова."
         )
         return
+    prefix_raw, group_raw = data.split(":", 1)
+    prefix = f"{prefix_raw}:"
+    template_info = bot_handlers_module.get_template_from_map(
+        context, prefix, group_raw
+    )
+    template_path_obj = (
+        bot_handlers_module._template_path(template_info)
+        if template_info
+        else None
+    )
+    if not template_info or not template_path_obj or not template_path_obj.exists():
+        group_code_fallback = bot_handlers_module._normalize_template_code(group_raw)
+        template_info = bot_handlers_module.get_template(group_code_fallback)
+        template_path_obj = bot_handlers_module._template_path(template_info)
+        if not template_info or not template_path_obj or not template_path_obj.exists():
+            await query.message.reply_text(
+                "⚠️ Шаблон не найден или файл отсутствует. Обновите список и попробуйте снова."
+            )
+            return
+        group_raw = template_info.get("code") or group_code_fallback
+    group_code = bot_handlers_module._normalize_template_code(group_raw)
     template_path = str(template_path_obj)
     label = bot_handlers_module._template_label(template_info) or group_code
     state = bot_handlers_module.get_state(context)
@@ -119,7 +138,11 @@ async def select_group(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     context.chat_data["current_template_label"] = label
     context.chat_data["current_template_path"] = template_path
     try:
-        await query.message.edit_reply_markup(reply_markup=build_templates_kb(group_code))
+        await query.message.edit_reply_markup(
+            reply_markup=build_templates_kb(
+                context, current_code=group_code, prefix=prefix
+            )
+        )
     except Exception:
         pass
     await query.message.reply_text(f"✅ Выбран шаблон: «{label}»\nФайл: {template_path}")


### PR DESCRIPTION
## Summary
- deduplicate template options when building keyboards and track template metadata per prefix
- look up selected templates using the stored map to ensure stable callbacks for mass and manual flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cac8412be48326889bbb29af9220c9