### PR TITLE
Improve manual email input routing

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -191,6 +191,7 @@ def main() -> None:
         "cmd:reports_debug",
     )
 
+    # Ловим URL в любом состоянии (до общих текстовых/состояний "жду файл")
     _safe_add(
         app,
         MessageHandler(
@@ -199,6 +200,16 @@ def main() -> None:
             bot_handlers.message_router,
         ),
         "msg:url_router",
+    )
+
+    # Ввод для режима "✉️ Ручная" ловим раньше, чем общий текст
+    _safe_add(
+        app,
+        MessageHandler(
+            filters.TEXT & ~filters.COMMAND,
+            bot_handlers.manual_input_router,  # внутри проверяет state "жду e-mail"
+        ),
+        "msg:manual_input_router",
     )
 
     # Inline-кнопки для подозрительных адресов

--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -5,15 +5,18 @@ import types
 
 import pytest
 from telegram import InlineKeyboardMarkup
+from telegram.ext import ApplicationHandlerStop
 
 import emailbot.bot_handlers as bh
 from emailbot import config as C
 from emailbot.messaging import SendOutcome
 from emailbot.bot_handlers import (
+    MANUAL_WAIT_INPUT,
     SESSION_KEY,
     SessionState,
     handle_document,
     handle_text,
+    manual_input_router,
     start,
 )
 
@@ -278,6 +281,28 @@ def test_handle_text_manual_emails():
     assert "support@support.com — role-like" in drop_reply
 
 
+def test_manual_input_router_summary(monkeypatch):
+    update = DummyUpdate(text="User@example.com other@example.com")
+    ctx = DummyContext()
+    ctx.user_data["state"] = MANUAL_WAIT_INPUT
+    ctx.user_data["awaiting_manual_email"] = True
+
+    monkeypatch.setattr(bh, "should_skip_by_cooldown", lambda email, days=None: (False, ""))
+
+    with pytest.raises(ApplicationHandlerStop):
+        run(manual_input_router(update, ctx))
+
+    assert ctx.user_data.get("state") is None
+    assert ctx.user_data.get("awaiting_manual_email") is False
+    assert update.message.replies
+    assert update.message.replies[0].startswith("✅ Ручная отправка — предпросмотр")
+    assert any("Адреса получены." in text for text in update.message.replies)
+    assert set(ctx.chat_data.get("manual_all_emails", [])) == {
+        "other@example.com",
+        "user@example.com",
+    }
+
+
 def test_prompt_manual_email_clears_previous_list():
     update = DummyUpdate(text="/manual")
     ctx = DummyContext()
@@ -288,6 +313,7 @@ def test_prompt_manual_email_clears_previous_list():
 
     assert "manual_all_emails" not in ctx.chat_data
     assert ctx.user_data["awaiting_manual_email"] is True
+    assert ctx.user_data["state"] == MANUAL_WAIT_INPUT
     assert ctx.user_data.get("awaiting_block_email") is False
 
 


### PR DESCRIPTION
## Summary
- capture URLs for parsing before other text handlers and prioritize manual email router registration
- add a dedicated manual-input router with cooldown-aware summaries and resilient parsing
- refactor manual preview flow to reuse helper logic and update tests for new behaviour

## Testing
- pytest tests/test_bot_handlers.py

------
https://chatgpt.com/codex/tasks/task_e_68d3dc4d36388326bb94d681a48026ab