### PR TITLE
Ensure single-instance bot execution and robust IMAP/TG helpers

### DIFF
--- a/emailbot/handlers/manual_send.py
+++ b/emailbot/handlers/manual_send.py
@@ -41,7 +41,7 @@ from emailbot.messaging_utils import (
     suppress_add,
 )
 from emailbot.reporting import build_mass_report_text, log_mass_filter_digest
-from emailbot.utils import log_error
+from emailbot.utils import log_error, safe_send_message
 from utils.smtp_client import RobustSMTP
 
 import emailbot.bot_handlers as bot_handlers_module
@@ -394,7 +394,7 @@ async def send_all(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                 )
                 info_text = "ℹ️ Часть адресов была исключена перед отправкой:\n" + details
                 try:
-                    await context.bot.send_message(chat_id, info_text)
+                    await safe_send_message(context.bot, chat_id, info_text)
                 except Exception:
                     pass
 


### PR DESCRIPTION
## Summary
- enforce a single running bot instance, switch to run_polling, and clean up lifecycle handling
- add a helper for chunked Telegram messages and use it for manual-send notifications
- prioritize .env overrides and localized names when selecting the Sent mailbox, caching under var/

## Testing
- pytest tests/test_detect_sent_folder.py
- pytest tests/test_messaging.py

------
https://chatgpt.com/codex/tasks/task_e_68d43157ddc08326a2e1406b4412ca72