### PR TITLE
Make state path configurable and harden SMTP TLS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-telegram-bot>=20,<21
-aiogram>=3.4,<4
+aiogram>=3.6,<3.9
 aiohttp>=3.9
 pandas>=2.0
 openpyxl>=3.1

--- a/tests/test_icons_path.py
+++ b/tests/test_icons_path.py
@@ -1,0 +1,24 @@
+import json
+from importlib import reload
+from pathlib import Path
+
+
+def test_icons_loaded_from_module_dir(tmp_path, monkeypatch):
+    # подложим icons.json рядом с модулем
+    import emailbot.bot.keyboards as kb
+
+    icons_path = Path(kb.__file__).resolve().parent / "icons.json"
+    backup = None
+    if icons_path.exists():
+        backup = icons_path.read_bytes()
+    try:
+        icons_path.write_text(json.dumps({"bioinformatics": "🧬"}), encoding="utf-8")
+        reload(kb)
+        # _load_icons должен вернуть наши данные
+        icons = kb._load_icons()
+        assert icons.get("bioinformatics") == "🧬"
+    finally:
+        if backup is None:
+            icons_path.unlink(missing_ok=True)
+        else:
+            icons_path.write_bytes(backup)

--- a/tests/test_mass_state_path.py
+++ b/tests/test_mass_state_path.py
@@ -1,0 +1,12 @@
+import os, json, tempfile, importlib
+
+
+def test_mass_state_uses_env_path(monkeypatch, tmp_path):
+    p = tmp_path / "ms.json"
+    monkeypatch.setenv("MASS_STATE_PATH", str(p))
+    mod = importlib.import_module("emailbot.mass_state")
+    state = {"x": 1}
+    mod._state_cache = {"42": state}
+    mod._save_all(state)  # type: ignore[arg-type]
+    data = json.loads(p.read_text(encoding="utf-8"))
+    assert data["42"]["x"] == 1


### PR DESCRIPTION
## Summary
- make the mass mailing state file path configurable, resolving via `utils.paths` and preparing parent directories
- harden the SMTP client by using a strict TLS context, default timeouts, and tolerant STARTTLS handling
- pin `aiogram` to 3.6-3.8 and add regression tests covering state path resolution and keyboard icon loading

## Testing
- `pytest tests/test_mass_state_path.py tests/test_icons_path.py`
- `pytest` *(fails: tests/test_obfuscations.py::test_pipeline_russian_only_ru_com expects tea_88@inbox.ru in output)*

------
https://chatgpt.com/codex/tasks/task_e_68d5237a99c88326a1a7a681a1343c02