### PR TITLE
Add smoke utilities and stress tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,6 @@ pre-commit
 black
 ruff
 isort
+pytest
+pytest-cov
+playwright>=1.45

--- a/tests/test_accept_confirm_flow_pure.py
+++ b/tests/test_accept_confirm_flow_pure.py
@@ -1,0 +1,38 @@
+"""Unit test for suspect auto-fix helpers used in the confirm flow."""
+
+from __future__ import annotations
+
+import pytest
+
+from utils.email_clean import parse_emails_unified
+
+try:  # pragma: no cover - import guard for optional handlers module
+    from emailbot.bot_handlers import dedupe_keep_original, drop_leading_char_twins
+
+    HAVE_BOT_HELPERS = True
+except Exception:  # pragma: no cover - environments without bot handlers
+    HAVE_BOT_HELPERS = False
+
+
+@pytest.mark.skipif(not HAVE_BOT_HELPERS, reason="bot_helpers not importable in this env")
+def test_accept_suspects_autofix_and_dedupe() -> None:
+    suspects = [
+        "ivanov@mail.ru",
+        "aivanov@mail.ru",
+        "russiaanalexan@mail.ru",
+        " user.name+tag@mail.ru ",
+        "USER.NAME@mail.ru",
+    ]
+
+    text_blob = "\n".join(suspects)
+    fixed, meta = parse_emails_unified(text_blob, return_meta=True)
+    fixed = dedupe_keep_original(fixed)
+    fixed = drop_leading_char_twins(fixed)
+
+    assert "aivanov@mail.ru" in fixed
+    assert "ivanov@mail.ru" not in fixed
+    suspects_meta = set(meta.get("suspects") or [])
+    assert "russiaanalexan@mail.ru" in suspects_meta
+    assert "russiaanalexan@mail.ru" not in fixed
+    canon_like = [email for email in fixed if email.endswith("@mail.ru") and email.startswith("user.name")]
+    assert len(canon_like) == 1, f"expected single canon of user.name@, got: {canon_like}"

--- a/tests/test_pdf_stress_suite.py
+++ b/tests/test_pdf_stress_suite.py
@@ -1,0 +1,39 @@
+"""Stress-tests for PDF extraction edge cases."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from emailbot.extraction_pdf import extract_from_pdf_stream
+from utils.tld_utils import is_allowed_domain
+
+
+PDF_DIR = Path(__file__).resolve().parent / "fixtures/pdfs"
+
+
+def _has_cyrillic(text: str) -> bool:
+    return any("\u0400" <= char <= "\u04FF" for char in text)
+
+
+@pytest.mark.skipif(not PDF_DIR.exists(), reason="no PDF fixtures provided")
+def test_pdf_extract_no_glued_boundaries() -> None:
+    for pdf_path in sorted(PDF_DIR.glob("*.pdf")):
+        data = pdf_path.read_bytes()
+        hits, stats = extract_from_pdf_stream(data, source_ref=str(pdf_path))
+        cleaned = {hit.email for hit in hits}
+        assert all(not _has_cyrillic(email) for email in cleaned), f"{pdf_path} has Cyrillic in emails"
+        assert all(
+            is_allowed_domain(email.split("@", 1)[1])
+            for email in cleaned
+        ), f"{pdf_path} invalid TLD"
+        suspects = set(stats.get("emails_suspects") or stats.get("suspects") or [])
+        assert cleaned.isdisjoint(suspects), f"{pdf_path} suspects leaked into cleaned"
+
+
+@pytest.mark.skipif(not PDF_DIR.exists(), reason="no PDF fixtures provided")
+def test_pdf_handles_hyphen_and_linebreaks() -> None:
+    for pdf_path in sorted(PDF_DIR.glob("*.pdf")):
+        hits, _ = extract_from_pdf_stream(pdf_path.read_bytes(), source_ref=str(pdf_path))
+        assert len({hit.email for hit in hits}) >= 1, f"{pdf_path} yielded zero emails"

--- a/tests/test_site_snapshots.py
+++ b/tests/test_site_snapshots.py
@@ -1,0 +1,27 @@
+"""Smoke-tests for HTML snapshots captured with Playwright."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from emailbot.extraction import extract_from_html_stream
+from utils.tld_utils import is_allowed_domain
+
+
+SITES_DIR = Path(__file__).resolve().parent / "fixtures/sites"
+
+
+@pytest.mark.skipif(not SITES_DIR.exists(), reason="no site snapshots provided")
+def test_snapshots_basic_quality() -> None:
+    for html_path in sorted(SITES_DIR.glob("*.html")):
+        data = html_path.read_bytes()
+        hits, stats = extract_from_html_stream(data, source_ref=str(html_path))
+        cleaned = {hit.email for hit in hits}
+        assert len(cleaned) >= 0
+        for email in cleaned:
+            domain = email.split("@", 1)[1]
+            assert is_allowed_domain(domain), f"{html_path}: bad domain {domain}"
+        suspects = set(stats.get("emails_suspects") or stats.get("suspects") or [])
+        assert cleaned.isdisjoint(suspects), f"{html_path} suspects leaked into cleaned"

--- a/tools/pdf_smoke.py
+++ b/tools/pdf_smoke.py
@@ -1,0 +1,49 @@
+"""Batch PDF smoke-test helper."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from emailbot.extraction_pdf import extract_from_pdf_stream
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PDF_DIR = ROOT / "tests/fixtures/pdfs"
+OUT = ROOT / "var/pdf_smoke_report.jsonl"
+
+
+def run_one(pdf_path: Path) -> dict:
+    data = pdf_path.read_bytes()
+    hits, stats = extract_from_pdf_stream(data, source_ref=str(pdf_path))
+    emails = sorted({hit.email for hit in hits})
+    suspects = stats.get("emails_suspects") or stats.get("suspects") or []
+    return {
+        "file": str(pdf_path),
+        "emails": emails,
+        "emails_count": len(emails),
+        "suspects_count": len(suspects),
+        "stats": {k: v for k, v in stats.items() if isinstance(v, (int, str))},
+    }
+
+
+def main() -> None:
+    if not PDF_DIR.exists():
+        print("[skip] no tests/fixtures/pdfs directory")
+        return
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    with OUT.open("w", encoding="utf-8") as handle:
+        for pdf_path in sorted(PDF_DIR.glob("*.pdf")):
+            try:
+                row = run_one(pdf_path)
+                handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+                print(
+                    f"[ok] {pdf_path.name}: {row['emails_count']} emails "
+                    f"(suspects {row['suspects_count']})"
+                )
+            except Exception as exc:  # pragma: no cover - diagnostic output
+                print(f"[warn] {pdf_path}: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/snapshot_sites.py
+++ b/tools/snapshot_sites.py
@@ -1,0 +1,63 @@
+"""Utility to capture offline HTML snapshots of dynamic sites."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from urllib.parse import quote, urlparse
+
+from playwright.async_api import async_playwright
+
+
+SITES = [
+    "https://biathlonrus.com/union/region/",
+    "https://alpfederation.ru/search/club/#JTdCJTdE",
+    "https://russwimming.ru/federations/",
+    "https://rusclimbing.ru/regions/",
+]
+
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT_DIR = ROOT / "tests/fixtures/sites"
+
+
+def _safe_name(url: str) -> str:
+    parsed = urlparse(url)
+    fragment = f"_{quote(parsed.fragment)}" if parsed.fragment else ""
+    path = f"{parsed.netloc}{parsed.path}{fragment}".strip("/")
+    return path.replace("/", "_") or "index"
+
+
+async def snapshot(url: str, page) -> None:
+    await page.goto(url, wait_until="networkidle", timeout=90_000)
+    await page.wait_for_timeout(1_200)
+    html = await page.content()
+    name = _safe_name(url)
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    (OUT_DIR / f"{name}.html").write_text(html, encoding="utf-8", errors="ignore")
+    meta = {"url": url}
+    (OUT_DIR / f"{name}.json").write_text(
+        json.dumps(meta, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    rel = OUT_DIR.relative_to(ROOT)
+    print(f"[ok] {url} -> {rel}/{name}.html")
+
+
+async def main() -> None:
+    async with async_playwright() as pw:
+        browser = await pw.chromium.launch(headless=True)
+        context = await browser.new_context(locale="ru-RU", user_agent="email-bot QA")
+        page = await context.new_page()
+        for url in SITES:
+            try:
+                await snapshot(url, page)
+            except Exception as exc:  # pragma: no cover - diagnostic output
+                print(f"[warn] {url}: {exc}")
+        await context.close()
+        await browser.close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add Playwright to dev requirements for capturing JS-rendered snapshots
- implement tools to collect site snapshots and generate PDF extraction smoke reports
- add stress tests covering PDF fixtures, site snapshots, and confirm-flow helpers

## Testing
- pytest tests/test_accept_confirm_flow_pure.py tests/test_site_snapshots.py tests/test_pdf_stress_suite.py

------
https://chatgpt.com/codex/tasks/task_e_68ced3a54ef0832687743c2c9acb75e8