### PR TITLE
Allow configuring Telegram start message

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,3 +136,18 @@ DEBUG_EMAIL_PARSE_LOG=0
 TEMPLATES_NEW_SIGNATURE=bioinformatics,geography,psychology
 
 
+#########################################
+# Приветствие /start (Telegram-бот)
+#########################################
+# Путь к файлу с приветствием (HTML или текст). Если указан и существует — имеет приоритет.
+# Пример: templates/start_legacy.html
+# START_MESSAGE_HTML_PATH=templates/start_legacy.html
+
+# Текст приветствия (можно с HTML). Используется, если файл не указан/не найден.
+# Пример:
+# START_MESSAGE_TEXT=<b>Привет!</b> Я помогу с рассылкой. Нажмите «Старт», чтобы продолжить.
+
+# Показывать ли клавиатуру направлений под приветствием (1=да, 0=нет)
+START_MESSAGE_SHOW_DIRECTIONS=1
+
+

--- a/emailbot/bot/handlers/start.py
+++ b/emailbot/bot/handlers/start.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
+
 from aiogram import Router
 from aiogram.filters import Command, CommandStart
 from aiogram.types import Message
@@ -10,24 +13,50 @@ from emailbot.bot import keyboards
 from emailbot.settings import list_available_directions
 
 router = Router()
+DEFAULT_START_MESSAGE = (
+    "Привет! Я помогу с рассылкой.\n\n"
+    "• /send email@domain.tld | Тема | Текст — отправка письма вручную.\n"
+    "• Выберите направление из списка ниже, чтобы работать с шаблонами.\n\n"
+    "Правило: один адрес — не чаще раза в 180 дней."
+)
 
 
-def _start_message() -> str:
-    return (
-        "Привет! Я помогу с рассылкой.\n\n"
-        "• /send email@domain.tld | Тема | Текст — отправка письма вручную.\n"
-        "• Выберите направление из списка ниже, чтобы работать с шаблонами.\n\n"
-        "Правило: один адрес — не чаще раза в 180 дней."
-    )
+def _load_start_message_text() -> str:
+    """
+    Возвращает текст приветствия:
+      1) если задан START_MESSAGE_HTML_PATH и файл существует — читаем из него;
+      2) иначе, если задан START_MESSAGE_TEXT — используем его (можно с HTML);
+      3) иначе — дефолтный текст (текущий).
+    """
+
+    path_value = (os.getenv("START_MESSAGE_HTML_PATH") or "").strip()
+    if path_value:
+        path = Path(path_value)
+        if path.exists():
+            try:
+                return path.read_text(encoding="utf-8")
+            except Exception:
+                pass
+
+    env_text = (os.getenv("START_MESSAGE_TEXT") or "").strip()
+    if env_text:
+        return env_text
+
+    return DEFAULT_START_MESSAGE
 
 
 @router.message(CommandStart())
 @router.message(Command("help"))
 async def start(message: Message) -> None:
-    """Reply with instructions and inline keyboard of directions."""
+    """Reply with instructions and optional inline keyboard of directions."""
 
-    directions = list_available_directions()
+    text = _load_start_message_text()
+    show_directions = os.getenv("START_MESSAGE_SHOW_DIRECTIONS", "1") == "1"
     keyboard = None
-    if directions:
-        keyboard = keyboards.directions_keyboard(directions)
-    await message.answer(_start_message(), reply_markup=keyboard)
+    if show_directions:
+        directions = list_available_directions()
+        if directions:
+            keyboard = keyboards.directions_keyboard(directions)
+
+    # В aiogram parse_mode уже HTML (ставится в __main__), поэтому можно присылать HTML.
+    await message.answer(text, reply_markup=keyboard)


### PR DESCRIPTION
## Summary
- allow configuring the bot's start/help message via environment variables or an HTML file
- document the new configuration knobs in `.env.example` and make showing directions optional

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd8712ed2c8326a4c29bc6b28925ed