### PR TITLE
Handle async entrypoints in launcher

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
 from importlib import import_module
+
 
 # Порядок важен: сначала старые точки входа, затем новые.
 CANDIDATES = [
     ("emailbot.messaging_utils", ("main", "run", "start")),
-    ("emailbot.messaging",      ("main", "run", "start")),
-    ("emailbot.bot.__main__",   ("main", "run", "start")),
+    ("emailbot.messaging", ("main", "run", "start")),
+    ("emailbot.bot.__main__", ("main", "run", "start")),
 ]
 
 
@@ -25,8 +30,33 @@ def resolve_entrypoint():
     )
 
 
+def _run_entrypoint(entrypoint):
+    """Запускает синхронную или асинхронную точку входа."""
+
+    def _ensure_windows_policy():
+        try:
+            import sys
+
+            if sys.platform.startswith("win"):
+                asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+        except Exception:
+            # Если не получилось выставить политику — продолжаем без ошибок
+            pass
+
+    if inspect.iscoroutinefunction(entrypoint):
+        _ensure_windows_policy()
+        return asyncio.run(entrypoint())
+
+    result = entrypoint()
+    if inspect.isawaitable(result):
+        _ensure_windows_policy()
+        return asyncio.run(result)
+
+    return result
+
+
 def main():
-    return resolve_entrypoint()()
+    return _run_entrypoint(resolve_entrypoint())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add asyncio-aware launcher logic so coroutine entrypoints run correctly
- reuse existing entrypoint resolution while supporting Windows event loop policy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de6870205c8326a3ef38f576fa4b00