### PR TITLE
Harden email parser against glued prefixes and non-ASCII locals

### DIFF
--- a/tests/test_email_clean.py
+++ b/tests/test_email_clean.py
@@ -124,3 +124,17 @@ def test_label_length_and_tld_rules():
     assert sanitize_email("user@example.c0m") == ""
     assert sanitize_email("user@example." + "a" * 25) == ""
     assert sanitize_email("user@example." + "a" * 24) == "user@example." + "a" * 24
+
+
+def test_non_ascii_local_is_rejected():
+    assert sanitize_email("россияalexdru9@gmail.com") == ""
+
+
+def test_glued_role_prefix_is_rejected():
+    src = "Россия: russia1elena@example.com"
+    assert parse_emails_unified(src) == []
+
+
+def test_plain_role_address_still_allowed():
+    src = "Связь: support@support.com"
+    assert parse_emails_unified(src) == ["support@support.com"]

--- a/tests/test_email_deobfuscate.py
+++ b/tests/test_email_deobfuscate.py
@@ -14,7 +14,7 @@ def enable_obfuscation(monkeypatch):
 def test_obfuscated_russian_words():
     raw = "Иван (собака) yandex (точка) ru"
     final, _ = run_pipeline_on_text(raw)
-    assert "Иван@yandex.ru".lower() in [e.lower() for e in final]
+    assert final == []
 
 
 def test_obfuscated_english_words():


### PR DESCRIPTION
## Summary
- enforce ASCII-only local validation, guard role-like digit prefixes, and detect glued contexts in the unified parser
- record match spans in meta for debugging and keep sanitize reasons for new rejection modes
- extend email cleaning tests for ASCII locals, glued prefixes, and update obfuscation expectations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd0e867a508326aa3280e13c0cd30e