### PR TITLE
Restore synchronous bot entrypoint wrapper

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -1,3 +1,5 @@
+"""Synchronous entrypoint resolver for the email bot project."""
+
 from importlib import import_module
 
 # Порядок важен: сначала старые точки входа, затем новые.
@@ -26,6 +28,8 @@ def resolve_entrypoint():
 
 
 def main():
+    """Invoke the first available entrypoint synchronously."""
+
     return resolve_entrypoint()()
 
 

--- a/emailbot/bot/__main__.py
+++ b/emailbot/bot/__main__.py
@@ -1,4 +1,4 @@
-"""Async entrypoint for the aiogram-based Telegram bot."""
+"""Synchronous entrypoint for the aiogram-based Telegram bot (async under the hood)."""
 
 from __future__ import annotations
 
@@ -100,7 +100,7 @@ def include_all_routers(dp: Dispatcher) -> None:
             dp.include_router(router)
 
 
-async def main() -> None:
+async def _amain() -> None:
     """Run the bot dispatcher until cancelled."""
 
     _load_dotenv()
@@ -144,10 +144,17 @@ async def main() -> None:
             pass
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Synchronous entrypoint that wraps the async bot startup."""
+
     if sys.platform.startswith("win"):
         try:  # pragma: no cover - specific to Windows event loop
             asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # type: ignore[attr-defined]
         except Exception:
             pass
-    asyncio.run(main())
+
+    asyncio.run(_amain())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- wrap the asynchronous bot startup in emailbot.bot.__main__ with a synchronous main() that manages the event loop policy
- document the repository-level entrypoint module while keeping its synchronous resolution behaviour

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd7df6b7848326bd05328e466cbeec