### PR TITLE
Handle per-domain rate limiting and pytest DB isolation

### DIFF
--- a/emailbot/history_service.py
+++ b/emailbot/history_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from threading import Lock
@@ -17,6 +18,16 @@ _INITIALIZED_PATH: Path | None = None
 _DEFAULT_DB_PATH = Path("var/state.db")
 
 
+def _default_db_path() -> Path:
+    """Return default DB path, isolating pytest runs."""
+
+    if os.getenv("PYTEST_CURRENT_TEST"):
+        base = Path(tempfile.gettempdir()) / "emailbot_test_state"
+        base.mkdir(parents=True, exist_ok=True)
+        return base / "state.db"
+    return _DEFAULT_DB_PATH
+
+
 def _resolve_path() -> Path:
     raw = os.getenv("HISTORY_DB_PATH")
     if raw:
@@ -24,7 +35,7 @@ def _resolve_path() -> Path:
         if not path.is_absolute():
             path = Path.cwd() / path
         return path
-    return _DEFAULT_DB_PATH
+    return _default_db_path()
 
 
 def ensure_initialized() -> None:


### PR DESCRIPTION
## Summary
- isolate the default history database location in pytest by redirecting to a temp directory
- enforce a per-domain per-minute send plan with deferrals and per-recipient delivery in the SMTP sender while keeping Run-ID idempotency
- adjust SMTP retry logic to treat 4xx responses as soft bounces and 5xx as hard failures

## Testing
- pytest tests/test_history_service.py tests/test_history_integration.py tests/test_retry_last.py tests/test_messaging.py tests/test_idempotency.py tests/test_limits.py tests/test_rate_limit_logging.py tests/test_smtp_client_throttle.py tests/test_smtp_client_env.py


------
https://chatgpt.com/codex/tasks/task_e_68cd574b67888326b77ab68e154373d5