### PR TITLE
Add SMTP throttle to prevent exceeding per-minute and per-hour limits

### DIFF
--- a/tests/test_smtp_client_throttle.py
+++ b/tests/test_smtp_client_throttle.py
@@ -1,0 +1,68 @@
+import importlib
+from typing import List
+
+import pytest
+
+
+class FakeTime:
+    def __init__(self, start: float) -> None:
+        self.now = start
+        self.sleep_calls: List[float] = []
+
+    def time(self) -> float:
+        return self.now
+
+    def sleep(self, duration: float) -> None:
+        self.sleep_calls.append(duration)
+        self.now += duration
+
+    def advance(self, delta: float) -> None:
+        self.now += delta
+
+
+def _reload_client(monkeypatch: pytest.MonkeyPatch, per_min: str, per_hour: str):
+    monkeypatch.setenv("SMTP_MAX_PER_MIN", per_min)
+    monkeypatch.setenv("SMTP_MAX_PER_HOUR", per_hour)
+    module = importlib.import_module("utils.smtp_client")
+    return importlib.reload(module)
+
+
+@pytest.fixture(autouse=True)
+def _restore_smtp_client_state():
+    module = importlib.import_module("utils.smtp_client")
+    orig_min = module.MAX_PER_MIN
+    orig_hour = module.MAX_PER_HOUR
+    yield
+    module.MAX_PER_MIN = orig_min
+    module.MAX_PER_HOUR = orig_hour
+    module._TS_MIN.clear()
+    module._TS_HOUR.clear()
+
+
+def test_throttle_blocks_when_minute_limit_hit(monkeypatch: pytest.MonkeyPatch):
+    module = _reload_client(monkeypatch, per_min="2", per_hour="10")
+    fake = FakeTime(start=1000.0)
+    monkeypatch.setattr(module, "time", fake)
+
+    module._throttle_block()
+    fake.advance(10)
+    module._throttle_block()
+    fake.advance(5)
+    module._throttle_block()
+
+    assert module.MAX_PER_MIN == 2
+    assert fake.sleep_calls == [pytest.approx(45.0)]
+    assert len(module._TS_MIN) == 2
+
+
+def test_throttle_disabled_when_limits_zero(monkeypatch: pytest.MonkeyPatch):
+    module = _reload_client(monkeypatch, per_min="0", per_hour="0")
+    fake = FakeTime(start=2000.0)
+    monkeypatch.setattr(module, "time", fake)
+
+    for _ in range(3):
+        module._throttle_block()
+
+    assert fake.sleep_calls == []
+    assert len(module._TS_MIN) == 0
+    assert len(module._TS_HOUR) == 0

--- a/utils/smtp_client.py
+++ b/utils/smtp_client.py
@@ -2,11 +2,69 @@ import logging
 import os
 import smtplib
 import time
+from collections import deque
 from email.message import EmailMessage
-from typing import Optional
+from typing import Deque, List, Optional
 
 
 logger = logging.getLogger(__name__)
+
+
+def _parse_limit(env_name: str, default: int) -> int:
+    try:
+        value = int(os.getenv(env_name, str(default)))
+    except Exception:
+        return default
+    return max(0, value)
+
+
+MAX_PER_MIN = _parse_limit("SMTP_MAX_PER_MIN", 20)
+MAX_PER_HOUR = _parse_limit("SMTP_MAX_PER_HOUR", 200)
+_TS_MIN: Deque[float] = deque()
+_TS_HOUR: Deque[float] = deque()
+
+
+def _throttle_block() -> None:
+    if MAX_PER_MIN <= 0 and MAX_PER_HOUR <= 0:
+        _TS_MIN.clear()
+        _TS_HOUR.clear()
+        return
+
+    while True:
+        now = time.time()
+        if MAX_PER_MIN > 0:
+            cutoff_min = now - 60
+            while _TS_MIN and _TS_MIN[0] <= cutoff_min:
+                _TS_MIN.popleft()
+        else:
+            _TS_MIN.clear()
+
+        if MAX_PER_HOUR > 0:
+            cutoff_hour = now - 3600
+            while _TS_HOUR and _TS_HOUR[0] <= cutoff_hour:
+                _TS_HOUR.popleft()
+        else:
+            _TS_HOUR.clear()
+
+        exceeded_min = MAX_PER_MIN > 0 and len(_TS_MIN) >= MAX_PER_MIN
+        exceeded_hour = MAX_PER_HOUR > 0 and len(_TS_HOUR) >= MAX_PER_HOUR
+        if not exceeded_min and not exceeded_hour:
+            break
+
+        waits: List[float] = []
+        if exceeded_min and _TS_MIN:
+            waits.append(max(0.0, 60 - (now - _TS_MIN[0])))
+        if exceeded_hour and _TS_HOUR:
+            waits.append(max(0.0, 3600 - (now - _TS_HOUR[0])))
+
+        wait_for = max(0.1, min(waits) if waits else 0.1)
+        time.sleep(wait_for)
+
+    stamp = time.time()
+    if MAX_PER_MIN > 0:
+        _TS_MIN.append(stamp)
+    if MAX_PER_HOUR > 0:
+        _TS_HOUR.append(stamp)
 
 
 class RobustSMTP:
@@ -85,6 +143,7 @@ def send_with_retry(
 ):
     for attempt in range(retries):
         try:
+            _throttle_block()
             return smtp.send(msg)
         except (
             smtplib.SMTPServerDisconnected,


### PR DESCRIPTION
## Summary
- add an in-process throttle to `send_with_retry` so SMTP sends obey per-minute and per-hour limits from environment variables
- guard the throttle logic with new unit tests covering limit enforcement and disabled configuration

## Testing
- pytest tests/test_smtp_client_throttle.py

------
https://chatgpt.com/codex/tasks/task_e_68cc85bdaa308326b7bb6f21082cf9c9