### PR TITLE
Add aiogram entrypoint and manual send skeleton

### DIFF
--- a/README_MIGRATION.md
+++ b/README_MIGRATION.md
@@ -1,0 +1,34 @@
+# EBOT-REV-001 — Миграция на aiogram 3.x
+
+Этот каркас вводит точку входа `python -m emailbot.bot` на базе **aiogram 3.x**
+и объединяет базовые обработчики `/start` и `/send` в новом `Dispatcher`.
+
+## Запуск
+
+```bash
+python -m emailbot.bot
+```
+
+Перед запуском создайте файл `.env` и заполните переменные:
+
+- `TELEGRAM_BOT_TOKEN` — токен Telegram-бота.
+- `EMAIL_ADDRESS` и `EMAIL_PASSWORD` — SMTP-аккаунт для отправки писем.
+- Дополнительно можно указать `SMTP_HOST`, `SMTP_PORT`, `SMTP_STARTTLS`.
+- `COOLDOWN_DAYS` и `SEND_STATS_PATH` — настройки кулдауна и логов отправки.
+
+Библиотека `python-dotenv` подхватывает `.env` автоматически.
+
+## Обработчики
+
+- `/start` и `/help` показывают клавиатуру направлений из `templates/_labels.json`.
+- `/send email@domain.tld | Тема | Текст` валидирует адрес и отправляет письмо через SMTP.
+
+Отправка проходит через общий шлюз `emailbot.aiogram_port.messaging.send_one_email`,
+который проверяет кулдаун, логирует события в `utils.send_stats` и уважает настройку
+`COOLDOWN_DAYS`.
+
+## Дополнительно
+
+- Для Windows (Anaconda PowerShell) добавлен скрипт `run_bot.ps1`.
+- `requirements.delta.txt` содержит подсказку по зависимостям: удалить
+  `python-telegram-bot` и добавить `aiogram`/`python-dotenv`, если ещё не сделано.

--- a/emailbot/aiogram_port/__init__.py
+++ b/emailbot/aiogram_port/__init__.py
@@ -1,0 +1,8 @@
+"""Compatibility layer used by the aiogram entrypoint."""
+
+__all__ = [
+    "cooldown",
+    "logs",
+    "messaging",
+    "smtp_sender",
+]

--- a/emailbot/aiogram_port/cooldown.py
+++ b/emailbot/aiogram_port/cooldown.py
@@ -1,0 +1,24 @@
+"""Lightweight wrapper around the existing cooldown service."""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from emailbot.services import cooldown as cooldown_service
+
+
+def enforce_cooldown(email: str, *, days: Optional[int] = None) -> Tuple[bool, Optional[str]]:
+    """Check whether the cooldown allows sending to ``email`` now."""
+
+    if not email:
+        return False, "empty email"
+    skip, reason = cooldown_service.should_skip_by_cooldown(email, days=days)
+    if skip:
+        return False, reason or "cooldown active"
+    return True, None
+
+
+def mark_sent(email: str) -> None:
+    """Persist send information for subsequent cooldown checks."""
+
+    cooldown_service.mark_sent(email)

--- a/emailbot/aiogram_port/logs.py
+++ b/emailbot/aiogram_port/logs.py
@@ -1,0 +1,24 @@
+"""Helpers for safe logging in the aiogram entrypoint."""
+
+from __future__ import annotations
+
+
+def mask_email(addr: str) -> str:
+    """Return an obfuscated representation of an e-mail for INFO logs."""
+
+    if not addr:
+        return "***"
+    parts = addr.split("@", 1)
+    if len(parts) != 2:
+        return "***"
+    local, domain = parts
+    local = local.strip()
+    if not local:
+        return f"***@{domain}"
+    if len(local) <= 2:
+        prefix = local[:1]
+        suffix = local[-1:]
+    else:
+        prefix = local[:1]
+        suffix = local[-1:]
+    return f"{prefix}***{suffix}@{domain}"

--- a/emailbot/aiogram_port/messaging.py
+++ b/emailbot/aiogram_port/messaging.py
@@ -1,0 +1,65 @@
+"""Messaging helpers for the aiogram entrypoint."""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Dict, Optional, Tuple
+
+from emailbot.aiogram_port import cooldown
+from emailbot.aiogram_port.logs import mask_email
+from emailbot.aiogram_port.smtp_sender import SmtpSender
+from utils import send_stats
+
+_SENDER: Optional[SmtpSender] = None
+
+
+def _get_sender() -> SmtpSender:
+    global _SENDER
+    if _SENDER is None:
+        _SENDER = SmtpSender()
+    return _SENDER
+
+
+def _trace_id() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+async def _send_via_smtp(**kwargs) -> None:
+    sender = _get_sender()
+    await asyncio.to_thread(sender.send, **kwargs)
+
+
+async def send_one_email(
+    to_addr: str,
+    subject: str,
+    body: str,
+    *,
+    source: str,
+    html: Optional[str] = None,
+) -> Tuple[bool, Dict[str, str]]:
+    """Send an e-mail after enforcing cooldown and logging outcomes."""
+
+    trace_id = _trace_id()
+    masked = mask_email(to_addr)
+    allowed, reason = cooldown.enforce_cooldown(to_addr)
+    if not allowed:
+        return False, {
+            "trace_id": trace_id,
+            "masked_to": masked,
+            "reason": reason or "cooldown active",
+        }
+
+    try:
+        await _send_via_smtp(to_addr=to_addr, subject=subject, body=body, html=html)
+    except Exception as exc:  # pragma: no cover - network related
+        send_stats.log_error(to_addr, source, str(exc), {"trace_id": trace_id})
+        return False, {
+            "trace_id": trace_id,
+            "masked_to": masked,
+            "reason": str(exc),
+        }
+
+    cooldown.mark_sent(to_addr)
+    send_stats.log_success(to_addr, source, {"trace_id": trace_id, "subject": subject})
+    return True, {"trace_id": trace_id, "masked_to": masked}

--- a/emailbot/aiogram_port/smtp_sender.py
+++ b/emailbot/aiogram_port/smtp_sender.py
@@ -1,0 +1,80 @@
+"""Simple SMTP sending helper used by the aiogram entrypoint."""
+
+from __future__ import annotations
+
+import os
+import smtplib
+from email.message import EmailMessage
+from typing import Optional
+
+
+def _get_setting(name: str, default=None):
+    value = os.getenv(name)
+    if value is not None:
+        return value
+    try:
+        import emailbot.settings as settings_module  # type: ignore
+
+        if hasattr(settings_module, name):
+            return getattr(settings_module, name)
+    except Exception:
+        pass
+    return default
+
+
+def _as_bool(value) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    text = str(value).strip().lower()
+    return text in {"1", "true", "yes", "on"}
+
+
+class SmtpSender:
+    """Minimal SMTP client with optional STARTTLS support."""
+
+    def __init__(self) -> None:
+        self.host = str(_get_setting("SMTP_HOST", "smtp.mail.ru"))
+        self.port = int(_get_setting("SMTP_PORT", 465))
+        self.starttls = _as_bool(_get_setting("SMTP_STARTTLS", False))
+        self.email_address = _get_setting("EMAIL_ADDRESS")
+        self.email_password = _get_setting("EMAIL_PASSWORD")
+        if not self.email_address or not self.email_password:
+            raise RuntimeError("EMAIL_ADDRESS/EMAIL_PASSWORD must be configured")
+
+    def _connect(self):
+        if self.starttls:
+            client = smtplib.SMTP(self.host, self.port, timeout=30)
+            client.starttls()
+        else:
+            client = smtplib.SMTP_SSL(self.host, self.port, timeout=30)
+        client.login(str(self.email_address), str(self.email_password))
+        return client
+
+    def send(
+        self,
+        *,
+        to_addr: str,
+        subject: str,
+        body: str,
+        html: Optional[str] = None,
+    ) -> None:
+        msg = EmailMessage()
+        msg["Subject"] = subject
+        msg["From"] = str(self.email_address)
+        msg["To"] = to_addr
+        if html:
+            msg.set_content(body or "")
+            msg.add_alternative(html, subtype="html")
+        else:
+            msg.set_content(body or "")
+
+        client = self._connect()
+        try:
+            client.send_message(msg)
+        finally:
+            try:
+                client.quit()
+            except Exception:
+                pass

--- a/emailbot/bot/__main__.py
+++ b/emailbot/bot/__main__.py
@@ -1,0 +1,82 @@
+"""Async entrypoint for the aiogram-based Telegram bot."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+
+from aiogram import Bot, Dispatcher
+from aiogram.types import BotCommand
+from dotenv import load_dotenv
+
+from emailbot.bot.handlers.ingest import router as ingest_router
+from emailbot.bot.handlers.send import router as send_router
+from emailbot.bot.handlers.start import router as start_router
+
+
+def _load_dotenv() -> None:
+    env_file = Path(".env")
+    if env_file.exists():
+        load_dotenv(env_file)
+
+
+def _setup_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+
+
+def _resolve_token() -> str:
+    token = os.getenv("TELEGRAM_BOT_TOKEN")
+    if token:
+        return token
+    try:
+        import emailbot.settings as settings_module  # type: ignore
+
+        value = getattr(settings_module, "TELEGRAM_BOT_TOKEN", None)
+        if value:
+            return str(value)
+    except Exception:
+        pass
+    raise SystemExit("TELEGRAM_BOT_TOKEN is not set (check .env)")
+
+
+async def _set_bot_commands(bot: Bot) -> None:
+    commands = [
+        BotCommand(command="start", description="Запуск меню"),
+        BotCommand(command="help", description="Краткая инструкция"),
+        BotCommand(command="send", description="Ручная отправка письма"),
+    ]
+    try:
+        await bot.set_my_commands(commands)
+    except Exception:
+        logging.getLogger(__name__).debug("Unable to set bot commands", exc_info=True)
+
+
+async def main() -> None:
+    """Run the bot dispatcher until cancelled."""
+
+    _load_dotenv()
+    _setup_logging()
+    token = _resolve_token()
+    bot = Bot(token=token, parse_mode="HTML")
+    dispatcher = Dispatcher()
+    dispatcher.include_router(start_router)
+    dispatcher.include_router(ingest_router)
+    dispatcher.include_router(send_router)
+    await _set_bot_commands(bot)
+    await dispatcher.start_polling(bot, allowed_updates=dispatcher.resolve_used_update_types())
+
+
+if __name__ == "__main__":
+    if sys.platform.startswith("win"):
+        try:  # pragma: no cover - specific to Windows event loop
+            asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # type: ignore[attr-defined]
+        except Exception:
+            pass
+    asyncio.run(main())

--- a/emailbot/bot/handlers/ingest.py
+++ b/emailbot/bot/handlers/ingest.py
@@ -3,23 +3,11 @@
 from __future__ import annotations
 
 from aiogram import Router, F
-from aiogram.types import Message, CallbackQuery
+from aiogram.types import CallbackQuery
 
-from emailbot.bot import keyboards
-from emailbot.settings import list_available_directions, resolve_label
+from emailbot.settings import resolve_label
 
 router = Router()
-
-
-@router.message(F.text == "/start")
-async def start(message: Message) -> None:
-    """Send keyboard with available directions."""
-
-    directions = list_available_directions()
-    await message.answer(
-        "Выберите направление рассылки:",
-        reply_markup=keyboards.directions_keyboard(directions),
-    )
 
 
 @router.callback_query(F.data.startswith("set_group:"))

--- a/emailbot/bot/handlers/send.py
+++ b/emailbot/bot/handlers/send.py
@@ -1,0 +1,64 @@
+"""Manual send command handler for the aiogram bot."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+from aiogram import Router
+from aiogram.filters import Command
+from aiogram.types import Message
+from aiogram.filters import CommandObject
+from email_validator import EmailNotValidError, validate_email
+
+from emailbot.aiogram_port.messaging import send_one_email
+
+router = Router()
+
+
+def _parse_args(raw: str) -> Tuple[str, str, str]:
+    parts = [p.strip() for p in raw.split("|")]
+    if len(parts) < 3:
+        raise ValueError("not enough parts")
+    to_addr = parts[0]
+    subject = parts[1]
+    body = "|".join(parts[2:]).strip()
+    if not to_addr or not subject or not body:
+        raise ValueError("empty component")
+    return to_addr, subject, body
+
+
+@router.message(Command("send"))
+async def send(message: Message, command: CommandObject) -> None:
+    """Parse arguments and delegate to the messaging pipeline."""
+
+    if not command.args:
+        await message.answer("Формат: /send email@domain.tld | Тема | Текст")
+        return
+
+    try:
+        to_addr, subject, body = _parse_args(command.args)
+    except ValueError:
+        await message.answer(
+            "Не удалось разобрать аргументы. Пример: /send x@y.com | Привет | Текст…"
+        )
+        return
+
+    try:
+        result = validate_email(to_addr, check_deliverability=False)
+    except EmailNotValidError as exc:
+        await message.answer(f"Некорректный адрес: {exc}")
+        return
+
+    normalized = result.normalized
+    await message.bot.send_chat_action(message.chat.id, "typing")
+    ok, info = await send_one_email(normalized, subject, body, source="telegram_manual")
+    trace_id = info.get("trace_id", "—")
+    if ok:
+        await message.answer(
+            f"✅ Отправлено на {info.get('masked_to', normalized)} (trace_id={trace_id})"
+        )
+    else:
+        reason = info.get("reason") or "неизвестная ошибка"
+        await message.answer(
+            f"⛔ Не отправлено: {reason} (trace_id={trace_id})"
+        )

--- a/emailbot/bot/handlers/start.py
+++ b/emailbot/bot/handlers/start.py
@@ -1,0 +1,33 @@
+"""Start/help handlers for the aiogram-based bot."""
+
+from __future__ import annotations
+
+from aiogram import Router
+from aiogram.filters import Command, CommandStart
+from aiogram.types import Message
+
+from emailbot.bot import keyboards
+from emailbot.settings import list_available_directions
+
+router = Router()
+
+
+def _start_message() -> str:
+    return (
+        "Привет! Я помогу с рассылкой.\n\n"
+        "• /send email@domain.tld | Тема | Текст — отправка письма вручную.\n"
+        "• Выберите направление из списка ниже, чтобы работать с шаблонами.\n\n"
+        "Правило: один адрес — не чаще раза в 180 дней."
+    )
+
+
+@router.message(CommandStart())
+@router.message(Command("help"))
+async def start(message: Message) -> None:
+    """Reply with instructions and inline keyboard of directions."""
+
+    directions = list_available_directions()
+    keyboard = None
+    if directions:
+        keyboard = keyboards.directions_keyboard(directions)
+    await message.answer(_start_message(), reply_markup=keyboard)

--- a/requirements.delta.txt
+++ b/requirements.delta.txt
@@ -1,0 +1,6 @@
+# Apply on top of the existing requirements when migrating to aiogram.
+
+remove: python-telegram-bot
+add:
+  - aiogram>=3.4,<4
+  - python-dotenv>=1.0

--- a/run_bot.ps1
+++ b/run_bot.ps1
@@ -1,0 +1,11 @@
+# Helper script to launch the aiogram bot on Windows (Anaconda PowerShell).
+
+param()
+
+Write-Host "Activating environment..." -ForegroundColor Cyan
+conda activate emailbot
+
+$env:PYTHONUNBUFFERED = "1"
+
+Write-Host "Starting aiogram bot" -ForegroundColor Green
+python -m emailbot.bot


### PR DESCRIPTION
## Summary
- add `python -m emailbot.bot` entrypoint with aiogram 3 dispatcher and logging setup
- implement /start and /send handlers plus manual send validation and cooldown checks
- introduce isolated aiogram_port helpers for SMTP, cooldown, logging, and docs/scripts for migration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4647a114c8326ab66be707abf5ab8