### PR TITLE
Implement SQLite send history registry and fix email normalization

### DIFF
--- a/emailbot/history_service.py
+++ b/emailbot/history_service.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from threading import Lock
-from typing import Iterable
+from typing import Iterable, List, Tuple
 
 from .extraction_common import normalize_email as _normalize_email
 from . import history_store
+from emailbot.services.cooldown import _env_int
 
 _LOCK = Lock()
 _INITIALIZED_PATH: Path | None = None
@@ -37,53 +38,56 @@ def ensure_initialized() -> None:
             _INITIALIZED_PATH = path
 
 
-def _canonical_email(email: str) -> str:
-    email = (email or "").strip()
-    if not email:
-        return ""
+def _norm_email(email: str) -> str:
     try:
         return _normalize_email(email)
     except Exception:
-        return email.lower()
+        return (email or "").strip().lower()
 
 
-def _canonical_group(group: str) -> str:
+def _norm_group(group: str) -> str:
     return (group or "").strip().lower()
 
 
-def _ensure_utc(dt: datetime) -> datetime:
-    if dt.tzinfo is None:
-        return dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc)
+def _ensure_utc(dt: datetime | None) -> datetime:
+    value = dt or datetime.now(timezone.utc)
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
 
 
 def get_days_rule_default() -> int:
     """Return the default number of days for the history rule."""
 
-    for name in ("DAYS_RULE_DEFAULT", "EMAIL_LOOKBACK_DAYS"):
-        raw = os.getenv(name)
-        if raw is None:
-            continue
-        raw = raw.strip()
-        if not raw:
-            continue
-        try:
-            value = int(raw)
-        except ValueError:
-            continue
-        return max(0, value)
-    return 180
+    # Keep the default in sync with the global cooldown setting.
+    return _env_int("COOLDOWN_DAYS", 180)
 
 
-def mark_sent(email: str, group: str, msg_id: str | None, sent_at: datetime) -> None:
+def mark_sent(
+    email: str,
+    group: str,
+    msg_id: str | None = None,
+    sent_at: datetime | None = None,
+    *,
+    run_id: str = "",
+    smtp_result: str = "ok",
+) -> None:
     """Record a successful send event."""
 
     ensure_initialized()
-    norm_email = _canonical_email(email)
+    norm_email = _norm_email(email)
     if not norm_email:
         return
-    norm_group = _canonical_group(group)
-    history_store.record_sent(norm_email, norm_group, msg_id, _ensure_utc(sent_at))
+    norm_group = _norm_group(group)
+    ts = _ensure_utc(sent_at)
+    history_store.record_send(
+        norm_email,
+        norm_group,
+        ts,
+        message_id=(msg_id or "").strip(),
+        run_id=run_id,
+        smtp_result=smtp_result,
+    )
 
 
 def was_sent_within_days(email: str, group: str, days: int) -> bool:
@@ -92,22 +96,35 @@ def was_sent_within_days(email: str, group: str, days: int) -> bool:
     ensure_initialized()
     if days <= 0:
         return False
-    norm_email = _canonical_email(email)
+    norm_email = _norm_email(email)
     if not norm_email:
         return False
-    norm_group = _canonical_group(group)
-    return history_store.was_sent_within(norm_email, norm_group, days)
+    norm_group = _norm_group(group)
+    last = history_store.last_send(norm_email, norm_group)
+    if last is None:
+        return False
+    return (datetime.now(timezone.utc) - last) < timedelta(days=days)
 
 
 def get_last_sent(email: str, group: str) -> datetime | None:
     """Return the last send timestamp for the address/group pair."""
 
     ensure_initialized()
-    norm_email = _canonical_email(email)
+    norm_email = _norm_email(email)
     if not norm_email:
         return None
-    norm_group = _canonical_group(group)
-    return history_store.get_last_sent(norm_email, norm_group)
+    norm_group = _norm_group(group)
+    return history_store.last_send(norm_email, norm_group)
+
+
+def get_last_sent_any_group(email: str) -> Tuple[str, datetime] | None:
+    """Return the most recent send timestamp regardless of group."""
+
+    ensure_initialized()
+    norm_email = _norm_email(email)
+    if not norm_email:
+        return None
+    return history_store.last_send_any_group(norm_email)
 
 
 def filter_by_days(
@@ -118,20 +135,20 @@ def filter_by_days(
     ensure_initialized()
     if days <= 0:
         return list(emails), []
-    norm_group = _canonical_group(group)
-    allowed: list[str] = []
-    rejected: list[str] = []
-    cache: dict[str, bool] = {}
+    norm_group = _norm_group(group)
+    allowed: List[str] = []
+    rejected: List[str] = []
+    cache: dict[str, datetime | None] = {}
+    threshold = datetime.now(timezone.utc) - timedelta(days=days)
     for email in emails:
-        norm_email = _canonical_email(email)
+        norm_email = _norm_email(email)
         if not norm_email:
             allowed.append(email)
             continue
-        cached = cache.get(norm_email)
-        if cached is None:
-            cached = history_store.was_sent_within(norm_email, norm_group, days)
-            cache[norm_email] = cached
-        if cached:
+        if norm_email not in cache:
+            cache[norm_email] = history_store.last_send(norm_email, norm_group)
+        last = cache[norm_email]
+        if last and last >= threshold:
             rejected.append(email)
         else:
             allowed.append(email)
@@ -144,5 +161,6 @@ __all__ = [
     "was_sent_within_days",
     "filter_by_days",
     "get_last_sent",
+    "get_last_sent_any_group",
     "get_days_rule_default",
 ]

--- a/emailbot/history_store.py
+++ b/emailbot/history_store.py
@@ -1,4 +1,6 @@
-"""SQLite-backed storage for send history."""
+"""Low-level SQLite helpers for send-history registry.
+   [EBOT-SQL-COOLDOWN-001]
+"""
 
 from __future__ import annotations
 
@@ -10,7 +12,7 @@ import sqlite3
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from threading import Lock
-from typing import Iterable
+from typing import Iterable, Optional, Tuple
 
 from .extraction_common import normalize_email as _normalize_email
 
@@ -21,52 +23,58 @@ _INITIALIZED = False
 _LOCK = Lock()
 
 
-def _ensure_path(path: Path) -> Path:
+def _ensure_path(path: Path | str) -> Path:
     path = Path(path)
     if not path.is_absolute():
         path = Path.cwd() / path
     return path
 
 
-def init_db(path: Path = Path("var/state.db")) -> None:
+def init_db(path: Path | str | None = None) -> None:
     """Initialise the SQLite database and run legacy migrations."""
 
     global _DB_PATH, _INITIALIZED
-    resolved = _ensure_path(path)
+    target = path or _DB_PATH
+    resolved = _ensure_path(target)
     resolved.parent.mkdir(parents=True, exist_ok=True)
     with _LOCK:
         conn = sqlite3.connect(resolved)
         try:
+            conn.execute("PRAGMA journal_mode=WAL;")
+            conn.execute("PRAGMA synchronous=NORMAL;")
             conn.execute(
                 """
-                CREATE TABLE IF NOT EXISTS sent (
-                  email TEXT NOT NULL,
-                  grp   TEXT NOT NULL,
-                  msg_id TEXT,
-                  sent_at TEXT NOT NULL,
-                  PRIMARY KEY (email, grp, sent_at)
+                CREATE TABLE IF NOT EXISTS send_history(
+                    email_norm  TEXT NOT NULL,
+                    group_key   TEXT NOT NULL,
+                    sent_at_utc TEXT NOT NULL,
+                    message_id  TEXT,
+                    run_id      TEXT,
+                    smtp_result TEXT,
+                    PRIMARY KEY (email_norm, group_key, sent_at_utc)
                 )
                 """
             )
             conn.execute(
                 """
-                CREATE INDEX IF NOT EXISTS idx_sent_email_grp
-                ON sent(email, grp)
+                CREATE INDEX IF NOT EXISTS idx_send_history_last
+                  ON send_history(email_norm, group_key, sent_at_utc DESC)
                 """
             )
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS edits (
-                  chat_id INTEGER NOT NULL,
-                  old_email TEXT NOT NULL,
-                  new_email TEXT NOT NULL,
-                  edited_at TIMESTAMP NOT NULL
+                    chat_id   INTEGER NOT NULL,
+                    old_email TEXT NOT NULL,
+                    new_email TEXT NOT NULL,
+                    edited_at TEXT NOT NULL
                 )
                 """
             )
             conn.execute(
                 """
-                CREATE INDEX IF NOT EXISTS idx_edits_chat_email ON edits(chat_id, old_email)
+                CREATE INDEX IF NOT EXISTS idx_edits_chat_email
+                ON edits(chat_id, old_email)
                 """
             )
             _run_migrations(conn)
@@ -82,9 +90,10 @@ def _ensure_initialized() -> None:
         init_db(_DB_PATH)
 
 
-def _open() -> sqlite3.Connection:
+def _connect() -> sqlite3.Connection:
     _ensure_initialized()
-    conn = sqlite3.connect(_DB_PATH)
+    conn = sqlite3.connect(_DB_PATH, timeout=30)
+    conn.execute("PRAGMA foreign_keys=ON;")
     return conn
 
 
@@ -98,8 +107,8 @@ def _canonical_email(email: str) -> str:
         return email.lower()
 
 
-def _canonical_group(grp: str) -> str:
-    return (grp or "").strip().lower()
+def _canonical_group(group: str) -> str:
+    return (group or "").strip().lower()
 
 
 def _ensure_utc(dt: datetime) -> datetime:
@@ -109,10 +118,10 @@ def _ensure_utc(dt: datetime) -> datetime:
 
 
 def _isoformat(dt: datetime) -> str:
-    return _ensure_utc(dt).isoformat()
+    return _ensure_utc(dt).isoformat().replace("+00:00", "Z")
 
 
-def _parse_datetime(value) -> datetime | None:
+def _parse_datetime(value) -> Optional[datetime]:
     if isinstance(value, datetime):
         return _ensure_utc(value)
     if value is None:
@@ -130,68 +139,160 @@ def _parse_datetime(value) -> datetime | None:
 
 
 def _prepare_row(
-    email: str, grp: str, msg_id: str | None, sent_at: datetime | None
-) -> tuple[str, str, str | None, str] | None:
+    email: str,
+    group: str,
+    message_id: str | None,
+    sent_at: datetime | None,
+    *,
+    run_id: str = "",
+    smtp_result: str = "ok",
+) -> Optional[tuple[str, str, str, str | None, str | None, str | None]]:
     if sent_at is None:
         return None
     email_norm = _canonical_email(email)
     if not email_norm:
         return None
-    grp_norm = _canonical_group(grp)
-    msg_norm = (msg_id or "").strip() or None
-    return email_norm, grp_norm, msg_norm, _isoformat(sent_at)
+    group_norm = _canonical_group(group)
+    msg_norm = (message_id or "").strip() or None
+    run_norm = (run_id or "").strip() or None
+    result_norm = (smtp_result or "").strip() or None
+    return (
+        email_norm,
+        group_norm,
+        _isoformat(sent_at),
+        msg_norm,
+        run_norm,
+        result_norm,
+    )
 
 
-def record_sent(email: str, grp: str, msg_id: str | None, sent_at: datetime) -> None:
-    """Persist a new send event."""
-
-    row = _prepare_row(email, grp, msg_id, sent_at)
-    if row is None:
-        return
-    with _open() as conn:
+def _insert_history_row(row: tuple[str, str, str, str | None, str | None, str | None]) -> None:
+    conn = _connect()
+    try:
+        conn.execute("BEGIN IMMEDIATE;")
         conn.execute(
-            "INSERT OR REPLACE INTO sent(email, grp, msg_id, sent_at) VALUES (?, ?, ?, ?)",
+            """
+            INSERT OR REPLACE INTO send_history(
+                email_norm, group_key, sent_at_utc, message_id, run_id, smtp_result
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
             row,
         )
         conn.commit()
+    finally:
+        conn.close()
 
 
-def was_sent_within(email: str, grp: str, days: int) -> bool:
-    """Return ``True`` if ``email`` was sent to within ``days`` days for ``grp``."""
+def record_send(
+    email_norm: str,
+    group_key: str,
+    sent_at_utc: datetime,
+    message_id: str = "",
+    run_id: str = "",
+    smtp_result: str = "",
+) -> None:
+    email_norm = (email_norm or "").strip().lower()
+    if not email_norm:
+        return
+    group_key = (group_key or "").strip().lower()
+    row = (
+        email_norm,
+        group_key,
+        _isoformat(sent_at_utc),
+        (message_id or "").strip() or None,
+        (run_id or "").strip() or None,
+        (smtp_result or "").strip() or None,
+    )
+    _insert_history_row(row)
 
+
+def record_sent(email: str, group: str, msg_id: str | None, sent_at: datetime) -> None:
+    row = _prepare_row(email, group, msg_id, sent_at, smtp_result="ok")
+    if row is None:
+        return
+    _insert_history_row(row)
+
+
+def last_send(email_norm: str, group_key: str) -> Optional[datetime]:
+    email_norm = (email_norm or "").strip().lower()
+    if not email_norm:
+        return None
+    group_key = (group_key or "").strip().lower()
+    conn = _connect()
+    try:
+        cur = conn.execute(
+            """
+            SELECT sent_at_utc FROM send_history
+            WHERE email_norm=? AND group_key=?
+            ORDER BY sent_at_utc DESC
+            LIMIT 1
+            """,
+            (email_norm, group_key),
+        )
+        row = cur.fetchone()
+    finally:
+        conn.close()
+    if not row:
+        return None
+    return _parse_datetime(row[0])
+
+
+def last_send_any_group(email_norm: str) -> Optional[Tuple[str, datetime]]:
+    email_norm = (email_norm or "").strip().lower()
+    if not email_norm:
+        return None
+    conn = _connect()
+    try:
+        cur = conn.execute(
+            """
+            SELECT group_key, sent_at_utc FROM send_history
+            WHERE email_norm=?
+            ORDER BY sent_at_utc DESC
+            LIMIT 1
+            """,
+            (email_norm,),
+        )
+        row = cur.fetchone()
+    finally:
+        conn.close()
+    if not row:
+        return None
+    dt = _parse_datetime(row[1])
+    if dt is None:
+        return None
+    return row[0], dt
+
+
+def was_sent_within(email: str, group: str, days: int) -> bool:
+    if days <= 0:
+        return False
+    last = get_last_sent(email, group)
+    if last is None:
+        return False
+    now = datetime.now(timezone.utc)
+    return last >= now - timedelta(days=days)
+
+
+def get_last_sent(email: str, group: str) -> Optional[datetime]:
+    email_norm = _canonical_email(email)
+    if not email_norm:
+        return None
+    group_norm = _canonical_group(group)
+    return last_send(email_norm, group_norm)
+
+
+def was_sent_within_any_group(email: str, days: int) -> bool:
     if days <= 0:
         return False
     email_norm = _canonical_email(email)
     if not email_norm:
         return False
-    grp_norm = _canonical_group(grp)
+    info = last_send_any_group(email_norm)
+    if not info:
+        return False
+    _, last = info
     now = datetime.now(timezone.utc)
-    cutoff_iso = _isoformat(now - timedelta(days=days))
-    with _open() as conn:
-        cur = conn.execute(
-            "SELECT 1 FROM sent WHERE email=? AND grp=? AND sent_at >= ? LIMIT 1",
-            (email_norm, grp_norm, cutoff_iso),
-        )
-        return cur.fetchone() is not None
-
-
-def get_last_sent(email: str, grp: str) -> datetime | None:
-    """Return the most recent send timestamp for ``email``/``grp`` if present."""
-
-    email_norm = _canonical_email(email)
-    if not email_norm:
-        return None
-    grp_norm = _canonical_group(grp)
-    with _open() as conn:
-        cur = conn.execute(
-            "SELECT sent_at FROM sent WHERE email=? AND grp=? ORDER BY sent_at DESC LIMIT 1",
-            (email_norm, grp_norm),
-        )
-        row = cur.fetchone()
-    if not row:
-        return None
-    value = row[0]
-    return _parse_datetime(value)
+    return last >= now - timedelta(days=days)
 
 
 def _legacy_stats_paths() -> Iterable[Path]:
@@ -237,7 +338,7 @@ def _migrate_send_stats(conn: sqlite3.Connection) -> None:
                     if rec.get("status") not in {"success", "ok", "sent"}:
                         continue
                     email = rec.get("email") or ""
-                    grp = rec.get("group") or rec.get("source") or ""
+                    group = rec.get("group") or rec.get("source") or ""
                     ts = rec.get("ts")
                     dt = _parse_datetime(ts)
                     if dt is None:
@@ -246,11 +347,16 @@ def _migrate_send_stats(conn: sqlite3.Connection) -> None:
                         except Exception:
                             dt = datetime.now(timezone.utc)
                     msg_id = rec.get("message_id") or rec.get("msg_id")
-                    row = _prepare_row(email, grp, msg_id, dt)
+                    status = rec.get("status") or "ok"
+                    row = _prepare_row(email, group, msg_id, dt, smtp_result=status)
                     if row is None:
                         continue
                     conn.execute(
-                        "INSERT OR REPLACE INTO sent(email, grp, msg_id, sent_at) VALUES (?, ?, ?, ?)",
+                        """
+                        INSERT OR REPLACE INTO send_history(
+                            email_norm, group_key, sent_at_utc, message_id, run_id, smtp_result
+                        ) VALUES (?, ?, ?, ?, ?, ?)
+                        """,
                         row,
                     )
         except FileNotFoundError:
@@ -264,20 +370,24 @@ def _migrate_sent_log(conn: sqlite3.Connection) -> None:
         try:
             with path.open(encoding="utf-8") as fh:
                 reader = csv.DictReader(fh)
-                for row in reader:
-                    email = row.get("email") or row.get("key") or ""
-                    grp = row.get("source") or row.get("group") or ""
-                    ts = row.get("last_sent_at")
+                for rec in reader:
+                    email = rec.get("email") or rec.get("key") or ""
+                    group = rec.get("source") or rec.get("group") or ""
+                    ts = rec.get("last_sent_at")
                     dt = _parse_datetime(ts)
                     if dt is None:
                         continue
-                    msg_id = row.get("message_id") or row.get("msg_id")
-                    prepared = _prepare_row(email, grp, msg_id, dt)
-                    if prepared is None:
+                    msg_id = rec.get("message_id") or rec.get("msg_id")
+                    row = _prepare_row(email, group, msg_id, dt, smtp_result="ok")
+                    if row is None:
                         continue
                     conn.execute(
-                        "INSERT OR REPLACE INTO sent(email, grp, msg_id, sent_at) VALUES (?, ?, ?, ?)",
-                        prepared,
+                        """
+                        INSERT OR REPLACE INTO send_history(
+                            email_norm, group_key, sent_at_utc, message_id, run_id, smtp_result
+                        ) VALUES (?, ?, ?, ?, ?, ?)
+                        """,
+                        row,
                     )
         except FileNotFoundError:
             continue
@@ -295,7 +405,11 @@ def _run_migrations(conn: sqlite3.Connection) -> None:
 
 __all__ = [
     "init_db",
+    "record_send",
     "record_sent",
     "was_sent_within",
     "get_last_sent",
+    "last_send",
+    "last_send_any_group",
+    "was_sent_within_any_group",
 ]

--- a/tests/test_cooldown.py
+++ b/tests/test_cooldown.py
@@ -64,3 +64,16 @@ def test_should_allow_after_window(cooldown_module):
     skip, reason = cooldown.should_skip_by_cooldown("пример@почта.рф", now=now, days=180)
     assert skip is False
     assert reason == ""
+
+
+def test_should_use_history_registry(cooldown_module):
+    cooldown, _ = cooldown_module
+    from emailbot import history_service
+
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    history_service.ensure_initialized()
+    history_service.mark_sent("history@example.com", "grp", "msg", now - timedelta(days=5))
+
+    skip, reason = cooldown.should_skip_by_cooldown("history@example.com", now=now, days=180)
+    assert skip is True
+    assert "source=history" in reason

--- a/tests/test_history_service.py
+++ b/tests/test_history_service.py
@@ -41,3 +41,9 @@ def test_get_last_sent(monkeypatch):
     last = history_service.get_last_sent("rec@example.com", "grp")
     assert last is not None
     assert abs((last - now).total_seconds()) < 1
+
+    info = history_service.get_last_sent_any_group("rec@example.com")
+    assert info is not None
+    group, last_any = info
+    assert group == "grp"
+    assert abs((last_any - now).total_seconds()) < 1

--- a/utils/email_clean.py
+++ b/utils/email_clean.py
@@ -805,6 +805,17 @@ def normalize_confusables(local: str, domain: str) -> tuple[str, str, bool]:
     new_local = unicodedata.normalize("NFKC", new_local)
     new_domain = unicodedata.normalize("NFKC", new_domain)
 
+    # Не допускаем «смешанных» результатов вроде "Иbah": если после замены
+    # остались символы обоих алфавитов, откатываем изменения, иначе sanitize
+    # забракует адрес как mixed-script-local.
+    if _has_cyrillic(new_local) and _has_latin(new_local):
+        new_local = local
+    if _has_cyrillic(new_domain) and _has_latin(new_domain):
+        new_domain = domain
+
+    if new_local == local and new_domain == domain:
+        return local, domain, False
+
     changed = new_local != local or new_domain != domain
     return new_local, new_domain, changed
 

--- a/utils/email_deobfuscate.py
+++ b/utils/email_deobfuscate.py
@@ -19,9 +19,12 @@ def _word_pattern(base: str) -> str:
 _LOCAL_FRAGMENT = r"[\w.%+\-]{1,64}"
 _DOMAIN_LABEL = r"[A-Za-z0-9-]{1,63}"
 
+# Разделитель между local-part и обфусцированным «at»: хотя бы один не-алфанумерик.
+_AT_SEP = r"\W+"
+
 _PAT_ATS = [
     re.compile(
-        rf"(?P<L>{_LOCAL_FRAGMENT})\s*[\(\[\{{]?\s*(?:{_word_pattern('собака')}|{_word_pattern('at')})\s*[\)\]\}}]?\s*(?P<R>{_DOMAIN_LABEL}(?:\.{_DOMAIN_LABEL})*)",
+        rf"(?P<L>{_LOCAL_FRAGMENT}){_AT_SEP}(?:{_word_pattern('собака')}|{_word_pattern('at')}){_AT_SEP}(?P<R>{_DOMAIN_LABEL}(?:\.{_DOMAIN_LABEL})*)",
         re.IGNORECASE,
     )
 ]


### PR DESCRIPTION
## Summary
- add a WAL-backed SQLite send history registry with migrations and helper queries
- integrate the new history service with cooldown checks, SMTP logging, and edit service path resolution
- harden email deobfuscation/confusable normalization logic and extend tests for the new history features

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc212b8548832682ce703d06c9c7d8