### PR TITLE
Improve parsing and messaging configuration

### DIFF
--- a/emailbot/config.py
+++ b/emailbot/config.py
@@ -1,0 +1,6 @@
+import os
+
+SEND_COOLDOWN_DAYS = int(os.getenv("SEND_COOLDOWN_DAYS", "180"))
+SEND_STATS_PATH = os.getenv("SEND_STATS_PATH", "var/send_stats.jsonl")
+DOMAIN_RATE_LIMIT_SEC = float(os.getenv("DOMAIN_RATE_LIMIT_SEC", "1.0"))
+APPEND_TO_SENT = int(os.getenv("APPEND_TO_SENT", "1")) == 1

--- a/tests/test_parsing_edgecases.py
+++ b/tests/test_parsing_edgecases.py
@@ -1,0 +1,17 @@
+from utils.text_normalize import normalize_text
+from utils.email_clean import parse_emails_unified
+
+
+def test_obfuscated_with_phone_and_footnote():
+    src = "Связь: +7 999 123 45 67 russiaivanov@mail.ru (1) и ivanov at gmail dot com"
+    text = normalize_text(src)
+    emails = parse_emails_unified(text)
+    # «russiaivanov@» не должен попасть в чистые автоматически
+    assert "ivanov@gmail.com" in emails
+    assert all(not x.startswith("russia") for x in emails)
+
+
+def test_domain_glue():
+    src = "Почта: yandex.ru3nekit.maksimovich@mail.ru"
+    emails = parse_emails_unified(normalize_text(src))
+    assert "nekit.maksimovich@mail.ru" in emails or any("nekit" in e for e in emails)


### PR DESCRIPTION
## Summary
- add a central `emailbot.config` module and consume it from the messaging helpers
- emit structured cooldown and append failures while respecting the append-to-sent switch
- extend the unified parser to salvage domain-glued locals with numeric footnotes and cover the cases with regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d07091b0148326b229961fe800e9a1