### PR TITLE
Add adaptive bot creation and error logging middleware

### DIFF
--- a/emailbot/bot/middlewares/error_logging.py
+++ b/emailbot/bot/middlewares/error_logging.py
@@ -1,26 +1,16 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Awaitable, Callable
 
 from aiogram import BaseMiddleware
-
 
 logger = logging.getLogger(__name__)
 
 
 class ErrorLoggingMiddleware(BaseMiddleware):
-    async def __call__(
-        self,
-        handler: Callable[[Any, dict[str, Any]], Awaitable[Any]],
-        event: Any,
-        data: dict[str, Any],
-    ) -> Any:
+    async def __call__(self, handler, event, data):
         try:
             return await handler(event, data)
         except Exception:
-            logger.exception(
-                "Unhandled error while processing update: %s",
-                getattr(event, "update_id", "?"),
-            )
+            logger.exception("Unhandled error while processing update")
             raise


### PR DESCRIPTION
## Summary
- add aiogram version-aware helper to create the Bot with consistent HTML parse mode
- register the error logging middleware defensively and keep dispatcher setup intact
- simplify the error logging middleware to log and re-raise errors consistently

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d522ea6ab88326b4b42b2a8eb78d41