### PR TITLE
Improve bot env loading and icons path

### DIFF
--- a/emailbot/bot/__main__.py
+++ b/emailbot/bot/__main__.py
@@ -18,9 +18,11 @@ from emailbot.bot.handlers.start import router as start_router
 
 
 def _load_dotenv() -> None:
-    env_file = Path(".env")
+    env_file = Path(__file__).resolve().parent.parent.parent / ".env"
     if env_file.exists():
-        load_dotenv(env_file)
+        load_dotenv(dotenv_path=env_file)
+    else:
+        load_dotenv()
 
 
 def _setup_logging() -> None:
@@ -43,7 +45,7 @@ def _resolve_token() -> str:
             return str(value)
     except Exception:
         pass
-    raise SystemExit("TELEGRAM_BOT_TOKEN is not set (check .env)")
+    raise SystemExit("TELEGRAM_BOT_TOKEN is not set. Specify it in .env or environment.")
 
 
 async def _set_bot_commands(bot: Bot) -> None:

--- a/emailbot/bot/keyboards.py
+++ b/emailbot/bot/keyboards.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import json
 import os
 import unicodedata
+from pathlib import Path
 
 from aiogram.types import InlineKeyboardMarkup
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 
-ICONS_PATH = Path("icons.json")
+_HERE = Path(__file__).resolve().parent
+ICONS_PATH = _HERE / "icons.json"
 _DEFAULT_ICON = "📄"
 
 


### PR DESCRIPTION
## Summary
- load the Telegram bot .env from the project root with a fallback to default search
- clarify the TELEGRAM_BOT_TOKEN missing message and keep command setup intact
- resolve icons.json paths relative to the module for reliable keyboard icons loading

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d50f5429e08326b4edc3e95c2949df