### PR TITLE
Add middleware to log unhandled bot errors

### DIFF
--- a/emailbot/bot/__main__.py
+++ b/emailbot/bot/__main__.py
@@ -68,6 +68,10 @@ async def main() -> None:
     token = _resolve_token()
     bot = Bot(token=token, parse_mode="HTML")
     dispatcher = Dispatcher()
+    from emailbot.bot.middlewares.error_logging import ErrorLoggingMiddleware
+
+    dispatcher.message.middleware(ErrorLoggingMiddleware())
+    dispatcher.callback_query.middleware(ErrorLoggingMiddleware())
     dispatcher.include_router(start_router)
     dispatcher.include_router(ingest_router)
     dispatcher.include_router(send_router)

--- a/emailbot/bot/middlewares/__init__.py
+++ b/emailbot/bot/middlewares/__init__.py
@@ -1,0 +1,5 @@
+"""Middlewares for the emailbot Telegram bot."""
+
+from .error_logging import ErrorLoggingMiddleware
+
+__all__ = ["ErrorLoggingMiddleware"]

--- a/emailbot/bot/middlewares/error_logging.py
+++ b/emailbot/bot/middlewares/error_logging.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Awaitable, Callable
+
+from aiogram import BaseMiddleware
+
+
+logger = logging.getLogger(__name__)
+
+
+class ErrorLoggingMiddleware(BaseMiddleware):
+    async def __call__(
+        self,
+        handler: Callable[[Any, dict[str, Any]], Awaitable[Any]],
+        event: Any,
+        data: dict[str, Any],
+    ) -> Any:
+        try:
+            return await handler(event, data)
+        except Exception:
+            logger.exception(
+                "Unhandled error while processing update: %s",
+                getattr(event, "update_id", "?"),
+            )
+            raise


### PR DESCRIPTION
## Summary
- add an error logging middleware that records unexpected exceptions
- register the middleware for message and callback query updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d51b5b0f98832699b14aeaa03f3979