### PR TITLE
Add scripts to rotate send stats and vacuum state DB

### DIFF
--- a/scripts/rotate_send_stats.py
+++ b/scripts/rotate_send_stats.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+"""Rotate the send stats log when it grows too large."""
+# [EBOT-LOG-ROTATE-006]
+import gzip
+import os
+import shutil
+import time
+from pathlib import Path
+
+PATH = Path(os.getenv("SEND_STATS_PATH", "var/send_stats.jsonl"))
+MAX_SIZE_MB = int(os.getenv("SEND_STATS_MAX_MB", "50"))
+
+
+def main() -> None:
+    """Rotate the send stats file if it exceeds the configured size."""
+    if not PATH.exists():
+        print("no stats file")
+        return
+
+    size_mb = PATH.stat().st_size / (1024 * 1024)
+    if size_mb < MAX_SIZE_MB:
+        print(f"ok ({size_mb:.1f}MB < {MAX_SIZE_MB}MB)")
+        return
+
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    destination = PATH.with_name(f"{PATH.name}.{timestamp}.gz")
+
+    with open(PATH, "rb") as src, gzip.open(destination, "wb", compresslevel=6) as gz:
+        shutil.copyfileobj(src, gz)
+
+    PATH.write_text("")
+    print(f"rotated -> {destination}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/vacuum_state_db.py
+++ b/scripts/vacuum_state_db.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+"""Run VACUUM/optimize on the state database."""
+# [EBOT-LOG-ROTATE-006]
+import os
+import sqlite3
+from pathlib import Path
+
+DB = Path(os.getenv("STATE_DB_PATH", "var/state.db"))
+
+
+def main() -> None:
+    """Ensure the database path exists and vacuum the SQLite file."""
+    DB.parent.mkdir(parents=True, exist_ok=True)
+
+    with sqlite3.connect(DB) as connection:
+        connection.execute("PRAGMA optimize;")
+        connection.execute("VACUUM;")
+
+    print("vacuum done")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a maintenance script that gzips and rotates the send stats JSONL file when it exceeds a configurable size
- add a helper to run PRAGMA optimize and VACUUM on the SQLite state database

## Testing
- python -m compileall scripts/rotate_send_stats.py scripts/vacuum_state_db.py

------
https://chatgpt.com/codex/tasks/task_e_68cc61a8c35c8326a66c70941764a7c5