### PR TITLE
Handle URL messages early and improve crawl errors

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -191,6 +191,16 @@ def main() -> None:
         "cmd:reports_debug",
     )
 
+    _safe_add(
+        app,
+        MessageHandler(
+            (filters.Entity("url") | filters.Regex(r"https?://\S+"))
+            & ~filters.COMMAND,
+            bot_handlers.message_router,
+        ),
+        "msg:url_router",
+    )
+
     # Inline-кнопки для подозрительных адресов
     _safe_add(
         app,


### PR DESCRIPTION
## Summary
- register a URL-specific message handler so links trigger the parsing router before general text handlers
- extend the router to reuse the parse-mode keyboard when possible and fall back to single-page parsing with clearer failure messaging
- surface HTTP/network failures from the crawler pipeline so users see why a URL could not be fetched

## Testing
- pytest tests/test_bot_handlers.py tests/test_extraction.py

------
https://chatgpt.com/codex/tasks/task_e_68d3ceedabe083268bf2a2630eea915a