### PR TITLE
Refactor bounce handling and domain rate limiting

### DIFF
--- a/utils/bounce_common.py
+++ b/utils/bounce_common.py
@@ -1,0 +1,69 @@
+import re
+import email
+from email.message import Message
+from email.utils import parsedate_to_datetime
+from datetime import datetime, timezone
+
+BOUNCE_FROM_RE = re.compile(r"(mailer-daemon|postmaster)@", re.I)
+
+
+def is_bounce_from(value: str | None) -> bool:
+    return bool(value and BOUNCE_FROM_RE.search(value))
+
+
+def parse_date_utc(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        dt = parsedate_to_datetime(value)
+    except Exception:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt
+
+
+def extract_original_message(msg: Message) -> Message | None:
+    """Вернуть вложенный оригинал (message/rfc822), если есть."""
+    for part in msg.walk():
+        if part.get_content_type() != "message/rfc822":
+            continue
+        payload = part.get_payload(decode=True)
+        if payload:
+            try:
+                return email.message_from_bytes(payload)
+            except Exception:
+                continue
+        nested = part.get_payload()
+        if isinstance(nested, list) and nested:
+            obj = nested[0]
+            if isinstance(obj, Message):
+                return obj
+    return None
+
+
+def extract_recipient_fallback(msg: Message) -> str:
+    """Попробовать достать получателя из текстовой части (Final-Recipient…)."""
+    rcpt = msg.get("Final-Recipient", "") or msg.get("Original-Recipient", "")
+    if rcpt:
+        return rcpt.split(";")[-1].strip()
+    for part in msg.walk():
+        if part.get_content_type() not in (
+            "message/delivery-status",
+            "text/plain",
+            "text/rfc822-headers",
+        ):
+            continue
+        payload = part.get_payload(decode=True)
+        if not payload:
+            continue
+        try:
+            text = payload.decode(errors="ignore")
+        except AttributeError:
+            text = str(payload)
+        match = re.search(r"Final-Recipient:\s*[^;]+;\s*(\S+)", text, re.I)
+        if match:
+            return match.group(1)
+    return ""

--- a/utils/bounce_pop3.py
+++ b/utils/bounce_pop3.py
@@ -1,54 +1,15 @@
 import os
 import poplib
-import re
 from datetime import datetime, timedelta, timezone
-from email.utils import parsedate_to_datetime
-from email.message import Message
 import email
 
 from .send_stats import log_bounce
-
-
-BOUNCE_FROM = re.compile(r"(mailer-daemon|postmaster)@", re.I)
-
-
-def _parse_date(value: str | None) -> datetime | None:
-    if not value:
-        return None
-    try:
-        dt = parsedate_to_datetime(value)
-    except Exception:
-        return None
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    else:
-        dt = dt.astimezone(timezone.utc)
-    return dt
-
-
-def _extract_original(msg: Message) -> Message | None:
-    for part in msg.walk():
-        if part.get_content_type() != "message/rfc822":
-            continue
-        payload = part.get_payload(decode=True)
-        if payload:
-            try:
-                return email.message_from_bytes(payload)
-            except Exception:
-                continue
-        nested = part.get_payload()
-        if isinstance(nested, list) and nested:
-            obj = nested[0]
-            if isinstance(obj, Message):
-                return obj
-    return None
-
-
-def _extract_recipient(msg: Message) -> str:
-    rcpt = msg.get("Final-Recipient", "") or msg.get("Original-Recipient", "")
-    if rcpt:
-        return rcpt.split(";")[-1].strip()
-    return ""
+from .bounce_common import (
+    is_bounce_from,
+    extract_original_message,
+    extract_recipient_fallback,
+    parse_date_utc,
+)
 
 
 def sync_bounces_pop3() -> int:
@@ -75,13 +36,13 @@ def sync_bounces_pop3() -> int:
             resp, lines, octets = pop.retr(i)
             msg = email.message_from_bytes(b"\r\n".join(lines))
             if cutoff is not None:
-                msg_dt = _parse_date(msg.get("Date"))
+                msg_dt = parse_date_utc(msg.get("Date"))
                 if msg_dt is not None and msg_dt < cutoff:
                     continue
-            if not BOUNCE_FROM.search(msg.get("From", "")):
+            if not is_bounce_from(msg.get("From", "")):
                 continue
 
-            orig = _extract_original(msg)
+            orig = extract_original_message(msg)
             uuid = rcpt = mid = ""
             reason = msg.get("Subject", "(bounce)")
 
@@ -90,23 +51,7 @@ def sync_bounces_pop3() -> int:
                 rcpt = orig.get("X-EBOT-Recipient", "") or orig.get("To", "")
                 mid = orig.get("Message-ID", "")
             else:
-                rcpt = _extract_recipient(msg)
-
-                if not rcpt:
-                    for part in msg.walk():
-                        if part.get_content_type() not in ("message/delivery-status", "text/plain", "text/rfc822-headers"):
-                            continue
-                        payload = part.get_payload(decode=True)
-                        if not payload:
-                            continue
-                        try:
-                            text = payload.decode(errors="ignore")
-                        except AttributeError:
-                            text = str(payload)
-                        match = re.search(r"Final-Recipient:\s*[^;]+;\s*(\S+)", text, re.I)
-                        if match:
-                            rcpt = match.group(1)
-                            break
+                rcpt = extract_recipient_fallback(msg)
 
             if rcpt:
                 log_bounce(rcpt, reason, uuid=uuid, message_id=mid)
@@ -121,4 +66,3 @@ def sync_bounces_pop3() -> int:
                 pop.close()
             except Exception:
                 pass
-


### PR DESCRIPTION
## Summary
- add a shared `bounce_common` helper that centralises bounce detection, parsing original messages and fallback recipient extraction
- update both IMAP and POP3 bounce processors to reuse the shared helpers instead of duplicated logic
- wrap SMTP domain rate limiting state in a `DomainRateLimiter` helper for clearer encapsulation while keeping the public API unchanged

## Testing
- pytest tests/test_smtp_client_throttle.py

------
https://chatgpt.com/codex/tasks/task_e_68d28ee300c4832699e150026578fb64