### PR TITLE
Improve suspect handling and dedupe for glued email variants

### DIFF
--- a/pipelines/extract_emails.py
+++ b/pipelines/extract_emails.py
@@ -7,6 +7,7 @@ from utils.email_clean import (
     dedupe_with_variants,
     finalize_email,
     parse_emails_unified,
+    drop_leading_char_twins,
 )
 from utils.email_role import classify_email_role
 from utils.name_match import fio_candidates, fio_match_score
@@ -76,6 +77,7 @@ def extract_emails_pipeline(text: str) -> Tuple[List[str], Dict[str, int]]:
         blocked = set(suspects)
         send_candidates = [candidate for candidate in send_candidates if candidate not in blocked]
 
+    send_candidates = drop_leading_char_twins(send_candidates)
     unique = dedupe_with_variants(send_candidates)
     meta["items_rejected"] = rejected
     meta["emails_suspects"] = suspects

--- a/tests/test_boundaries_generic.py
+++ b/tests/test_boundaries_generic.py
@@ -1,0 +1,65 @@
+import pytest
+
+from utils import email_clean
+from utils.email_clean import parse_emails_unified
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "ЛюбоеСлово",
+        "Loremipsumdolor",
+        "prefixwithoutspace",
+        "superlongwordprefix",
+        "研究所",
+        "قسم",
+    ],
+)
+def test_left_glued_word_becomes_suspect(prefix, monkeypatch):
+    """Любое слово (любая письменность) слева без разделителя делает адрес подозрительным."""
+
+    monkeypatch.setenv("STRICT_LEFT_BOUNDARY", "1")
+    email_clean.STRICT_LEFT_BOUNDARY = True
+    src = f"{prefix}ivanov@mail.ru"
+    emails, meta = parse_emails_unified(src, return_meta=True)
+    suspects = set(meta.get("suspects") or [])
+    assert suspects
+    if emails:
+        assert set(emails) <= suspects
+
+
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        "Россия",
+        "附加",
+        "قسم",
+        "слово",
+        "研究所",
+    ],
+)
+def test_right_glued_word_becomes_suspect(suffix, monkeypatch):
+    """Любое слово справа без разделителя помечает адрес как подозрительный."""
+
+    monkeypatch.setenv("STRICT_LEFT_BOUNDARY", "1")
+    email_clean.STRICT_LEFT_BOUNDARY = True
+    src = f"ivanov@mail.ru{suffix}"
+    emails, meta = parse_emails_unified(src, return_meta=True)
+    suspects = set(meta.get("suspects") or [])
+    assert suspects
+    if emails:
+        assert set(emails) <= suspects
+
+
+def test_orcid_like_and_long_digits_marked_suspect(monkeypatch):
+    monkeypatch.setenv("STRICT_LEFT_BOUNDARY", "1")
+    email_clean.STRICT_LEFT_BOUNDARY = True
+    src = "0000-0002-1234-5678stolbov@mail.ru 79082412863@yandex.ru"
+    emails, meta = parse_emails_unified(src, return_meta=True)
+    suspects = set(meta.get("suspects") or [])
+    assert "0000-0002-1234-5678stolbov@mail.ru" in suspects
+    assert "79082412863@yandex.ru" in suspects
+    assert set(emails) >= {
+        "0000-0002-1234-5678stolbov@mail.ru",
+        "79082412863@yandex.ru",
+    }

--- a/tests/test_footnote_prefix_dedupe.py
+++ b/tests/test_footnote_prefix_dedupe.py
@@ -1,0 +1,12 @@
+import pytest
+
+from pipelines.extract_emails import extract_emails_pipeline
+
+
+def test_footnote_prefixed_duplicate_removed(monkeypatch):
+    monkeypatch.setenv("SUSPECTS_REQUIRE_CONFIRM", "1")
+    text = "Контакты: 1ivanov@mail.ru; ivanov@mail.ru"
+    allowed, meta = extract_emails_pipeline(text)
+    assert "ivanov@mail.ru" in allowed
+    assert all(not addr.startswith("1ivanov@") for addr in allowed)
+    assert meta["suspicious_count"] == 0

--- a/tests/test_pdf_join_breaks.py
+++ b/tests/test_pdf_join_breaks.py
@@ -1,0 +1,20 @@
+import pytest
+
+from emailbot.extraction_pdf import _join_email_linebreaks, _join_hyphen_breaks
+from utils.email_clean import parse_emails_unified
+
+
+def test_pdf_hyphen_breaks_join(monkeypatch):
+    monkeypatch.setenv("PDF_JOIN_HYPHEN_BREAKS", "1")
+    text = "Почта: jo-\nhn@example.com, другое: te-\nst."
+    result = _join_hyphen_breaks(text)
+    assert "john@example.com" in result
+    assert "test" in result
+
+
+def test_pdf_email_linebreaks_join(monkeypatch):
+    monkeypatch.setenv("PDF_JOIN_EMAIL_BREAKS", "1")
+    text = "Связь: user.\nname@\nmail.\nru"
+    result = _join_email_linebreaks(text)
+    emails, _ = parse_emails_unified(result, return_meta=True)
+    assert "user.name@mail.ru" in set(emails)

--- a/tests/test_tld_tail_repair.py
+++ b/tests/test_tld_tail_repair.py
@@ -1,0 +1,17 @@
+import pytest
+
+from utils.email_clean import sanitize_email
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("user@mail.rurussia", "user@mail.ru"),
+        ("user@test.comcom", "user@test.com"),
+        ("user@site.runet", "user@site.ru"),
+    ],
+)
+def test_domain_tail_repair(raw, expected, monkeypatch):
+    monkeypatch.setenv("REPAIR_TLD_TAIL", "1")
+    cleaned, reason = sanitize_email(raw)
+    assert cleaned == expected, reason


### PR DESCRIPTION
## Summary
- extend the unified parser to surface suspect candidates based on glued boundaries and local-part heuristics, and expose them via sanitize_email metadata
- drop leading-character footnote variants before deduplication so shortened addresses don’t survive the pipeline
- add regression tests for glued boundaries, PDF break repair, TLD tail fixes, and prefixed footnote duplicates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cecc1d807883269bfad57b8c6c5eca