### PR TITLE
Propagate template labels safely

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -10,7 +10,7 @@ from telegram.ext import ContextTypes
 
 from services.templates import list_templates
 
-_ICONS = {}
+_ICONS: Dict[str, str] = {}
 _ICONS_PATH = Path("icons.json")
 if _ICONS_PATH.exists():
     try:
@@ -20,7 +20,22 @@ if _ICONS_PATH.exists():
 
 
 def _icon_for(label: str) -> str:
-    return _ICONS.get(label) or _ICONS.get(label.strip()) or ""
+    if not label:
+        return ""
+    key = label.strip()
+    if not key:
+        return ""
+    icon = _ICONS.get(key)
+    if icon:
+        return icon
+    capitalized = _ICONS.get(key.capitalize())
+    if capitalized:
+        return capitalized
+    lowered = key.casefold()
+    for stored_key, stored_icon in _ICONS.items():
+        if stored_key.strip().casefold() == lowered:
+            return stored_icon
+    return ""
 
 
 def _normalize_code(code: str | None) -> str:
@@ -64,7 +79,7 @@ def build_templates_kb(
         base_label = str(info.get("label") or info.get("code") or key)
         display_label = base_label
         # Префиксуем иконкой, если она задана в icons.json
-        icon = _icon_for(display_label)
+        icon = _icon_for(base_label)
         if icon:
             display_label = f"{icon} {display_label}"
         if normalized_current and key == normalized_current:

--- a/emailbot/bot/keyboards.py
+++ b/emailbot/bot/keyboards.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 import json
 
+from typing import Dict
+
 from aiogram.types import InlineKeyboardMarkup
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 
@@ -20,8 +22,28 @@ def _load_icons() -> dict[str, str]:
     return {}
 
 
+def _icon_for(label: str, icons: Dict[str, str]) -> str:
+    if not label:
+        return ""
+    key = label.strip()
+    if not key:
+        return ""
+    icon = icons.get(key)
+    if icon:
+        return icon
+    capitalized = icons.get(key.capitalize())
+    if capitalized:
+        return capitalized
+    lowered = key.casefold()
+    for stored_key, stored_icon in icons.items():
+        if stored_key.strip().casefold() == lowered:
+            return stored_icon
+    return ""
+
+
 def _label_with_icon(label: str, icons: dict[str, str]) -> str:
-    return f"{icons.get(label, '📧')} {label}"
+    icon = _icon_for(label, icons)
+    return f"{icon} {label}" if icon else label
 
 
 def directions_keyboard(directions: list[str]) -> InlineKeyboardMarkup:

--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -31,7 +31,7 @@ from telegram import (
 from telegram.ext import ContextTypes
 
 from bot.keyboards import build_templates_kb
-from services.templates import get_template
+from services.templates import get_template, get_template_label
 from emailbot.notify import notify
 
 from utils.email_clean import (
@@ -1779,7 +1779,11 @@ async def send_manual_email(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         group_raw = template_info.get("code") or group_code_fallback
     group_code = _normalize_template_code(group_raw)
     template_path = str(template_path_obj)
-    label = _template_label(template_info) or group_code
+    label = _template_label(template_info)
+    if not label and group_code:
+        label = get_template_label(group_code)
+    if not label:
+        label = group_code
 
     enforce, days, allow_override = _manual_cfg()
     if enforce and mode == "allowed":

--- a/emailbot/handlers/preview.py
+++ b/emailbot/handlers/preview.py
@@ -9,6 +9,7 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup, Update
 from telegram.ext import ContextTypes
 
 from emailbot.notify import notify
+from services.templates import get_template_label
 
 from emailbot import history_service, mass_state, messaging
 from emailbot.edit_service import (
@@ -544,6 +545,8 @@ async def _regenerate_preview(update: Update, context: ContextTypes.DEFAULT_TYPE
     label = context.chat_data.get("current_template_label") or ""
     if not label and state and getattr(state, "template_label", None):
         label = state.template_label or ""
+    if not label and group_code:
+        label = get_template_label(group_code)
     template_path = context.chat_data.get("current_template_path") or ""
     if not template_path and state and getattr(state, "template", None):
         template_path = state.template or ""

--- a/services/templates.py
+++ b/services/templates.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 import json
 import os
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Iterable, Optional
 
 
 def _allowed_exts() -> tuple[str, ...]:
@@ -124,6 +124,25 @@ def get_template(code: str) -> dict[str, Any] | None:
         if _normalize_code(tpl.get("code")) == normalized:
             return tpl
     return None
+
+
+def get_template_label(code: str) -> str:
+    """Return a human-readable label for template ``code``.
+
+    Falls back to the template ``code`` when metadata is missing or incomplete.
+    """
+
+    if not code:
+        return ""
+    template: Optional[Dict[str, Any]] = get_template(code)
+    if isinstance(template, dict):
+        raw_label = template.get("label")
+        if isinstance(raw_label, str):
+            label = raw_label.strip()
+            if label:
+                return label
+    fallback = str(code).strip()
+    return fallback or str(code)
 
 
 def get_template_by_path(path: str | Path) -> dict[str, Any] | None:


### PR DESCRIPTION
## Summary
- add a helper in `services.templates` to resolve template labels with safe fallbacks
- propagate the resolved label through manual send state/job bookkeeping and preview regeneration
- normalize icon lookup for keyboards so direction/template buttons share the same mapping logic

## Testing
- `pytest` *(fails: pre-existing sanitizer/unicode parsing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf5917bc883269f045937b0789cc8