### PR TITLE
Auto include bot routers and improve icon path detection

### DIFF
--- a/emailbot/bot/keyboards.py
+++ b/emailbot/bot/keyboards.py
@@ -10,11 +10,20 @@ from pathlib import Path
 from aiogram.types import InlineKeyboardMarkup
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 
-_ICONS_ENV = os.getenv("DIRECTION_ICONS_PATH")
-if _ICONS_ENV:
-    ICONS_PATH = Path(os.path.expandvars(os.path.expanduser(_ICONS_ENV))).resolve()
-else:
-    ICONS_PATH = Path(__file__).resolve().parents[2] / "icons.json"
+def _resolve_icons_path() -> Path:
+    override = os.getenv("DIRECTION_ICONS_PATH")
+    if override:
+        return Path(os.path.expandvars(os.path.expanduser(override))).resolve()
+
+    module_dir = Path(__file__).resolve().parent
+    module_local = module_dir / "icons.json"
+    if module_local.exists():
+        return module_local
+
+    return module_dir.parents[1] / "icons.json"
+
+
+ICONS_PATH = _resolve_icons_path()
 _DEFAULT_ICON = "📄"
 
 


### PR DESCRIPTION
## Summary
- automatically discover and include all aiogram routers from the handlers package
- refine direction icons path detection to prioritize module-local overrides while keeping env overrides

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d54adba10c832687be712b02b2fa60