### PR TITLE
Use synchronous entrypoint for launcher

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -1,33 +1,6 @@
-from importlib import import_module
-
-# Порядок важен: сначала старые точки входа, затем новые.
-CANDIDATES = [
-    ("emailbot.messaging_utils", ("main", "run", "start")),
-    ("emailbot.messaging",      ("main", "run", "start")),
-    ("emailbot.bot.__main__",   ("main", "run", "start")),
-]
-
-
-def resolve_entrypoint():
-    for mod_name, names in CANDIDATES:
-        try:
-            mod = import_module(mod_name)
-            for name in names:
-                fn = getattr(mod, name, None)
-                if callable(fn):
-                    return fn
-        except Exception:
-            # Переходим к следующему варианту
-            pass
-    raise SystemExit(
-        "Не найдено ни одной точки входа (main/run/start). "
-        "Уточните, в каком модуле она находится, и добавьте его в CANDIDATES."
-    )
-
-
-def main():
-    return resolve_entrypoint()()
+"""Синхронная точка входа (без asyncio)."""
+from emailbot.bot.__main__ import main_sync as entrypoint
 
 
 if __name__ == "__main__":
-    main()
+    entrypoint()


### PR DESCRIPTION
## Summary
- replace the dynamic entrypoint resolver with a direct call to the synchronous `main_sync` entrypoint
- add a module docstring describing the synchronous entrypoint script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df8853f5f8832691872d6b7dca68ef