### PR TITLE
Add sections crawl command with path-prefix filtering

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -181,6 +181,7 @@ def main() -> None:
         app, CommandHandler("features", bot_handlers.features), "cmd:features"
     )
     _safe_add(app, CommandHandler("page", bot_handlers.page_url_command), "cmd:page")
+    _safe_add(app, CommandHandler("sections", bot_handlers.sections_command), "cmd:sections")
     _safe_add(
         app, CommandHandler("reports", bot_handlers.handle_reports), "cmd:reports"
     )


### PR DESCRIPTION
## Summary
- add path prefix filtering to the crawler and expose metadata about the applied prefixes
- propagate optional path prefix lists through the extraction pipeline and progress UI
- add a /sections bot command that deep-crawls only the requested sections and shows the filters in status updates

## Testing
- pytest tests/test_batch_isolation.py

------
https://chatgpt.com/codex/tasks/task_e_68d3b33aeaa083268fdf25b661e4b6e4