### PR TITLE
Refine report email classification

### DIFF
--- a/tests/test_report_sets.py
+++ b/tests/test_report_sets.py
@@ -1,0 +1,21 @@
+from emailbot.bot_handlers import _classify_emails
+
+
+def test_disjoint_sets():
+    emails = [
+        "ok@mail.ru",
+        "suspect@mail.ru",
+        "again@mail.ru",
+        "x@qq.com",
+    ]
+    classes = _classify_emails(emails)
+    S_all = classes["all"]
+    S_sus = classes["sus"]
+    S_foreign = classes["foreign"]
+    S_cool = classes["cool"]
+    S_send = classes["send"]
+
+    assert not (S_sus & S_foreign)
+    assert not (S_cool & S_foreign)
+    assert not (S_send & (S_cool | S_sus | S_foreign))
+    assert (S_send | S_cool | S_sus | S_foreign) <= S_all


### PR DESCRIPTION
## Summary
- normalize TLD handling with IDNA support and expose a resilient `is_foreign_domain`
- recompute report sections from disjoint email classes to avoid overlap and refresh counts
- cover the new classifier with a sanity test to ensure the sets stay disjoint

## Testing
- pytest tests/test_report_sets.py tests/test_bot_handlers.py::test_preview_separates_foreign

------
https://chatgpt.com/codex/tasks/task_e_68d130f8c0888326a03d4bd59e5c0873