### PR TITLE
Add resilient entrypoint discovery and pin PTB to 20.8

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -1,35 +1,32 @@
-# Точка входа как раньше:  python email_bot.py
-# Ничего не меняет в логике/UI — лишь проксирует вызов в основной main().
 from importlib import import_module
 
-_CANDIDATE_MODULES = [
+# Порядок важен: сначала старые точки входа, затем новые.
+CANDIDATES = [
     ("emailbot.messaging_utils", ("main", "run", "start")),
     ("emailbot.messaging",      ("main", "run", "start")),
-    ("emailbot.bot.__main__",   ("main", "run", "start")),  # на случай если main расположен здесь
+    ("emailbot.bot.__main__",   ("main", "run", "start")),
 ]
 
 
-def _resolve_entrypoint():
-    errors = []
-    for mod_name, names in _CANDIDATE_MODULES:
+def resolve_entrypoint():
+    for mod_name, names in CANDIDATES:
         try:
             mod = import_module(mod_name)
-            for attr in names:
-                fn = getattr(mod, attr, None)
+            for name in names:
+                fn = getattr(mod, name, None)
                 if callable(fn):
                     return fn
-        except Exception as e:
-            errors.append(f"{mod_name}: {e}")
-            continue
+        except Exception:
+            # Переходим к следующему варианту
+            pass
     raise SystemExit(
-        "Не найден main()/run()/start() в известных модулях.\n"
-        "Проверьте, где у вас фактический вход, и при необходимости добавьте его в список _CANDIDATE_MODULES."
+        "Не найдено ни одной точки входа (main/run/start). "
+        "Уточните, в каком модуле она находится, и добавьте его в CANDIDATES."
     )
 
 
 def main():
-    entry = _resolve_entrypoint()
-    return entry()
+    return resolve_entrypoint()()
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-python-telegram-bot==20.8
-# aiogram удалён: используем стабильный PTB-рантайм (UI/логика без изменений)
+python-telegram-bot==20.8  # фиксируем стабильную версию PTB
 aiohttp>=3.9
 pandas>=2.0
 openpyxl>=3.1


### PR DESCRIPTION
## Summary
- simplify the email_bot entrypoint wrapper to try known modules in order and return the first callable main/run/start
- pin python-telegram-bot to the stable 20.8 release and clean up the redundant aiogram dependency entry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d679655c748326845fa019cd63b944