### PR TITLE
Improve email extraction robustness and URL fetching

### DIFF
--- a/crawler/html_to_text.py
+++ b/crawler/html_to_text.py
@@ -1,8 +1,16 @@
 try:
     from html2text import html2text
-except Exception:  # pragma: no cover - fallback if html2text is missing
+except Exception:  # pragma: no cover - safer fallback
+    import re
+
     def html2text(html: str) -> str:  # type: ignore
-        return html
+        # Remove script/style blocks and basic tags when html2text is unavailable.
+        s = re.sub(r"(?is)<(script|style)[^>]*>.*?</\\1>", " ", html or "")
+        s = re.sub(r"(?i)<\s*(br|/p|/div|/li|/tr|/h[1-6])\s*>", "\n", s)
+        s = re.sub(r"(?s)<[^>]+>", " ", s)
+        s = re.sub(r"[\t \x0b\r\f]+", " ", s)
+        s = re.sub(r"\n{2,}", "\n", s)
+        return s.strip()
 
 from utils.email_clean import _normalize_text
 

--- a/emailbot/extraction.py
+++ b/emailbot/extraction.py
@@ -123,7 +123,9 @@ def _is_local_char(ch: str) -> bool:
     return ch.isalnum() or ch in _ATEXT_PUNCT
 
 def _valid_local(local: str) -> bool:
-    if not local or local[0] == "." or local[-1] == "." or ".." in local:
+    if not (1 <= len(local) <= 64):
+        return False
+    if local.startswith(".") or local.endswith(".") or ".." in local:
         return False
     return all(_is_local_char(c) for c in local)
 
@@ -370,7 +372,7 @@ def smart_extract_emails(text: str, stats: Dict[str, int] | None = None) -> List
 
 # --- MANUAL mode (for chat input) ---------------------------------
 
-_EMAIL_CORE = r"[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@(?:[A-Za-z0-9-]+\.)+[A-Za-z]{2,63}"
+_EMAIL_CORE = r"[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+@(?:[A-Za-z0-9-]+\.)+[A-Za-z0-9-]{2,63}"
 _RE_ANGLE = re.compile(rf"<\s*({_EMAIL_CORE})\s*>")
 _RE_MAILTO = re.compile(rf"mailto:\s*({_EMAIL_CORE})", re.IGNORECASE)
 # Универсальная юникод-граница:


### PR DESCRIPTION
## Summary
- add an IDNA-aware domain normalizer and tighten local-part validation
- expand obfuscated email detection and restrict URL fetching based on headers and content type
- enhance the HTML fallback converter when html2text is unavailable

## Testing
- pytest tests/test_normalize_email.py tests/test_tld_validation.py tests/test_idna.py tests/test_manual_parse.py tests/test_url_obfuscation.py tests/test_extraction.py

------
https://chatgpt.com/codex/tasks/task_e_68cda04fe0208326b18947b14df372e2