### PR TITLE
Normalize recipients before sending emails

### DIFF
--- a/tests/test_apply_edits_in_send.py
+++ b/tests/test_apply_edits_in_send.py
@@ -1,0 +1,28 @@
+from emailbot.messaging_utils import prepare_recipients_for_send
+
+
+def test_trailing_cyrillic_tail_is_removed(monkeypatch):
+    monkeypatch.setattr(
+        "emailbot.edit_service.load_edits",
+        lambda: {"MAP": {}, "DROP": set()},
+    )
+    good, dropped, remap = prepare_recipients_for_send(["user@example.ru кафедра"])
+    assert good == ["user@example.ru"]
+    assert not dropped
+    assert remap["user@example.ru кафедра"] == "user@example.ru"
+
+
+def test_edits_drop_and_map(monkeypatch):
+    monkeypatch.setattr(
+        "emailbot.edit_service.load_edits",
+        lambda: {
+            "DROP": ["bad@host.tld"],
+            "MAP": {"wrong@host.tld": "right@host.tld"},
+        },
+    )
+    good, dropped, remap = prepare_recipients_for_send(
+        ["bad@host.tld", "wrong@host.tld"]
+    )
+    assert "bad@host.tld" in dropped
+    assert good == ["right@host.tld"]
+    assert remap["wrong@host.tld"] == "right@host.tld"

--- a/utils/email_norm.py
+++ b/utils/email_norm.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import re
 
 # Strict e-mail matcher with named groups for local and domain parts
-_RX = re.compile(r"(?i)\b(?P<local>[a-z0-9._%+-]+)@(?P<domain>[a-z0-9.-]+\.[a-z]{2,})\b")
+_RX = re.compile(
+    r"(?i)\b(?P<local>[-a-z0-9!#$%&'*+/=?^_`{|}~./]+)@(?P<domain>[a-z0-9.-]+\.[a-z]{2,})\b"
+)
 
 
 def sanitize_for_send(addr: str) -> str:


### PR DESCRIPTION
## Summary
- add a shared prepare_recipients_for_send helper that sanitises addresses, applies saved edits, and reports dropped or remapped emails
- switch the aiogram single-send flow and manual /send handler to use the central preprocessing before attempting delivery
- expand email extraction cleanup and regex handling to strip glued Russian words, sanitise final results, and cover RFC atext in sanitize_for_send; add regression tests for the preprocessing pipeline

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d651788cf4832689694fc75ae7dd61