### PR TITLE
Handle graceful shutdown for bot and SMTP

### DIFF
--- a/emailbot/aiogram_port/messaging.py
+++ b/emailbot/aiogram_port/messaging.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import atexit
 import uuid
 from typing import Dict, Optional, Tuple
 
@@ -19,6 +20,18 @@ def _get_sender() -> SmtpSender:
     if _SENDER is None:
         _SENDER = SmtpSender()
     return _SENDER
+
+
+def _close_sender() -> None:
+    global _SENDER
+    try:
+        if _SENDER is not None:
+            _SENDER.close()
+    finally:
+        _SENDER = None
+
+
+atexit.register(_close_sender)
 
 
 def _trace_id() -> str:


### PR DESCRIPTION
## Summary
- add signal handling and stop event to gracefully stop polling while ensuring the bot session is closed
- close the global SMTP sender via an atexit handler to release resources on shutdown

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d51d3c941c8326a5e6bd17c1db67ec