### PR TITLE
Remove start router to restore legacy UI

### DIFF
--- a/emailbot/bot/__main__.py
+++ b/emailbot/bot/__main__.py
@@ -15,7 +15,6 @@ from dotenv import load_dotenv
 
 from emailbot.bot.handlers.ingest import router as ingest_router
 from emailbot.bot.handlers.send import router as send_router
-from emailbot.bot.handlers.start import router as start_router
 
 
 def _make_bot(token: str) -> Bot:
@@ -91,7 +90,6 @@ async def main() -> None:
         dispatcher.callback_query.middleware(ErrorLoggingMiddleware())
     except Exception:
         pass
-    dispatcher.include_router(start_router)
     dispatcher.include_router(ingest_router)
     dispatcher.include_router(send_router)
     await _set_bot_commands(bot)


### PR DESCRIPTION
## Summary
- stop registering the new start router so the bot returns to the legacy start flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d529f4a57c8326b2a8bcda05c56786