### PR TITLE
Persist idempotency keys and improve shutdown handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@
 #########################################
 EMAIL_ADDRESS=your_mail@mail.ru              # реальный адрес на mail.ru
 EMAIL_PASSWORD=app_specific_password         # пароль приложения (Mail.ru → Безопасность)
+APPEND_TO_SENT=1                             # дублировать отправку в «Отправленные»
+USE_SMTP_SESSIONS=0                          # 1 = переиспользовать одно SMTP-соединение
 TELEGRAM_BOT_TOKEN=123456:ABCDEF-telegram    # токен от @BotFather
 
 #########################################
@@ -10,10 +12,24 @@ TELEGRAM_BOT_TOKEN=123456:ABCDEF-telegram    # токен от @BotFather
 #########################################
 IMAP_HOST=imap.mail.ru
 IMAP_PORT=993
+IMAP_TIMEOUT=15                              # таймаут соединения, секунд
+IMAP_RETRIES=3                               # кол-во повторов при ошибках
+IMAP_IPV4_ONLY=1                             # 1 = избегать IPv6 (актуально для VPN)
+INBOX_MAILBOX=INBOX                          # папка входящих писем
+SENT_MAILBOX=Отправленные                    # папка «Отправленные» (Mail.ru)
 SMTP_HOST=smtp.mail.ru
-SMTP_PORT=465                               # 465 (SSL) или 587 (STARTTLS)
-SMTP_SSL=1                                  # 1 = SSL, 0 = STARTTLS
-SMTP_TIMEOUT=45                             # таймаут в секундах
+SMTP_PORT=465                                # 465 (SSL) или 587 (STARTTLS)
+SMTP_SSL=1                                   # 1 = SSL, 0 = STARTTLS
+SMTP_TIMEOUT=45                              # таймаут в секундах
+SMTP_MODE=auto                               # auto|ssl|starttls
+SMTP_CONNECT_RETRIES=3                       # повторы при ошибке подключения
+SMTP_CONNECT_BACKOFF=2                       # экспоненциальный бэкофф (секунд)
+
+#########################################
+# Ограничения отправки
+#########################################
+DAILY_SEND_LIMIT=200                         # суточный лимит рассылки
+COOLDOWN_DAYS=180                            # глобальный кулдаун перед повторной отправкой
 
 #########################################
 # Встраивание логотипа (если шаблон поддерживает)
@@ -32,7 +48,6 @@ NOTIFY_LEVEL=brief
 MANUAL_ENFORCE_180=1                        # 1 = применять правило; 0 = не применять
 MANUAL_DAYS=180
 MANUAL_ALLOW_OVERRIDE=1                     # 1 = показать кнопку «Отправить всем»
-COOLDOWN_DAYS=180                           # глобальный кулдаун перед отправкой
 
 #########################################
 # Расширяемый блок-лист (опционально)
@@ -41,25 +56,53 @@ FILTER_SUPPORT=0                            # 1 = блокировать support
 FILTER_BLOCKLIST=help@x.com,alerts@news.io  # CSV-список адресов (или используйте файл blocked_emails.txt)
 
 #########################################
-# Отчёты об отправке
+# Поведение санитайзера / нормализация адресов
+#########################################
+OBFUSCATION_ENABLE=1                        # включить деобфускацию адресов
+CONFUSABLES_NORMALIZE=1                     # нормализовать «похожие» символы
+IDNA_DOMAIN_NORMALIZE=1                     # приводить домены к IDNA (punycode)
+STRICT_DOMAIN_VALIDATE=1                    # строгая проверка доменов
+DROP_REASON_IN_AUDIT=1                      # писать причину дропа в аудит-лог
+FOOTNOTES_MODE=smart
+AGGRESSIVE_LOCAL_REPAIR=1
+STRICT_LEFT_BOUNDARY=1                      # строгая левая граница при парсинге
+SUSPECTS_REQUIRE_CONFIRM=1                  # требовать подтверждения для подозрительных
+REPAIR_TLD_TAIL=1
+PDF_JOIN_HYPHEN_BREAKS=1
+PDF_JOIN_EMAIL_BREAKS=1
+
+#########################################
+# Ограничение на тип e-mail (роль и FIO)
+#########################################
+EMAIL_ROLE_PERSONAL_ONLY=1                  # 1 = пропускать только персональные адреса
+EMAIL_ROLE_PERSONAL_THRESHOLD=0.9           # порог совпадения ФИО для персональных адресов
+
+#########################################
+# Отчёты / логи
 #########################################
 SEND_STATS_PATH=var/send_stats.jsonl
 REPORT_TZ=Europe/Moscow
 
 #########################################
-# Поведение санитайзера
+# Bounce-сканер (fallback POP3, если IMAP недоступен)
 #########################################
-FOOTNOTES_MODE=smart
-AGGRESSIVE_LOCAL_REPAIR=1
+BOUNCE_FETCH_BACKEND=auto                   # auto|imap|pop3
+POP3_HOST=pop.mail.ru
+POP3_PORT=995
+POP3_SSL=1
+POP3_TIMEOUT=20
+BOUNCE_SINCE_DAYS=7                         # глубина сканирования бонсов
 
-# --- Parsing quality toggles (safe by default) ---
-# Строгая левая граница: если перед адресом сразу буква/цифра — помечать как подозрительный
-STRICT_LEFT_BOUNDARY=1
-# Не включать подозрительные в "к отправке" без подтверждения
-SUSPECTS_REQUIRE_CONFIRM=1
-# Ремонт «хвоста» домена до валидной TLD (например, 'rurussia' -> 'ru')
-REPAIR_TLD_TAIL=1
-# Собирать склейки переносов и дефисов в PDF-тексте (A-\nB -> AB)
-PDF_JOIN_HYPHEN_BREAKS=1
-# Собирать разрывы строки внутри адреса вокруг '.' и '@'
-PDF_JOIN_EMAIL_BREAKS=1
+#########################################
+# Парсинг e-mail (отладка)
+#########################################
+DEBUG_EMAIL_PARSE=0
+DEBUG_EMAIL_PARSE_LOG=0
+# DEBUG_EMAIL_PARSE_LOG_PATH=var/email_parse_debug.log
+
+#########################################
+# Подписи/шаблоны — «новый» режим для кодов направлений
+#########################################
+TEMPLATES_NEW_SIGNATURE=bioinformatics,geography,psychology
+
+

--- a/emailbot/utils.py
+++ b/emailbot/utils.py
@@ -6,6 +6,9 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 
+logger = logging.getLogger(__name__)
+
+
 def load_env(script_dir: Path) -> None:
     """Load environment variables from .env files."""
     try:
@@ -25,9 +28,6 @@ def setup_logging(log_file: Path) -> None:
             logging.FileHandler(log_file, encoding="utf-8"),
         ],
     )
-
-
-logger = logging.getLogger(__name__)
 
 
 def log_error(msg: str) -> None:

--- a/pipelines/extract_emails.py
+++ b/pipelines/extract_emails.py
@@ -25,7 +25,16 @@ from utils.name_match import fio_candidates, fio_match_score
 from utils.tld_utils import is_allowed_domain, is_foreign_domain
 
 PERSONAL_ONLY = os.getenv("EMAIL_ROLE_PERSONAL_ONLY", "1") == "1"
-FIO_PERSONAL_THRESHOLD = 0.9
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float((os.getenv(name, "") or "").strip())
+    except Exception:
+        return default
+
+
+FIO_PERSONAL_THRESHOLD = _env_float("EMAIL_ROLE_PERSONAL_THRESHOLD", 0.9)
 
 
 def extract_emails_pipeline(text: str) -> Tuple[List[str], Dict[str, int]]:


### PR DESCRIPTION
## Summary
- load and append persistent idempotency keys for sent messages and record them when sends succeed
- add graceful signal handling, ensure the Telegram error handler is always registered, and refresh config documentation
- allow tuning the FIO personal threshold via environment variables and initialise the logger earlier

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d2bac52c2c8326b5eb7f62feb0623c