### PR TITLE
Add IPv4-aware IMAP connection helper

### DIFF
--- a/emailbot/net_imap.py
+++ b/emailbot/net_imap.py
@@ -1,0 +1,70 @@
+"""Utilities for establishing IMAP connections with additional policies."""
+
+from __future__ import annotations
+
+import os
+import socket
+import ssl
+import imaplib
+from typing import Optional
+
+
+def _resolve_preferred_addrinfos(host: str, port: int) -> list[tuple]:
+    """Return address infos preferring IPv4 when ``IMAP_IPV4_ONLY`` is set."""
+
+    prefer_ipv4 = os.getenv("IMAP_IPV4_ONLY", "0") == "1"
+    addrinfos = socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM)
+    if prefer_ipv4:
+        only_v4 = [info for info in addrinfos if info[0] == socket.AF_INET]
+        if only_v4:
+            return only_v4
+    return addrinfos
+
+
+def get_imap_timeout(default: Optional[float] = None) -> Optional[float]:
+    """Return the IMAP timeout from the ``IMAP_TIMEOUT`` env var."""
+
+    raw = os.getenv("IMAP_TIMEOUT")
+    if raw is None:
+        return default
+    raw = raw.strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def imap_connect_ssl(
+    host: str, port: int, timeout: Optional[float] = None
+) -> imaplib.IMAP4_SSL:
+    """Create an ``IMAP4_SSL`` connection honouring IPv4 preference and timeout."""
+
+    context = ssl.create_default_context()
+    last_error: Optional[BaseException] = None
+    for family, socktype, proto, _, sockaddr in _resolve_preferred_addrinfos(host, port):
+        sock = None
+        wrapped = None
+        try:
+            sock = socket.socket(family, socktype, proto)
+            if timeout is not None:
+                sock.settimeout(timeout)
+            wrapped = context.wrap_socket(sock, server_hostname=host)
+            wrapped.connect(sockaddr)
+            return imaplib.IMAP4_SSL(host=None, port=None, ssl_context=context, sock=wrapped)
+        except Exception as exc:  # pragma: no cover - network errors
+            last_error = exc
+            if wrapped is not None:
+                try:
+                    wrapped.close()
+                except Exception:
+                    pass
+            elif sock is not None:
+                try:
+                    sock.close()
+                except Exception:
+                    pass
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("IMAP connect failed")

--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -1,5 +1,4 @@
 import asyncio
-import imaplib
 import logging
 import types
 
@@ -457,7 +456,10 @@ def test_send_manual_email_uses_html_template(monkeypatch, tmp_path):
 
     monkeypatch.setattr(bh, "RobustSMTP", lambda *a, **k: DummySMTP())
     monkeypatch.setattr(
-        bh, "imaplib", types.SimpleNamespace(IMAP4_SSL=lambda *a, **k: DummyImap())
+        bh,
+        "imap_connect_ssl",
+        lambda *a, **k: DummyImap(),
+        raising=False,
     )
     monkeypatch.setattr(bh, "send_email_with_sessions", fake_send)
     monkeypatch.setattr(bh, "get_blocked_emails", lambda: set())
@@ -525,7 +527,7 @@ async def test_send_manual_email_no_block_mentions(monkeypatch, tmp_path):
         def logout(self):
             return
 
-    monkeypatch.setattr(imaplib, "IMAP4_SSL", lambda *a, **k: DummyImap())
+    monkeypatch.setattr(bh.messaging, "imap_connect_ssl", lambda *a, **k: DummyImap())
 
     monkeypatch.setattr(
         bh.messaging,
@@ -588,8 +590,9 @@ async def test_manual_send_override_sets_flag(monkeypatch, tmp_path):
     monkeypatch.setattr(bh, "RobustSMTP", lambda *a, **k: DummySMTP())
     monkeypatch.setattr(
         bh,
-        "imaplib",
-        types.SimpleNamespace(IMAP4_SSL=lambda *a, **k: DummyImap()),
+        "imap_connect_ssl",
+        lambda *a, **k: DummyImap(),
+        raising=False,
     )
     monkeypatch.setattr(bh, "send_email_with_sessions", fake_send)
     monkeypatch.setattr(bh, "get_blocked_emails", lambda: set())
@@ -730,8 +733,9 @@ async def test_manual_send_selective_override(monkeypatch, tmp_path):
     monkeypatch.setattr(bh, "RobustSMTP", lambda *a, **k: DummySMTP())
     monkeypatch.setattr(
         bh,
-        "imaplib",
-        types.SimpleNamespace(IMAP4_SSL=lambda *a, **k: DummyImap()),
+        "imap_connect_ssl",
+        lambda *a, **k: DummyImap(),
+        raising=False,
     )
     monkeypatch.setattr(bh, "send_email_with_sessions", fake_send)
     monkeypatch.setattr(bh, "get_blocked_emails", lambda: set())

--- a/tests/test_retry_last.py
+++ b/tests/test_retry_last.py
@@ -134,7 +134,7 @@ def test_sync_uses_upsert_and_no_duplicates(monkeypatch, tmp_path):
         def logout(self):
             pass
 
-    monkeypatch.setattr(messaging, "imaplib", types.SimpleNamespace(IMAP4_SSL=lambda *a, **k: DummyImap()))
+    monkeypatch.setattr(messaging, "imap_connect_ssl", lambda *a, **k: DummyImap())
 
     stats1 = messaging.sync_log_with_imap()
     stats2 = messaging.sync_log_with_imap()


### PR DESCRIPTION
## Summary
- add a shared helper that respects IMAP_IPV4_ONLY and configurable timeouts when creating SSL IMAP connections
- use the helper across messaging, bounce processing, and IMAP lookup utilities to ensure consistent connection handling
- update the bot and messaging tests to patch the new helper when faking IMAP interactions

## Testing
- pytest tests/test_messaging.py tests/test_retry_last.py tests/test_bot_handlers.py *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68dfce01e0608326b024059593dedd56