### PR TITLE
Add explicit send-flow controls before manual mailing

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -100,3 +100,23 @@ def build_templates_kb(
         storage[prefix] = mapping
 
     return InlineKeyboardMarkup(rows)
+
+
+def send_flow_keyboard() -> InlineKeyboardMarkup:
+    """Inline keyboard shown before starting bulk send."""
+
+    return InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton("🚀 Отправить", callback_data="bulk:send:start")],
+            [
+                InlineKeyboardButton(
+                    "↩️ Вернуться / Править", callback_data="bulk:send:back"
+                )
+            ],
+            [
+                InlineKeyboardButton(
+                    "✏️ Исправить адрес", callback_data="bulk:send:edit"
+                )
+            ],
+        ]
+    )

--- a/email_bot.py
+++ b/email_bot.py
@@ -22,6 +22,7 @@ from telegram.ext import (
 )
 
 from emailbot import bot_handlers, messaging
+from emailbot.handlers.manual_send import handle_send_flow_actions
 from emailbot.messaging_utils import SecretFilter
 from emailbot.utils import load_env
 
@@ -280,6 +281,13 @@ def main() -> None:
         app,
         CallbackQueryHandler(bot_handlers.select_group, pattern="^tpl:"),
         "cb:select_group",
+    )
+    _safe_add(
+        app,
+        CallbackQueryHandler(
+            handle_send_flow_actions, pattern=r"^bulk:send:(start|back|edit)$"
+        ),
+        "cb:bulk_send_flow",
     )
     _safe_add(
         app,

--- a/emailbot/bot/keyboards.py
+++ b/emailbot/bot/keyboards.py
@@ -69,3 +69,14 @@ def directions_keyboard(directions: list[str]) -> InlineKeyboardMarkup:
         )
     builder.adjust(1)
     return builder.as_markup()
+
+
+def send_flow_keyboard() -> InlineKeyboardMarkup:
+    """Keyboard shown before sending bulk e-mails."""
+
+    builder = InlineKeyboardBuilder()
+    builder.button(text="🚀 Отправить", callback_data="bulk:send:start")
+    builder.button(text="↩️ Вернуться / Править", callback_data="bulk:send:back")
+    builder.button(text="✏️ Исправить адрес", callback_data="bulk:send:edit")
+    builder.adjust(1)
+    return builder.as_markup()

--- a/emailbot/utils.py
+++ b/emailbot/utils.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from datetime import datetime
 from pathlib import Path
 
@@ -38,3 +39,11 @@ def log_error(msg: str) -> None:
             f.write(f"{datetime.now().isoformat()} {msg}\n")
     except Exception:
         pass
+
+
+try:  # pragma: no cover - optional bridge for legacy imports
+    from . import utils_preview_export as _preview_export
+
+    sys.modules[__name__ + ".preview_export"] = _preview_export
+except Exception:  # pragma: no cover - ignore if optional dependency missing
+    pass

--- a/emailbot/utils_preview_export.py
+++ b/emailbot/utils_preview_export.py
@@ -1,0 +1,52 @@
+"""Helpers for building lightweight preview files."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+try:  # pragma: no cover - optional dependency
+    import pandas as pd  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    pd = None  # type: ignore
+
+
+def _normalize(emails: Iterable[str]) -> list[str]:
+    seen: dict[str, None] = {}
+    result: list[str] = []
+    for email in emails:
+        value = (email or "").strip()
+        if not value or value in seen:
+            continue
+        seen[value] = None
+        result.append(value)
+    return result
+
+
+def build_preview_excel(to_send: Iterable[str], suspects: Iterable[str]) -> str:
+    """Create a lightweight preview file and return its path as string."""
+
+    outdir = Path("var")
+    outdir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    path_xlsx = outdir / f"preview_{timestamp}.xlsx"
+    path_csv = outdir / f"preview_{timestamp}.csv"
+
+    cleaned_to_send = _normalize(to_send)
+    cleaned_suspects = _normalize(suspects)
+
+    if pd is None:
+        content = ["to_send", *cleaned_to_send, "", "suspects", *cleaned_suspects]
+        path_csv.write_text("\n".join(content), encoding="utf-8")
+        return str(path_csv)
+
+    with pd.ExcelWriter(path_xlsx, engine="openpyxl") as writer:  # type: ignore[arg-type]
+        pd.DataFrame({"email": cleaned_to_send}).to_excel(
+            writer, sheet_name="to_send", index=False
+        )
+        pd.DataFrame({"email": cleaned_suspects}).to_excel(
+            writer, sheet_name="suspects", index=False
+        )
+    return str(path_xlsx)
+

--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -367,15 +367,16 @@ async def test_select_group_sends_preview_document(monkeypatch, tmp_path):
     assert path.exists()
     markup = update.callback_query.message.reply_markups[-1]
     assert isinstance(markup, InlineKeyboardMarkup)
-    buttons = markup.inline_keyboard[0]
-    assert buttons[0].callback_data == "start_sending"
-    assert buttons[1].callback_data == "preview_back"
-    assert len(markup.inline_keyboard) >= 2
-    rows = [btn for row in markup.inline_keyboard for btn in row]
-    if C.ALLOW_EDIT_AT_PREVIEW:
-        assert any(button.callback_data == "preview_edit" for button in rows)
-    else:
-        assert all(button.callback_data != "preview_edit" for button in rows)
+    callbacks = [
+        button.callback_data
+        for row in markup.inline_keyboard
+        for button in row
+    ]
+    assert callbacks == [
+        "bulk:send:start",
+        "bulk:send:back",
+        "bulk:send:edit",
+    ]
     assert "Готово к отправке" in update.callback_query.message.replies[-1]
     doc_entry = update.callback_query.message.documents[-1]
     assert doc_entry["name"] and doc_entry["name"].endswith("preview_42.xlsx")


### PR DESCRIPTION
## Summary
- add reusable inline keyboard for send-flow actions and register new callback handler
- introduce a lightweight preview export helper with fallback integration in the preview workflow
- update manual send flow to use the new keyboard without auto prompts and adjust tests accordingly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2645068348326ae0b3c84feff6726