### PR TITLE
Restrict allowed email TLDs to ru and com

### DIFF
--- a/emailbot/extraction.py
+++ b/emailbot/extraction.py
@@ -38,6 +38,7 @@ from .extraction_pdf import (
 )
 from .extraction_zip import extract_emails_from_zip
 from .settings_store import get
+from utils.tld_utils import is_allowed_domain
 from .reporting import log_extract_digest
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -345,7 +346,10 @@ def smart_extract_emails(text: str, stats: Dict[str, int] | None = None) -> List
         domain_ok = _valid_domain(dom)
         features = {"tld_known": domain_ok}
         if local_ok and domain_ok:
-            if score_candidate(features) >= CANDIDATE_SCORE_THRESHOLD:
+            if not is_allowed_domain(dom):
+                if stats is not None:
+                    stats["foreign_domains"] = stats.get("foreign_domains", 0) + 1
+            elif score_candidate(features) >= CANDIDATE_SCORE_THRESHOLD:
                 emails.append(final_email)
             else:
                 if stats is not None:

--- a/tests/test_canonical_vs_original.py
+++ b/tests/test_canonical_vs_original.py
@@ -23,7 +23,7 @@ def test_yandex_plus_is_removed_in_canonical_only():
 
 
 def test_other_domains_keep_dots():
-    originals = ["name.surname@uni.edu", "namesurname@uni.edu"]
+    originals = ["name.surname@uni.com", "namesurname@uni.com"]
     # для других доменов точки значимы → это не дубли
     keep = dedupe_keep_original(originals)
     assert keep == originals

--- a/tests/test_email_clean.py
+++ b/tests/test_email_clean.py
@@ -123,7 +123,7 @@ def test_label_length_and_tld_rules():
     assert sanitize_email(f"user@{long_label}.com") == ""
     assert sanitize_email("user@example.c0m") == ""
     assert sanitize_email("user@example." + "a" * 25) == ""
-    assert sanitize_email("user@example." + "a" * 24) == "user@example." + "a" * 24
+    assert sanitize_email("user@example." + "a" * 24) == ""
 
 
 def test_non_ascii_local_is_rejected():

--- a/tests/test_email_deobfuscate.py
+++ b/tests/test_email_deobfuscate.py
@@ -20,9 +20,9 @@ def test_obfuscated_russian_words():
 
 
 def test_obfuscated_english_words():
-    raw = "support [at] uni [dot] edu"
+    raw = "support [at] uni [dot] com"
     final, _ = run_pipeline_on_text(raw)
-    assert "support@uni.edu" in final
+    assert "support@uni.com" in final
 
 
 def test_no_false_positive():

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -6,14 +6,14 @@ from emailbot.extraction import smart_extract_emails
 @pytest.mark.parametrize(
     "raw,expected",
     [
-        ("\u00b9ivanov@uni.edu", ["ivanov@uni.edu"]),
-        ("1petrov@uni.edu", ["petrov@uni.edu"]),
-        ("apetrov@uni.edu", ["apetrov@uni.edu"]),
-        ("aivanov@uni.edu", ["aivanov@uni.edu"]),
-        ("name-name@dept.domain.co.uk", ["name-name@dept.domain.co.uk"]),
+        ("\u00b9ivanov@uni.com", ["ivanov@uni.com"]),
+        ("1petrov@uni.com", ["petrov@uni.com"]),
+        ("apetrov@uni.com", ["apetrov@uni.com"]),
+        ("aivanov@uni.com", ["aivanov@uni.com"]),
+        ("name-name@dept.domain.com", ["name-name@dept.domain.com"]),
         (
-            "user+tag_2024%eq=ok/part'one~x@sub-domain.xn--80asehdb",
-            ["user+tag_2024%eq=ok/part'one~x@sub-domain.xn--80asehdb"],
+            "user+tag_2024%eq=ok/part'one~x@sub-domain.com",
+            ["user+tag_2024%eq=ok/part'one~x@sub-domain.com"],
         ),
         ("na.me+tag@domain.ru", ["na.me+tag@domain.ru"]),
         ("name-\nname@domain.ru", ["namename@domain.ru"]),

--- a/tests/test_gold_dataset.py
+++ b/tests/test_gold_dataset.py
@@ -47,7 +47,7 @@ def test_phone_prefix_stripped():
     html = (
         "+7-913-331-52-25stark_velik@mail.ru.\n"
         "01-37-93-11elena-dzhioeva@yandex.ru\n"
-        "normal: user1@site.ru, help@site.org"
+        "normal: user1@site.ru, help@site.com"
     )
     text = strip_html(html)
     stats: dict = {}
@@ -56,7 +56,7 @@ def test_phone_prefix_stripped():
         "stark_velik@mail.ru",
         "elena-dzhioeva@yandex.ru",
         "user1@site.ru",
-        "help@site.org",
+        "help@site.com",
     } <= emails
     assert "+7-913-331-52-25stark_velik@mail.ru" not in emails
     assert "01-37-93elena-dzhioeva@yandex.ru" not in emails
@@ -89,10 +89,10 @@ def test_obfuscations(tmp_path, httpx_file_server):
 
 
 def test_tld_validator():
-    html = "local@site.ru tri@hlon.org a.d@a.message +m@h.abs"
+    html = "local@site.ru tri@hlon.com a.d@a.message +m@h.abs"
     text = strip_html(html)
     stats: dict = {}
     emails = {e.lower() for e in smart_extract_emails(text, stats)}
-    assert emails == {"local@site.ru", "tri@hlon.org"}
+    assert emails == {"local@site.ru", "tri@hlon.com"}
     assert stats.get("invalid_tld", 0) >= 0
 

--- a/tests/test_idna.py
+++ b/tests/test_idna.py
@@ -6,15 +6,14 @@ from utils.email_clean import sanitize_email as _sanitize_email
 def test_unicode_domain_punycode_local_nfc():
     # регресс: домен должен кодироваться как IDNA без подмен букв
     got, reason = _sanitize_email("test@тест.рф")
-    assert reason is None
-    assert got == "test@xn--e1aybc.xn--p1ai"
-    assert unicodedata.is_normalized("NFC", got.split("@", 1)[0])
+    assert got == ""
+    assert reason == "tld-not-allowed"
 
 
 def test_cyrillic_domain_to_punycode():
     got, reason = _sanitize_email("login@почта.рф")
-    assert reason is None
-    assert got == "login@xn--80a1acny.xn--p1ai"
+    assert got == ""
+    assert reason == "tld-not-allowed"
 
 
 def test_mixed_domain_idna():

--- a/tests/test_obfuscations.py
+++ b/tests/test_obfuscations.py
@@ -2,7 +2,7 @@ from utils.email_clean import parse_emails_unified, dedupe_with_variants
 
 CASES = [
     ("name[at]domain[dot]com", {"name@domain.com"}),
-    ("name(at)university(dot)edu", {"name@university.edu"}),
+    ("name(at)university(dot)com", {"name@university.com"}),
     ("mailto:name.surname@domain.com", {"name.surname@domain.com"}),
     ("name\u2022surname@do\u00b7main.com", {"name.surname@domain.com"}),
     ("name@do-\nmain.com", {"name@domain.com"}),

--- a/tests/test_sanitize.py
+++ b/tests/test_sanitize.py
@@ -14,7 +14,7 @@ def test_strip_leading_superscript_footnote_only():
 
 def test_trim_local_part_edges():
     assert sanitize_email("..test-@site.com") == "test@site.com"
-    assert sanitize_email("__user__@example.org") == "user@example.org"
+    assert sanitize_email("__user__@example.com") == "user@example.com"
 
 
 def test_dedupe_with_variants_prefers_clean():

--- a/tests/test_tld_validation.py
+++ b/tests/test_tld_validation.py
@@ -22,7 +22,9 @@ def test_filter_invalid_tld():
 
 def test_smart_extract_skips_unknown_tld():
     text = "+m@h.abs a.d@a.message tri@hlon.org"
-    assert smart_extract_emails(text) == ["tri@hlon.org"]
+    stats = {}
+    assert smart_extract_emails(text, stats) == []
+    assert stats.get("foreign_domains") == 1
 
 
 def test_classify_tld_generic_domestic_foreign():

--- a/tests/test_unified_parser.py
+++ b/tests/test_unified_parser.py
@@ -61,8 +61,9 @@ def test_provider_dedupe_mailru_plus():
 
 def test_unicode_domain_punycode_kept_correct():
     src = "test@тест.рф"
-    got = parse_emails_unified(src)
-    assert got == ["test@xn--e1aybc.xn--p1ai"]
+    emails, meta = parse_emails_unified(src, return_meta=True)
+    assert emails == []
+    assert meta["items"][0]["reason"] == "tld-not-allowed"
 
 
 @pytest.mark.parametrize("flag", ["0", "1"])

--- a/utils/email_clean.py
+++ b/utils/email_clean.py
@@ -12,6 +12,8 @@ from config import CONFUSABLES_NORMALIZE, OBFUSCATION_ENABLE
 from utils.email_deobfuscate import deobfuscate_text
 from utils.email_role import classify_email_role
 
+from utils.tld_utils import is_allowed_domain
+
 logger = logging.getLogger(__name__)
 _FOOTNOTES_MODE = (os.getenv("FOOTNOTES_MODE", "smart") or "smart").lower()
 
@@ -1017,6 +1019,9 @@ def sanitize_email(email: str, strip_footnote: bool = True) -> tuple[str, str | 
     domain_ascii, domain_reason = normalize_domain(domain)
     if not domain_ascii:
         return "", domain_reason or reason
+
+    if not is_allowed_domain(domain_ascii):
+        return "", "tld-not-allowed"
 
     if AGGR and _POPULAR.match(domain_ascii):
         m = _REPAIR_RE.match(local)

--- a/utils/tld_utils.py
+++ b/utils/tld_utils.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import os
+
+_DEFAULT_ALLOWED = {"ru", "com"}
+
+
+def allowed_tlds() -> set[str]:
+    """Return the set of allowed top-level domains."""
+
+    env = os.getenv("TLD_ALLOWED", "")
+    if env.strip():
+        return {
+            t.strip().lstrip(".").lower()
+            for t in env.split(",")
+            if t.strip()
+        }
+    return set(_DEFAULT_ALLOWED)
+
+
+def is_allowed_domain(domain: str) -> bool:
+    """Return ``True`` if the domain belongs to the allow-list."""
+
+    d = (domain or "").strip().lower()
+    if "." not in d:
+        return False
+    tld = d.rsplit(".", 1)[-1]
+    return tld in allowed_tlds()
+
+
+def is_foreign_domain(domain: str) -> bool:
+    """Return ``True`` for domains outside of the allow-list."""
+
+    return not is_allowed_domain(domain)
+
+
+__all__ = ["allowed_tlds", "is_allowed_domain", "is_foreign_domain"]


### PR DESCRIPTION
## Summary
- add a shared TLD allow-list helper limited to `.ru`/`.com`
- enforce the allow-list in sanitisation, extraction, and messaging TLD classification while tracking foreign-domain stats
- refresh tests and fixtures to expect only `.ru`/`.com` addresses and validate the new foreign-domain counter

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd296ae5188326bbdba244dfbbd125