### PR TITLE
Add Dockerfile and docker-compose for MailHog

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt* setup.cfg .pre-commit-config.yaml ./
+RUN pip install --no-cache-dir -r requirements.txt || true \
+ && pip install --no-cache-dir .
+COPY . .
+ENV PYTHONUNBUFFERED=1
+CMD ["python","email_bot.py","--report"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+services:
+  mailhog:
+    image: mailhog/mailhog
+    ports: ["1025:1025","8025:8025"]
+  bot:
+    build: .
+    environment:
+      SMTP_HOST: mailhog
+      SMTP_PORT: 1025
+      EMAIL_ADDRESS: test@example.com
+      EMAIL_PASSWORD: dummy
+      APPEND_TO_SENT: "0"
+    depends_on: [mailhog]


### PR DESCRIPTION
## Summary
- add a Python 3.11 Dockerfile that installs dependencies and runs the email bot
- add a docker-compose stack with MailHog for local SMTP testing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4f3c6f1b48326b2dc1767ec5fc17f