### PR TITLE
Handle slash-prefixed section responses

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -182,6 +182,13 @@ def main() -> None:
     )
     _safe_add(app, CommandHandler("page", bot_handlers.page_url_command), "cmd:page")
     _safe_add(app, CommandHandler("sections", bot_handlers.sections_command), "cmd:sections")
+    # Когда бот ждёт ввод разделов, ответы вида "/e_arctic" Telegram помечает как COMMAND.
+    # Этот fallback ловит такие "команды" и передаёт их в обработчик разделов.
+    _safe_add(
+        app,
+        MessageHandler(filters.COMMAND, bot_handlers.sections_cmd_fallback),
+        "msg:sections_cmd_fallback",
+    )
     _safe_add(
         app, CommandHandler("reports", bot_handlers.handle_reports), "cmd:reports"
     )


### PR DESCRIPTION
## Summary
- register a command fallback so slash-prefixed section replies reach the section handler when we are waiting for input
- parse slash-style prefixes from command messages, reuse the logic in the router, and clarify the inline prompt text

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3ec588f4c8326a3390621569b6858