### PR TITLE
Centralize path handling and normalize env paths

### DIFF
--- a/emailbot/audit.py
+++ b/emailbot/audit.py
@@ -5,24 +5,25 @@ from __future__ import annotations
 import csv
 import os
 from datetime import datetime, timezone
+from pathlib import Path
 
-AUDIT_PATH = os.getenv("AUDIT_PATH", "var/audit.csv")
+from utils.paths import expand_path, ensure_parent
+
+_DEFAULT_AUDIT_PATH = expand_path("var/audit.csv")
+AUDIT_PATH = os.getenv("AUDIT_PATH", str(_DEFAULT_AUDIT_PATH))
 
 
-def _audit_path() -> str:
-    path = os.getenv("AUDIT_PATH", AUDIT_PATH)
-    return path
+def _audit_path() -> Path:
+    return expand_path(os.getenv("AUDIT_PATH", AUDIT_PATH))
 
 
 def write_audit_drop(email: str, reason: str, details: str = "") -> None:
     """Append a drop record to ``audit.csv``."""
 
     path = _audit_path()
-    directory = os.path.dirname(path)
-    if directory:
-        os.makedirs(directory, exist_ok=True)
-    exists = os.path.exists(path)
-    with open(path, "a", newline="", encoding="utf-8") as fp:
+    ensure_parent(path)
+    exists = path.exists()
+    with path.open("a", newline="", encoding="utf-8") as fp:
         writer = csv.writer(fp)
         if not exists:
             writer.writerow(["ts", "email", "action", "reason", "details"])

--- a/emailbot/history_service.py
+++ b/emailbot/history_service.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from threading import Lock
@@ -12,18 +11,18 @@ from typing import Iterable, List, Tuple
 from .extraction_common import normalize_email as _normalize_email
 from . import history_store
 from emailbot.services.cooldown import _env_int
+from utils.paths import expand_path, get_temp_dir
 
 _LOCK = Lock()
 _INITIALIZED_PATH: Path | None = None
-_DEFAULT_DB_PATH = Path("var/state.db")
+_DEFAULT_DB_PATH = expand_path("var/state.db")
 
 
 def _default_db_path() -> Path:
     """Return default DB path, isolating pytest runs."""
 
     if os.getenv("PYTEST_CURRENT_TEST"):
-        base = Path(tempfile.gettempdir()) / "emailbot_test_state"
-        base.mkdir(parents=True, exist_ok=True)
+        base = get_temp_dir("emailbot_test_state")
         return base / "state.db"
     return _DEFAULT_DB_PATH
 
@@ -31,10 +30,7 @@ def _default_db_path() -> Path:
 def _resolve_path() -> Path:
     raw = os.getenv("HISTORY_DB_PATH")
     if raw:
-        path = Path(raw).expanduser()
-        if not path.is_absolute():
-            path = Path.cwd() / path
-        return path
+        return expand_path(raw)
     return _default_db_path()
 
 

--- a/emailbot/history_store.py
+++ b/emailbot/history_store.py
@@ -15,19 +15,17 @@ from threading import Lock
 from typing import Iterable, Optional, Tuple
 
 from .extraction_common import normalize_email as _normalize_email
+from utils.paths import expand_path, ensure_parent
 
 logger = logging.getLogger(__name__)
 
-_DB_PATH: Path = Path("var/state.db")
+_DB_PATH: Path = expand_path("var/state.db")
 _INITIALIZED = False
 _LOCK = Lock()
 
 
 def _ensure_path(path: Path | str) -> Path:
-    path = Path(path)
-    if not path.is_absolute():
-        path = Path.cwd() / path
-    return path
+    return expand_path(path)
 
 
 def init_db(path: Path | str | None = None) -> None:
@@ -36,7 +34,7 @@ def init_db(path: Path | str | None = None) -> None:
     global _DB_PATH, _INITIALIZED
     target = path or _DB_PATH
     resolved = _ensure_path(target)
-    resolved.parent.mkdir(parents=True, exist_ok=True)
+    ensure_parent(resolved)
     with _LOCK:
         conn = sqlite3.connect(resolved)
         try:

--- a/scripts/rotate_send_stats.py
+++ b/scripts/rotate_send_stats.py
@@ -7,7 +7,9 @@ import shutil
 import time
 from pathlib import Path
 
-PATH = Path(os.getenv("SEND_STATS_PATH", "var/send_stats.jsonl"))
+from utils.paths import expand_path
+
+PATH = expand_path(os.getenv("SEND_STATS_PATH", "var/send_stats.jsonl"))
 MAX_SIZE_MB = int(os.getenv("SEND_STATS_MAX_MB", "50"))
 
 

--- a/scripts/vacuum_state_db.py
+++ b/scripts/vacuum_state_db.py
@@ -3,14 +3,15 @@
 # [EBOT-LOG-ROTATE-006]
 import os
 import sqlite3
-from pathlib import Path
 
-DB = Path(os.getenv("STATE_DB_PATH", "var/state.db"))
+from utils.paths import expand_path, ensure_parent
+
+DB = expand_path(os.getenv("STATE_DB_PATH", "var/state.db"))
 
 
 def main() -> None:
     """Ensure the database path exists and vacuum the SQLite file."""
-    DB.parent.mkdir(parents=True, exist_ok=True)
+    ensure_parent(DB)
 
     with sqlite3.connect(DB) as connection:
         connection.execute("PRAGMA optimize;")

--- a/services/templates.py
+++ b/services/templates.py
@@ -5,6 +5,8 @@ import json
 import os
 from typing import Any, Dict, Iterable, Optional
 
+from utils.paths import expand_path
+
 
 def _allowed_exts() -> tuple[str, ...]:
     parts = [
@@ -16,12 +18,7 @@ def _allowed_exts() -> tuple[str, ...]:
 
 
 def _base_dir() -> Path:
-    base = Path(os.getenv("TEMPLATES_DIR", "templates")).expanduser()
-    if not base.is_absolute():
-        base = (Path.cwd() / base).resolve()
-    else:
-        base = base.resolve()
-    return base
+    return expand_path(os.getenv("TEMPLATES_DIR", "templates"))
 
 
 def _labels_path(base: Path) -> Path:

--- a/utils/paths.py
+++ b/utils/paths.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def expand_path(p: str | os.PathLike) -> Path:
+    """Expand environment variables and ``~``, return absolute :class:`Path`."""
+
+    s = os.fspath(p)
+    s = os.path.expandvars(os.path.expanduser(s))
+    return Path(s).resolve()
+
+
+def ensure_parent(path: Path) -> None:
+    """Ensure parent directory for ``path`` exists."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+
+def get_temp_dir(prefix: str = "emailbot") -> Path:
+    """Return process-wide temp directory located under system temp root."""
+
+    base = Path(tempfile.gettempdir()).resolve()
+    d = base / prefix
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def get_temp_file(name: str, prefix: str = "emailbot") -> Path:
+    """Return path to named file inside :func:`get_temp_dir`."""
+
+    return get_temp_dir(prefix) / name

--- a/utils/rules.py
+++ b/utils/rules.py
@@ -5,9 +5,11 @@ import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from utils.paths import expand_path, ensure_parent
+
 REPORT_TZ = os.getenv("REPORT_TZ", "Europe/Moscow")
-HISTORY_PATH = Path(os.getenv("SEND_HISTORY_PATH", "var/send_history.jsonl"))
-BLOCKLIST_PATH = Path(os.getenv("BLOCKLIST_PATH", "var/blocklist.txt"))
+HISTORY_PATH = expand_path(os.getenv("SEND_HISTORY_PATH", "var/send_history.jsonl"))
+BLOCKLIST_PATH = expand_path(os.getenv("BLOCKLIST_PATH", "var/blocklist.txt"))
 MONTHS_WINDOW = int(os.getenv("RULE_MONTHS_WINDOW", "6"))
 
 
@@ -16,8 +18,8 @@ def _now_utc() -> datetime:
 
 
 def ensure_dirs() -> None:
-    HISTORY_PATH.parent.mkdir(parents=True, exist_ok=True)
-    BLOCKLIST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    ensure_parent(HISTORY_PATH)
+    ensure_parent(BLOCKLIST_PATH)
 
 
 def load_blocklist() -> set[str]:

--- a/utils/send_stats.py
+++ b/utils/send_stats.py
@@ -3,21 +3,12 @@ from pathlib import Path
 from datetime import datetime, timedelta, timezone
 
 from emailbot.services.cooldown import normalize_email_for_key
+from utils.paths import expand_path, ensure_parent
 
 try:
     from zoneinfo import ZoneInfo  # py3.9+
 except Exception:  # pragma: no cover - fallback for older Python
     ZoneInfo = None
-
-
-def _resolve_path(p: str) -> Path:
-    """Return absolute path resolving ``~`` and relative segments."""
-
-    path = Path(p).expanduser()
-    if not path.is_absolute():
-        path = Path.cwd() / path
-    return path.resolve()
-
 
 _TZ_NAME = (os.getenv("REPORT_TZ", "Europe/Moscow") or "Europe/Moscow").strip()
 
@@ -29,8 +20,8 @@ def _stats_path() -> Path:
     variable, which is important for tests monkeypatching it.
     """
 
-    path = _resolve_path(os.getenv("SEND_STATS_PATH", "var/send_stats.jsonl"))
-    path.parent.mkdir(parents=True, exist_ok=True)
+    path = expand_path(os.getenv("SEND_STATS_PATH", "var/send_stats.jsonl"))
+    ensure_parent(path)
     return path
 
 


### PR DESCRIPTION
## Summary
- add `utils.paths` helper module to centralize path expansion and temp directory helpers
- ensure email parser debug logging and other env-configured paths resolve to absolute locations and create parent directories before writing
- update services, utilities, and maintenance scripts to reuse the shared path helpers for stats, history, audit, and template files

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd5ee400148326837a3c45bc04ef56