### PR TITLE
Add generic suspect heuristics and count fix

### DIFF
--- a/tests/test_suspects_generic.py
+++ b/tests/test_suspects_generic.py
@@ -1,0 +1,32 @@
+from utils.email_clean import parse_emails_unified
+
+
+def _emails_meta(src: str):
+    emails, meta = parse_emails_unified(src, return_meta=True)
+    return set(emails), set(meta.get("suspects") or [])
+
+
+def test_long_alpha_run_marked_suspect():
+    # длинная буквенная «простыня» без разделителей (склейка слов)
+    emails, suspects = _emails_meta("russiaanalexan@mail.ru ok@ok.ru")
+    assert "russiaanalexan@mail.ru" in suspects
+
+
+def test_orcid_like_prefix_marked_suspect():
+    emails, suspects = _emails_meta("//orcid.org/0000-0003-2673-01192stolbov210857@mail.ru")
+    assert any(e.endswith("@mail.ru") for e in emails)
+    assert any(e.endswith("@mail.ru") for e in suspects)
+
+
+def test_glued_prev_letter_context_marked_suspect():
+    # Буква слева без разделителя → «склейка» (универсально, без словаря)
+    src = "Контакты:Россияbelyova@mail.ru"
+    emails, suspects = _emails_meta(src)
+    assert "belyova@mail.ru" in emails
+    assert "belyova@mail.ru" in suspects
+
+
+def test_long_digit_head_marked_suspect():
+    emails, suspects = _emails_meta("79082412863@yandex.ru another@site.ru")
+    assert "79082412863@yandex.ru" in emails
+    assert "79082412863@yandex.ru" in suspects


### PR DESCRIPTION
## Summary
- add generic heuristics to flag suspicious e-mails such as glued locals, ORCID-like prefixes, and long digit heads
- expose the suspect list via parsing meta and reuse it in the extraction pipeline, ensuring the suspicious counter is derived from the suspect list
- cover the new heuristics with dedicated unit tests

## Testing
- `pytest tests/test_suspects_generic.py`
- `pytest tests/test_suspects_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_68ce599873108326bb060d4e78b074fe