### PR TITLE
Improve email pre-cleaning, role filtering, and extraction previews

### DIFF
--- a/utils/email_clean.py
+++ b/utils/email_clean.py
@@ -59,6 +59,40 @@ def strip_invisibles(text: str) -> str:
     return cleaned
 
 
+# --- EB-2025-09-23-13: предочистка типовых обфускаций -----------------------
+
+_ZW_CLEAN_RE = re.compile(r"[\u200B-\u200D\uFEFF\u2060\u180E]")
+_SP_COMPACT_RE = re.compile(r"\s+")
+_AT_WORDS = r"(at|обака|собака|sobaka|\(at\)|\[at\]|\{at\}|\(собака\)|\[собака\]|\{собака\}|\(на\)|\[на\]|\{на\})"
+_DOT_WORDS = r"(dot|точка|tochka|\(dot\)|\[dot\]|\{dot\}|\(точка\)|\[точка\]|\{точка\})"
+_OBF_SEP = r"[\s\(\)\[\]\{\}]*"
+_OBFUSCATION_REPLACEMENTS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(_OBF_SEP + _AT_WORDS + _OBF_SEP, re.IGNORECASE), "@"),
+    (re.compile(_OBF_SEP + _DOT_WORDS + _OBF_SEP, re.IGNORECASE), "."),
+    (re.compile(r"\s*\[\s*@\s*\]\s*"), "@"),
+    (re.compile(r"\s*\(\s*@\s*\)\s*"), "@"),
+    (re.compile(r"\s*\[\s*\.\s*\]\s*"), "."),
+    (re.compile(r"\s*\(\s*\.\s*\)\s*"), "."),
+]
+
+
+def preclean_obfuscations(text: str) -> str:
+    """Нормализует текст до основного парсинга, снимая типовые обфускации."""
+
+    if text is None or text == "":
+        return "" if text == "" else text
+
+    s = unicodedata.normalize("NFKC", str(text))
+    s = _ZW_CLEAN_RE.sub("", s)
+    s = strip_invisibles(s)
+    s = re.sub(r"\s*@\s*", "@", s)
+    s = re.sub(r"\s*\.\s*", ".", s)
+    for regex, replacement in _OBFUSCATION_REPLACEMENTS:
+        s = regex.sub(replacement, s)
+    s = _SP_COMPACT_RE.sub(" ", s)
+    return s.strip()
+
+
 # Внешняя пунктуация, встречающаяся вокруг e-mail при парсинге
 _PUNCT_TRIM_RE = re.compile(
     r'^[\s\(\[\{<«‹"“”„‚’›»>}\]\).,:;—]+|[\s\(\[\{<«‹"“”„‚’›»>}\]\).,:;—]+$'
@@ -1546,3 +1580,5 @@ if "classify_email_role" not in __all__:
     __all__.append("classify_email_role")
 if "finalize_email" not in __all__:
     __all__.append("finalize_email")
+if "preclean_obfuscations" not in __all__:
+    __all__.append("preclean_obfuscations")


### PR DESCRIPTION
## Summary
- add a `preclean_obfuscations` helper to normalize obfuscated addresses and wire it into the extraction pipeline together with early role filtering and new metadata
- extend role-address heuristics and name matching to cover more RU/EN fragments, hyphenated surnames, and dotted initials
- surface a user-friendly extraction preview in bot handlers after manual input, file uploads, and URL scans

## Testing
- pytest tests/test_email_clean.py tests/test_email_role.py tests/test_fio_matching.py
- pytest tests/test_extraction.py
- pytest tests/test_bot_handlers.py

------
https://chatgpt.com/codex/tasks/task_e_68d2e1b1f0f08326befe2634ba570e26