### PR TITLE
feat: make storage paths configurable

### DIFF
--- a/emailbot/bot/__main__.py
+++ b/emailbot/bot/__main__.py
@@ -11,7 +11,13 @@ from pathlib import Path
 
 from aiogram import Bot, Dispatcher
 from aiogram.types import BotCommand
-from dotenv import load_dotenv
+
+try:  # pragma: no cover - optional dependency
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - optional dependency
+
+    def load_dotenv(*args, **kwargs):
+        return False
 
 from emailbot.bot.handlers.ingest import router as ingest_router
 from emailbot.bot.handlers.send import router as send_router

--- a/emailbot/bot/keyboards.py
+++ b/emailbot/bot/keyboards.py
@@ -10,8 +10,11 @@ from pathlib import Path
 from aiogram.types import InlineKeyboardMarkup
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 
-_HERE = Path(__file__).resolve().parent
-ICONS_PATH = _HERE / "icons.json"
+_ICONS_ENV = os.getenv("DIRECTION_ICONS_PATH")
+if _ICONS_ENV:
+    ICONS_PATH = Path(os.path.expandvars(os.path.expanduser(_ICONS_ENV))).resolve()
+else:
+    ICONS_PATH = Path(__file__).resolve().parents[2] / "icons.json"
 _DEFAULT_ICON = "📄"
 
 

--- a/emailbot/history_store.py
+++ b/emailbot/history_store.py
@@ -407,11 +407,14 @@ def _legacy_stats_paths() -> Iterable[Path]:
 
 def _legacy_sent_log_paths() -> Iterable[Path]:
     seen: set[Path] = set()
-    env = os.getenv("LEGACY_SENT_LOG_PATH")
-    if env:
-        seen.add(_ensure_path(Path(env)))
-    defaults = [Path("/mnt/data/sent_log.csv"), Path("var/sent_log.csv")]
-    for path in list(seen) + defaults:
+    candidates: list[Path | str] = []
+    env_path = os.getenv("LEGACY_SENT_LOG_PATH")
+    if env_path:
+        candidates.append(env_path)
+    else:
+        candidates.append("var/sent_log.csv")
+        candidates.append("/mnt/data/sent_log.csv")
+    for path in candidates:
         resolved = _ensure_path(path)
         if resolved in seen or not resolved.exists():
             continue

--- a/emailbot/mass_state.py
+++ b/emailbot/mass_state.py
@@ -5,7 +5,8 @@ from typing import Any, Dict, Optional
 
 from utils.paths import ensure_parent, expand_path
 
-STATE_PATH: Path = expand_path(os.getenv("MASS_STATE_PATH", "var/mass_state.json"))
+_STATE_ENV = os.getenv("MASS_STATE_PATH", "var/mass_state.json")
+STATE_PATH: Path = expand_path(_STATE_ENV)
 
 # In-memory representation of the persisted state.  The file stores a mapping
 # of ``chat_id`` (as string) to an arbitrary dictionary.  This allows multiple
@@ -44,7 +45,7 @@ def _save_all(state: Dict[str, Dict[str, Any]]) -> None:
         data = _state_cache or {}
 
     ensure_parent(STATE_PATH)
-    tmp = STATE_PATH.with_name(STATE_PATH.name + ".tmp")
+    tmp = STATE_PATH.with_name(f"{STATE_PATH.name}.tmp")
     with tmp.open("w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2)
     os.replace(tmp, STATE_PATH)

--- a/emailbot/messaging.py
+++ b/emailbot/messaging.py
@@ -66,6 +66,7 @@ from .services.cooldown import (
 )
 from utils import rules
 from utils.send_stats import log_error, log_success
+from utils.paths import expand_path
 from utils.smtp_client import RobustSMTP, send_with_retry
 
 logger = logging.getLogger(__name__)
@@ -83,7 +84,8 @@ class SendOutcome(str, Enum):
 # directories located at the repository root.
 SCRIPT_DIR = Path(__file__).resolve().parent.parent
 DOWNLOAD_DIR = str(SCRIPT_DIR / "downloads")
-LOG_FILE = str(Path("/mnt/data") / "sent_log.csv")
+_SENT_LOG_ENV = os.getenv("SENT_LOG_PATH", "var/sent_log.csv")
+LOG_FILE = str(expand_path(_SENT_LOG_ENV))
 BLOCKED_FILE = str(SCRIPT_DIR / "blocked_emails.txt")
 MAX_EMAILS_PER_DAY = int(os.getenv("DAILY_SEND_LIMIT", str(S.DAILY_SEND_LIMIT)))
 _ASCII_LOCAL_RX = re.compile(r"^[\x21-\x7E]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$")

--- a/emailbot/settings_store.py
+++ b/emailbot/settings_store.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
+
+from utils.paths import ensure_parent, expand_path
 
 
 DEFAULTS = {
@@ -18,7 +21,8 @@ DEFAULTS = {
     "EXTERNAL_SOURCES": {},
 }
 
-SETTINGS_PATH = Path("/mnt/data/settings.json")
+_SETTINGS_ENV = os.getenv("SETTINGS_PATH", "var/settings.json")
+SETTINGS_PATH: Path = expand_path(_SETTINGS_ENV)
 _cache: dict[str, Any] | None = None
 _mtime: float = 0.0
 
@@ -45,7 +49,7 @@ def _ensure_defaults() -> dict[str, Any]:
             changed = True
     if changed:
         try:
-            SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+            ensure_parent(SETTINGS_PATH)
             SETTINGS_PATH.write_text(json.dumps(data), encoding="utf-8")
             stat = SETTINGS_PATH.stat()
             global _mtime, _cache
@@ -77,7 +81,7 @@ def set(name: str, value: Any) -> None:
     data = _load()
     data[name] = value
     try:
-        SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+        ensure_parent(SETTINGS_PATH)
         SETTINGS_PATH.write_text(json.dumps(data), encoding="utf-8")
     except Exception:
         pass


### PR DESCRIPTION
## Summary
- make persisted state, settings, and messaging cache/log files configurable via environment variables with automatic directory creation
- update messaging and history modules to honour new path overrides and maintain atomic writes
- improve bot startup robustness by handling missing python-dotenv and locating keyboard icons relative to the project root

## Testing
- `pytest tests/test_messaging_utils.py tests/test_history_store.py`


------
https://chatgpt.com/codex/tasks/task_e_68d53c35a3588326b6d19452e3405f89