### PR TITLE
Introduce EmailEntry data model and enriched extraction helpers

### DIFF
--- a/emailbot/__init__.py
+++ b/emailbot/__init__.py
@@ -1,6 +1,7 @@
 """Helpers for the email bot."""
 
 from . import bot_handlers, extraction, messaging, unsubscribe, reporting
+from .models import EmailEntry
 from .smtp_client import SmtpClient
 from .utils import load_env, log_error, setup_logging
 
@@ -14,4 +15,5 @@ __all__ = [
     "bot_handlers",
     "unsubscribe",
     "reporting",
+    "EmailEntry",
 ]

--- a/emailbot/models.py
+++ b/emailbot/models.py
@@ -1,0 +1,87 @@
+"""Data models shared across the e-mail bot codebase."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from typing import Any, Iterable
+
+
+@dataclass(slots=True)
+class EmailEntry:
+    """A lightweight record describing a single e-mail address.
+
+    The model intentionally captures only the minimum amount of metadata
+    required across the extraction → deduplication → delivery pipeline.
+
+    Parameters
+    ----------
+    email:
+        Normalised e-mail address.
+    source:
+        A short label describing where the address came from
+        (``pdf``, ``url``, ``zip``, ``manual`` …).
+    status:
+        Processing status for the address, defaults to ``"new"``.
+    last_sent:
+        Timestamp of the last successful delivery, if known.
+    meta:
+        Arbitrary payload with auxiliary information (file path, author name,
+        scrape context, etc.).
+    """
+
+    email: str
+    source: str
+    status: str = "new"
+    last_sent: datetime | None = None
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise the entry into a dictionary safe for JSON output."""
+
+        data = asdict(self)
+        if self.last_sent is not None:
+            data["last_sent"] = self.last_sent.isoformat()
+        return data
+
+    @staticmethod
+    def from_email(
+        email: str,
+        *,
+        source: str,
+        status: str = "new",
+        last_sent: datetime | None = None,
+        meta: dict[str, Any] | None = None,
+    ) -> "EmailEntry":
+        """Construct an :class:`EmailEntry` from raw pieces of data."""
+
+        return EmailEntry(
+            email=email,
+            source=source,
+            status=status,
+            last_sent=last_sent,
+            meta=dict(meta) if meta else {},
+        )
+
+    @staticmethod
+    def wrap_list(
+        emails: Iterable[str],
+        *,
+        source: str,
+        status: str = "new",
+        last_sent: datetime | None = None,
+        meta: dict[str, Any] | None = None,
+    ) -> list["EmailEntry"]:
+        """Wrap a sequence of addresses in :class:`EmailEntry` objects."""
+
+        base_meta = dict(meta) if meta else {}
+        return [
+            EmailEntry(
+                email=e,
+                source=source,
+                status=status,
+                last_sent=last_sent,
+                meta=dict(base_meta),
+            )
+            for e in emails
+        ]

--- a/tests/test_extraction_enriched.py
+++ b/tests/test_extraction_enriched.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+
+from emailbot.extraction import extract_any_enriched
+from emailbot.models import EmailEntry
+
+
+def test_extract_any_enriched_pdf(monkeypatch):
+    from emailbot import extraction as ex
+
+    def fake_extract_any(path_or_url: str):
+        assert path_or_url.endswith(".pdf")
+        return ["a@b.com", "c@d.org"], {"dummy": True}
+
+    monkeypatch.setattr(ex, "extract_any", fake_extract_any)
+
+    timestamp = datetime.utcnow()
+    result = extract_any_enriched(
+        "sample.pdf",
+        status="queued",
+        last_sent=timestamp,
+        meta={"fixture": True},
+    )
+    assert len(result) == 2
+    assert isinstance(result[0], EmailEntry)
+    assert result[0].source == "pdf"
+    assert result[0].status == "queued"
+    assert result[0].last_sent == timestamp
+    assert result[0].meta.get("fixture") is True
+
+
+def test_extract_any_enriched_url(monkeypatch):
+    from emailbot import extraction as ex
+
+    def fake_extract_any(path_or_url: str):
+        assert path_or_url.startswith("https://")
+        return ["x@y.com"], {"dummy": True}
+
+    monkeypatch.setattr(ex, "extract_any", fake_extract_any)
+
+    result = extract_any_enriched("https://example.com/page", meta={"where": "test"})
+    assert len(result) == 1
+    assert isinstance(result[0], EmailEntry)
+    assert result[0].source == "url"
+    assert result[0].status == "new"
+    assert result[0].to_dict()["meta"]["where"] == "test"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+
+from emailbot.models import EmailEntry
+
+
+def test_email_entry_basic():
+    entry = EmailEntry.from_email("a@b.com", source="pdf")
+    assert entry.email == "a@b.com"
+    assert entry.source == "pdf"
+    assert entry.status == "new"
+    assert entry.last_sent is None
+    assert isinstance(entry.meta, dict)
+
+
+def test_email_entry_wrap_list_and_dict():
+    meta = {"file": "foo.pdf"}
+    items = EmailEntry.wrap_list(
+        ["x@y.com", "z@k.org"],
+        source="url",
+        status="queued",
+        meta=meta,
+    )
+    assert len(items) == 2
+    assert items[0].status == "queued"
+    assert items[0].meta is not meta
+    items[0].meta["file"] = "bar.pdf"
+    assert items[1].meta["file"] == "foo.pdf"
+    data = items[0].to_dict()
+    assert data["email"] == "x@y.com"
+    assert data["source"] == "url"
+    assert data["status"] == "queued"
+
+
+def test_email_entry_datetime_serialization():
+    now = datetime.utcnow()
+    entry = EmailEntry(email="m@n.io", source="manual", last_sent=now)
+    data = entry.to_dict()
+    assert "last_sent" in data
+    assert isinstance(data["last_sent"], str)
+    parsed = datetime.fromisoformat(data["last_sent"])
+    assert parsed.replace(microsecond=0) == now.replace(microsecond=0)


### PR DESCRIPTION
## Summary
- add a reusable `EmailEntry` dataclass and export it from the package
- expose helpers to wrap raw addresses and return enriched entries from `extract_any`
- add unit tests covering the new model utilities and enriched extraction flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb11d8df548326aff87c197052de6d