### PR TITLE
Add naive source context tagging for email pipeline

### DIFF
--- a/pipelines/extract_emails.py
+++ b/pipelines/extract_emails.py
@@ -13,7 +13,8 @@ from utils.name_match import extract_names, fio_match_score
 def extract_emails_pipeline(text: str) -> Tuple[List[str], Dict[str, int]]:
     """High-level pipeline that applies deobfuscation, normalization and dedupe."""
 
-    cleaned, meta = parse_emails_unified(text or "", return_meta=True)
+    raw_text = text or ""
+    cleaned, meta = parse_emails_unified(raw_text, return_meta=True)
     unique = dedupe_with_variants(cleaned)
 
     items = meta.get("items", [])
@@ -22,7 +23,7 @@ def extract_emails_pipeline(text: str) -> Tuple[List[str], Dict[str, int]]:
     dropped = sum(1 for item in items if not item.get("sanitized"))
 
     role_stats: Dict[str, int] = {"personal": 0, "role": 0}
-    ctx = text or ""
+    ctx = raw_text
     classified: Dict[str, Dict[str, object]] = {}
     for addr in unique:
         if "@" not in addr:
@@ -35,8 +36,36 @@ def extract_emails_pipeline(text: str) -> Tuple[List[str], Dict[str, int]]:
         role_stats[info_class] += 1
         classified[addr] = info
 
+    # [EBOT-PIPELINE-CONTEXT-004] naive source_context from nearby keywords
+    def guess_context(around: str) -> str:
+        s = around.lower()
+        if any(k in s for k in ("mailto:",)):
+            return "mailto"
+        if any(k in s for k in ("corresponding author", "corresponding", "корреспондир")):
+            return "pdf_corresponding_author"
+        if any(k in s for k in ("author", "автор")):
+            return "author_block"
+        if any(k in s for k in ("footer", "подвал", "copyright")):
+            return "footer"
+        if any(k in s for k in ("contact", "контакт", "связь")):
+            return "contacts"
+        return "unknown"
+
+    window = 180  # chars around email for context
+    contexts: Dict[str, str] = {}
+    raw_text_lower = raw_text.lower()
+    for addr in unique:
+        try:
+            index = raw_text_lower.find(addr.lower())
+            if index >= 0:
+                left = max(0, index - window)
+                right = min(len(raw_text), index + len(addr) + window)
+                contexts[addr] = guess_context(raw_text[left:right])
+        except Exception:
+            contexts[addr] = "unknown"
+
     # [EBOT-PARSER-FIO-003] FIO matching
-    names = extract_names(text or "")
+    names = extract_names(raw_text)
     fio_scores: Dict[str, float] = {}
     for addr in unique:
         if "@" not in addr:
@@ -47,6 +76,7 @@ def extract_emails_pipeline(text: str) -> Tuple[List[str], Dict[str, int]]:
 
     meta["role_stats"] = role_stats
     meta["classified"] = classified
+    meta["source_context"] = contexts
     meta["fio_scores"] = fio_scores
 
     stats = {
@@ -60,6 +90,7 @@ def extract_emails_pipeline(text: str) -> Tuple[List[str], Dict[str, int]]:
         "personal": role_stats.get("personal", 0),
         "role": role_stats.get("role", 0),
         "classified": classified,
+        "contexts_tagged": len(contexts),
         "has_fio": 1 if names else 0,
     }
 

--- a/tests/test_source_context.py
+++ b/tests/test_source_context.py
@@ -1,0 +1,41 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("text", "expected_email", "expected_context"),
+    [
+        ("Contact us at info@example.com", "info@example.com", "contacts"),
+        ("Link: mailto:support@example.com", "support@example.com", "mailto"),
+        (
+            "Corresponding author: cor@example.com",
+            "cor@example.com",
+            "pdf_corresponding_author",
+        ),
+        ("Lead author is lead@example.com", "lead@example.com", "author_block"),
+        ("Footer notes: copy@example.com", "copy@example.com", "footer"),
+        ("Write hi@example.com for details", "hi@example.com", "unknown"),
+    ],
+)
+def test_extract_emails_pipeline_source_context(monkeypatch, text, expected_email, expected_context):
+    captured_meta = {}
+
+    from pipelines import extract_emails as pipeline
+
+    original_parse = pipeline.parse_emails_unified
+
+    def capture_parse(raw_text: str, return_meta: bool = False):
+        cleaned, meta = original_parse(raw_text, return_meta=True)
+        captured_meta["meta"] = meta
+        if return_meta:
+            return cleaned, meta
+        return cleaned
+
+    monkeypatch.setattr(pipeline, "parse_emails_unified", capture_parse)
+
+    emails, stats = pipeline.extract_emails_pipeline(text)
+
+    assert emails == [expected_email]
+    assert stats["contexts_tagged"] == 1
+
+    contexts = captured_meta["meta"]["source_context"]
+    assert contexts.get(expected_email) == expected_context


### PR DESCRIPTION
## Summary
- add heuristics that infer a `source_context` for each extracted email and expose counts via the pipeline stats
- reuse the normalized text for downstream matching utilities
- cover the new tagging logic with parameterized tests

## Testing
- pytest tests/test_source_context.py


------
https://chatgpt.com/codex/tasks/task_e_68cc4e5b60b88326b94da5d496241cae