### PR TITLE
Use stored group metadata when building messages

### DIFF
--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -1798,6 +1798,8 @@ async def send_manual_email(update: Update, context: ContextTypes.DEFAULT_TYPE) 
                         email_addr,
                         template_path,
                         fixed_from=fixed_map.get(email_addr),
+                        group_title=label,
+                        group_key=group_code,
                     )
                     log_sent_email(
                         email_addr,

--- a/emailbot/handlers/manual_send.py
+++ b/emailbot/handlers/manual_send.py
@@ -383,6 +383,8 @@ async def send_all(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                         email_addr,
                         template_path,
                         fixed_from=fixed_map.get(email_addr),
+                        group_title=label,
+                        group_key=group_code,
                     )
                     log_sent_email(
                         email_addr,

--- a/mailer/smtp_sender.py
+++ b/mailer/smtp_sender.py
@@ -8,6 +8,11 @@ from smtplib import SMTPResponseException
 
 from utils.send_stats import log_error, log_success
 
+
+def _extract_group(msg: EmailMessage) -> str:
+    raw = msg.get("X-EBOT-Group-Key", "") or msg.get("X-EBOT-Group", "") or ""
+    return str(raw).strip()
+
 PORT = int(os.getenv("SMTP_PORT", "587"))
 USE_SSL = os.getenv("SMTP_SSL", "0") == "1"
 logger = logging.getLogger(__name__)
@@ -29,7 +34,7 @@ def send_messages(messages: Iterable[EmailMessage], user: str, password: str, ho
             try:
                 log_success(
                     msg.get("To", ""),
-                    msg.get("X-EBOT-Group", ""),
+                    _extract_group(msg),
                     extra={
                         "uuid": msg.get("X-EBOT-UUID", ""),
                         "message_id": msg.get("Message-ID", ""),
@@ -52,7 +57,7 @@ def send_messages(messages: Iterable[EmailMessage], user: str, password: str, ho
                     try:
                         log_success(
                             msg.get("To", ""),
-                            msg.get("X-EBOT-Group", ""),
+                            _extract_group(msg),
                             extra={
                                 "uuid": msg.get("X-EBOT-UUID", ""),
                                 "message_id": msg.get("Message-ID", ""),
@@ -66,7 +71,7 @@ def send_messages(messages: Iterable[EmailMessage], user: str, password: str, ho
             try:
                 log_error(
                     msg.get("To", ""),
-                    msg.get("X-EBOT-Group", ""),
+                    _extract_group(msg),
                     f"{code} {text}",
                     extra={
                         "uuid": msg.get("X-EBOT-UUID", ""),
@@ -80,7 +85,7 @@ def send_messages(messages: Iterable[EmailMessage], user: str, password: str, ho
             try:
                 log_error(
                     msg.get("To", ""),
-                    msg.get("X-EBOT-Group", ""),
+                    _extract_group(msg),
                     repr(e),
                     extra={
                         "uuid": msg.get("X-EBOT-UUID", ""),

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -168,6 +168,24 @@ def test_build_message_logo_toggle(tmp_path, monkeypatch):
     assert "<img" not in html2
 
 
+def test_build_message_uses_explicit_group_metadata(tmp_path, monkeypatch):
+    html_file = tmp_path / "template.html"
+    html_file.write_text("<html><body>Hello</body></html>", encoding="utf-8")
+    monkeypatch.setattr(messaging, "EMAIL_ADDRESS", "sender@example.com")
+
+    msg, _, _ = messaging.build_message(
+        "user@example.com",
+        str(html_file),
+        "Subject",
+        group_title="Custom Label",
+        group_key="custom-key",
+    )
+
+    assert msg["X-EBOT-Group"] == "Custom Label"
+    assert msg["X-EBOT-Group-Key"] == "custom-key"
+    assert msg["X-EBOT-Template-Label"] == "Custom Label"
+
+
 def test_repository_templates_logo_toggle(monkeypatch, tmp_path):
     template_path = tmp_path / "template.html"
     template_path.write_text(

--- a/tests/test_send_reports_integration.py
+++ b/tests/test_send_reports_integration.py
@@ -35,7 +35,7 @@ def _env_tmp_stats(tmp_path, monkeypatch):
     yield
 
 
-def _build_raw(group="sport"):
+def _build_raw(group="sport", title=None):
     from email.message import EmailMessage
 
     msg = EmailMessage()
@@ -43,13 +43,15 @@ def _build_raw(group="sport"):
     msg["To"] = "c@d.ru"
     msg["Subject"] = "t"
     if group:
-        msg["X-EBOT-Group"] = group
+        title_value = title if title is not None else group.upper()
+        msg["X-EBOT-Group"] = title_value
+        msg["X-EBOT-Group-Key"] = group
     msg.set_content("hi")
     return msg.as_bytes()
 
 
 def test_success_is_logged(tmp_path):
-    raw = _build_raw("sport")
+    raw = _build_raw("sport", title="Спорт")
     send_raw_smtp_with_retry(raw, "c@d.ru", max_tries=1)
     stats = Path(os.environ["SEND_STATS_PATH"])
     lines = stats.read_text(encoding="utf-8").strip().splitlines()


### PR DESCRIPTION
## Summary
- allow build_message to accept explicit group title/key and emit stable X-EBOT headers
- update SMTP senders and handlers to rely on the new group key header and pass stored metadata
- extend tests to cover the new headers and ensure logging still uses the stable key

## Testing
- pytest tests/test_messaging.py tests/test_send_reports_integration.py tests/test_bot_handlers.py


------
https://chatgpt.com/codex/tasks/task_e_68cace4172cc8326add8c887ecceb420