### PR TITLE
Support reusable section filters for URL parsing

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -9,22 +9,42 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
 
 
-def build_parse_mode_kb(token: str) -> InlineKeyboardMarkup:
+def build_parse_mode_kb(
+    token: str, last_sections: list[str] | None = None
+) -> InlineKeyboardMarkup:
     """Keyboard offering parse mode selection for a detected URL token."""
 
     value = (token or "").strip()
-    return InlineKeyboardMarkup(
+    rows = [
         [
-            [
-                InlineKeyboardButton(
-                    "📄 Только эта страница", callback_data=f"parse|single|{value}"
-                ),
-                InlineKeyboardButton(
-                    "🕸️ Сканировать сайт", callback_data=f"parse|deep|{value}"
-                ),
-            ]
+            InlineKeyboardButton(
+                "📄 Только эта страница", callback_data=f"parse|single|{value}"
+            ),
+            InlineKeyboardButton(
+                "🕸️ Сканировать сайт", callback_data=f"parse|deep|{value}"
+            ),
+        ]
+    ]
+    rows.append(
+        [
+            InlineKeyboardButton(
+                "🕸️ Выбрать разделы…", callback_data=f"parse|sections|{value}"
+            )
         ]
     )
+    if last_sections:
+        human = ", ".join(last_sections[:3])
+        if len(last_sections) > 3:
+            human += "…"
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    f"♻️ Разделы по умолчанию: {human}",
+                    callback_data=f"parse|use_last|{value}",
+                )
+            ]
+        )
+    return InlineKeyboardMarkup(rows)
 
 from services.templates import list_templates
 

--- a/email_bot.py
+++ b/email_bot.py
@@ -323,6 +323,15 @@ def main() -> None:
     )
     _safe_add(
         app,
+        MessageHandler(
+            filters.TEXT & ~filters.COMMAND,
+            bot_handlers.message_router,
+            block=False,
+        ),
+        "msg:router",
+    )
+    _safe_add(
+        app,
         MessageHandler(filters.TEXT & ~filters.COMMAND, bot_handlers.handle_text),
         "msg:handle_text",
     )

--- a/emailbot/sections_prefs.py
+++ b/emailbot/sections_prefs.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+from typing import List
+
+from . import history_store
+
+
+def _db() -> sqlite3.Connection:
+    """Return a SQLite connection ensuring the history database exists."""
+
+    history_store.init_db()
+    return sqlite3.connect(history_store._DB_PATH)
+
+
+def _init() -> None:
+    with _db() as con:
+        con.execute(
+            """
+        CREATE TABLE IF NOT EXISTS sections_prefs (
+            chat_id    INTEGER NOT NULL,
+            domain     TEXT    NOT NULL,
+            prefixes   TEXT    NOT NULL,
+            updated_at INTEGER NOT NULL,
+            PRIMARY KEY (chat_id, domain)
+        )
+        """
+        )
+        con.commit()
+
+
+_init()
+
+
+def save_sections_for_domain(chat_id: int, domain: str, prefixes: List[str]) -> None:
+    """Persist section prefixes for the given chat/domain pair."""
+
+    if not domain or not prefixes:
+        return
+    payload = json.dumps(list(dict.fromkeys(prefixes)))
+    with _db() as con:
+        con.execute(
+            "REPLACE INTO sections_prefs(chat_id, domain, prefixes, updated_at) VALUES (?,?,?,?)",
+            (int(chat_id), domain.lower().strip(), payload, int(time.time())),
+        )
+        con.commit()
+
+
+def get_last_sections_for_domain(chat_id: int, domain: str) -> List[str]:
+    """Return previously stored section prefixes for ``chat_id``/``domain``."""
+
+    if not domain:
+        return []
+    with _db() as con:
+        cur = con.execute(
+            "SELECT prefixes FROM sections_prefs WHERE chat_id=? AND domain=?",
+            (int(chat_id), domain.lower().strip()),
+        )
+        row = cur.fetchone()
+        if not row:
+            return []
+        try:
+            data = json.loads(row[0] or "[]")
+        except Exception:
+            return []
+        result: list[str] = []
+        for item in data:
+            if isinstance(item, str) and item.startswith("/"):
+                result.append(item)
+        return result


### PR DESCRIPTION
## Summary
- persist per-domain section prefixes so the bot can reuse them on future links
- extend the parse mode inline keyboard with buttons to pick sections or reuse saved defaults
- route follow-up messages with selected sections and trigger deep parsing immediately when sections are provided inline

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3bdbed9048326b87d74562d2868b2