### PR TITLE
Add local send rules for blocklist and six-month history

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 import pytest
 
+from utils import rules
+
 
 @dataclass
 class _Resp:
@@ -79,3 +81,12 @@ def _isolated_history_db(tmp_path, monkeypatch):
     history_store._INITIALIZED = False
     history_store._DB_PATH = db_path
     yield
+
+
+@pytest.fixture(autouse=True)
+def _isolated_rules_files(tmp_path, monkeypatch):
+    history_path = tmp_path / "send_history.jsonl"
+    blocklist_path = tmp_path / "blocklist.txt"
+    monkeypatch.setattr(rules, "HISTORY_PATH", history_path)
+    monkeypatch.setattr(rules, "BLOCKLIST_PATH", blocklist_path)
+    rules.ensure_dirs()

--- a/utils/rules.py
+++ b/utils/rules.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPORT_TZ = os.getenv("REPORT_TZ", "Europe/Moscow")
+HISTORY_PATH = Path(os.getenv("SEND_HISTORY_PATH", "var/send_history.jsonl"))
+BLOCKLIST_PATH = Path(os.getenv("BLOCKLIST_PATH", "var/blocklist.txt"))
+MONTHS_WINDOW = int(os.getenv("RULE_MONTHS_WINDOW", "6"))
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def ensure_dirs() -> None:
+    HISTORY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    BLOCKLIST_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+
+def load_blocklist() -> set[str]:
+    if not BLOCKLIST_PATH.exists():
+        return set()
+    try:
+        return {
+            line.strip().lower()
+            for line in BLOCKLIST_PATH.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        }
+    except Exception:
+        return set()
+
+
+def is_blocked(addr: str) -> bool:
+    return addr.strip().lower() in load_blocklist()
+
+
+def append_history(addr: str) -> None:
+    """Запоминаем успешную отправку (email + время UTC)."""
+
+    ensure_dirs()
+    record = {"email": addr.strip().lower(), "ts": _now_utc().isoformat()}
+    with HISTORY_PATH.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def seen_within_window(addr: str, months: int | None = None) -> bool:
+    """Проверка, было ли письмо этому адресу за последние N месяцев (по локальному журналу)."""
+
+    months = months or MONTHS_WINDOW
+    cutoff = _now_utc() - timedelta(days=30 * months)
+    target = addr.strip().lower()
+    if not target or not HISTORY_PATH.exists():
+        return False
+    try:
+        with HISTORY_PATH.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                try:
+                    rec = json.loads(line)
+                except Exception:
+                    continue
+                email = str(rec.get("email", "")).strip().lower()
+                if email != target:
+                    continue
+                raw_ts = rec.get("ts")
+                if not isinstance(raw_ts, str) or not raw_ts.strip():
+                    continue
+                try:
+                    ts = datetime.fromisoformat(raw_ts)
+                except Exception:
+                    continue
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                else:
+                    ts = ts.astimezone(timezone.utc)
+                if ts >= cutoff:
+                    return True
+        return False
+    except Exception:
+        return False


### PR DESCRIPTION
## Summary
- add a reusable utils.rules module to manage the local blocklist and recent send history
- integrate the local rules into manual sending and the mass mailing pipeline, including logging successful sends
- extend tests with isolated rule paths and coverage for the new filtering behaviour

## Testing
- pytest tests/test_history_integration.py tests/test_messaging.py tests/test_bot_handlers.py

------
https://chatgpt.com/codex/tasks/task_e_68cafc92011883269b80e9b2144ced72