### PR TITLE
Track send outcomes and audit bulk sends

### DIFF
--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -7,6 +7,7 @@ import pytest
 from telegram import InlineKeyboardMarkup
 
 import emailbot.bot_handlers as bh
+from emailbot.messaging import SendOutcome
 from emailbot.bot_handlers import (
     SESSION_KEY,
     SessionState,
@@ -399,7 +400,7 @@ def test_send_manual_email_uses_html_template(monkeypatch, tmp_path):
 
     def fake_send(client, imap, folder, addr, path, *a, **kw):
         sent_paths.append(path)
-        return "tok"
+        return SendOutcome.SENT, "tok"
 
     class DummyImap:
         def login(self, *a, **k):
@@ -529,7 +530,7 @@ async def test_manual_send_override_sets_flag(monkeypatch, tmp_path):
 
     def fake_send(client, imap, folder, addr, path, *a, **kw):
         overrides.append(kw.get("override_180d"))
-        return "tok"
+        return SendOutcome.SENT, "tok"
 
     class DummyImap:
         def login(self, *a, **k):
@@ -671,7 +672,7 @@ async def test_manual_send_selective_override(monkeypatch, tmp_path):
 
     def fake_send(client, imap, folder, addr, path, *a, **kw):
         overrides[addr] = kw.get("override_180d")
-        return "tok"
+        return SendOutcome.SENT, "tok"
 
     class DummyImap:
         def login(self, *a, **k):


### PR DESCRIPTION
## Summary
- return send outcomes and guard non-ASCII addresses in send_email_with_sessions
- audit manual bulk sends, count outcomes, and surface cooldown/error stats in Telegram replies
- adapt manual send helper flow and tests to the new SendOutcome-aware interface

## Testing
- pytest tests/test_bot_handlers.py
- pytest tests/test_manual_flow_no_filters.py
- pytest tests/test_reporting.py

------
https://chatgpt.com/codex/tasks/task_e_68d04cd0dde883268f5525ca4c0fff4b