### PR TITLE
Improve IMAP sent folder detection and add fix command

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -182,6 +182,7 @@ def main() -> None:
     )
     _safe_add(app, CommandHandler("page", bot_handlers.page_url_command), "cmd:page")
     _safe_add(app, CommandHandler("sections", bot_handlers.sections_command), "cmd:sections")
+    _safe_add(app, CommandHandler("fix_sent", bot_handlers.fix_sent_command), "cmd:fix_sent")
     # Когда бот ждёт ввод разделов, ответы вида "/e_arctic" Telegram помечает как COMMAND.
     # Этот fallback ловит такие "команды" и передаёт их в обработчик разделов.
     _safe_add(

--- a/emailbot/messaging.py
+++ b/emailbot/messaging.py
@@ -44,6 +44,7 @@ from .messaging_utils import (
     detect_sent_folder,
     ensure_aware_utc,
     ensure_sent_log_schema,
+    SENT_CACHE_FILE,
     is_foreign,
     is_hard_bounce,
     is_soft_bounce,
@@ -105,7 +106,7 @@ EMAIL_ADDRESS = ""
 EMAIL_PASSWORD = ""
 SMTP_HOST = os.getenv("SMTP_HOST", "smtp.mail.ru")
 
-IMAP_FOLDER_FILE = SCRIPT_DIR / "imap_sent_folder.txt"
+IMAP_FOLDER_FILE = SENT_CACHE_FILE
 
 _smtp_mode = os.getenv("SMTP_MODE", "auto").strip().lower() or "auto"
 _last_domain_send: Dict[str, float] = {}

--- a/tests/test_detect_sent_folder.py
+++ b/tests/test_detect_sent_folder.py
@@ -2,12 +2,20 @@ from emailbot.messaging_utils import detect_sent_folder
 
 
 class DummyImap:
-    def __init__(self, mailboxes):
+    def __init__(self, mailboxes, selectable=None):
         # формат ответа imap.list(): ('OK', [b'(\\HasNoChildren \\Sent) "/" "Sent"', ...])
         self._mailboxes = mailboxes
+        self._selectable = set(selectable or [])
+        self.selected = []
 
     def list(self):
         return "OK", self._mailboxes
+
+    def select(self, mailbox, readonly=False):
+        self.selected.append(mailbox)
+        if mailbox in self._selectable:
+            return "OK", [b""]
+        return "NO", [b""]
 
 
 def test_detect_sent_folder_prefers_flagged_sent(tmp_path, monkeypatch):
@@ -15,12 +23,14 @@ def test_detect_sent_folder_prefers_flagged_sent(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "emailbot.messaging_utils.SENT_CACHE_FILE", tmp_path / "imap_sent_folder.txt"
     )
+    monkeypatch.delenv("SENT_MAILBOX", raising=False)
     imap = DummyImap(
         [
             b'(\\HasNoChildren) "/" "INBOX"',
             b'(\\HasNoChildren \\Sent) "/" "Sent"',
             b'(\\HasNoChildren) "/" "&BB4EQgQ,BEAEMAQyBDsENQQ9BD0ESwQ1-"',
-        ]
+        ],
+        selectable={"Sent", "Отправленные"},
     )
     sent = detect_sent_folder(imap)
     assert sent == "Sent"
@@ -34,11 +44,13 @@ def test_detect_sent_folder_localized_ru(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "emailbot.messaging_utils.SENT_CACHE_FILE", tmp_path / "imap_sent_folder.txt"
     )
+    monkeypatch.delenv("SENT_MAILBOX", raising=False)
     imap = DummyImap(
         [
             b'(\\HasNoChildren) "/" "INBOX"',
             b'(\\HasNoChildren) "/" "&BB4EQgQ,BEAEMAQyBDsENQQ9BD0ESwQ1-"',
-        ]
+        ],
+        selectable={"Отправленные"},
     )
     sent = detect_sent_folder(imap)
     assert sent == "Отправленные"
@@ -48,7 +60,18 @@ def test_detect_sent_folder_uses_cache(tmp_path, monkeypatch):
     cache = tmp_path / "imap_sent_folder.txt"
     cache.write_text("Sent", encoding="utf-8")
     monkeypatch.setattr("emailbot.messaging_utils.SENT_CACHE_FILE", cache)
+    monkeypatch.delenv("SENT_MAILBOX", raising=False)
     # list не должен вызываться, вернётся кэш
-    imap = DummyImap([])
+    imap = DummyImap([], selectable={"Sent"})
     sent = detect_sent_folder(imap)
     assert sent == "Sent"
+
+
+def test_detect_sent_folder_prefers_env_override(tmp_path, monkeypatch):
+    cache = tmp_path / "imap_sent_folder.txt"
+    monkeypatch.setattr("emailbot.messaging_utils.SENT_CACHE_FILE", cache)
+    monkeypatch.setenv("SENT_MAILBOX", "Custom")
+    imap = DummyImap([], selectable={"Custom"})
+    sent = detect_sent_folder(imap)
+    assert sent == "Custom"
+    assert cache.read_text(encoding="utf-8").strip() == "Custom"


### PR DESCRIPTION
## Summary
- harden IMAP "Sent" folder detection with environment overrides, cache validation, and \Sent flag heuristics shared between modules
- expose a `/fix_sent` command to force re-detection via Telegram and ensure messaging uses the same cache file
- extend tests covering cached, localised and overridden folder detection paths

## Testing
- pytest tests/test_detect_sent_folder.py

------
https://chatgpt.com/codex/tasks/task_e_68d3fd522d4083269edde18feaa324ec