### PR TITLE
Improve parser resilience to obfuscated email noise

### DIFF
--- a/tests/test_obfuscations.py
+++ b/tests/test_obfuscations.py
@@ -1,0 +1,21 @@
+from utils.email_clean import parse_emails_unified, dedupe_with_variants
+
+CASES = [
+    ("name[at]domain[dot]com", {"name@domain.com"}),
+    ("name(at)university(dot)edu", {"name@university.edu"}),
+    ("mailto:name.surname@domain.com", {"name.surname@domain.com"}),
+    ("name\u2022surname@do\u00b7main.com", {"name.surname@domain.com"}),
+    ("name@do-\nmain.com", {"name@domain.com"}),
+    ("Иванов I. (i.ivanov@uni.ru)", {"i.ivanov@uni.ru"}),
+    (
+        "no-reply@journal.com; editor@journal.com; ivan.ivanov@uni.ru",
+        {"no-reply@journal.com", "editor@journal.com", "ivan.ivanov@uni.ru"},
+    ),
+]
+
+
+def test_obfuscations_and_dedupe():
+    for raw, expected in CASES:
+        cleaned, meta = parse_emails_unified(raw, return_meta=True)
+        uniq = set(dedupe_with_variants(cleaned))
+        assert expected.issubset(uniq)


### PR DESCRIPTION
## Summary
- add regression coverage for OCR-style obfuscations and address deduplication
- auto-enable deobfuscation for obvious `(at)/(dot)` markers and fix dot variants inside domains
- refine sanitize heuristics to keep legitimate local parts while still rejecting glued TLD artifacts

## Testing
- pytest
- pytest tests/test_obfuscations.py

------
https://chatgpt.com/codex/tasks/task_e_68cc6886513c83268ebc8d8dfc8c486f