### PR TITLE
Add synchronous entrypoint for bot

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -1,32 +1,6 @@
-from importlib import import_module
+"""Simple entrypoint for running the Telegram bot."""
 
-# Порядок важен: сначала старые точки входа, затем новые.
-CANDIDATES = [
-    ("emailbot.messaging_utils", ("main", "run", "start")),
-    ("emailbot.messaging",      ("main", "run", "start")),
-    ("emailbot.bot.__main__",   ("main", "run", "start")),
-]
-
-
-def resolve_entrypoint():
-    for mod_name, names in CANDIDATES:
-        try:
-            mod = import_module(mod_name)
-            for name in names:
-                fn = getattr(mod, name, None)
-                if callable(fn):
-                    return fn
-        except Exception:
-            # Переходим к следующему варианту
-            pass
-    raise SystemExit(
-        "Не найдено ни одной точки входа (main/run/start). "
-        "Уточните, в каком модуле она находится, и добавьте его в CANDIDATES."
-    )
-
-
-def main():
-    return resolve_entrypoint()()
+from emailbot.bot.__main__ import main_sync as main
 
 
 if __name__ == "__main__":

--- a/emailbot/bot/__main__.py
+++ b/emailbot/bot/__main__.py
@@ -144,10 +144,16 @@ async def main() -> None:
             pass
 
 
-if __name__ == "__main__":
-    if sys.platform.startswith("win"):
-        try:  # pragma: no cover - specific to Windows event loop
+def main_sync() -> None:
+    """Synchronous wrapper around :func:`main`."""
+
+    try:
+        if sys.platform.startswith("win"):
             asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # type: ignore[attr-defined]
-        except Exception:
-            pass
+    except Exception:
+        pass
     asyncio.run(main())
+
+
+if __name__ == "__main__":
+    main_sync()


### PR DESCRIPTION
## Summary
- add a synchronous `main_sync` wrapper in `emailbot.bot.__main__` that runs the async bot entrypoint via `asyncio.run`
- simplify `email_bot.py` to use the synchronous bot entrypoint without additional asyncio logic

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de785423408326bd4cc7fc58bd1f4f