### PR TITLE
Restore legacy email_bot entrypoint

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -1,119 +1,96 @@
-# === EBOT launcher (works from repo root or subfolder) ===
-# - Finds the repository root and adds it to sys.path
-# - Loads .env (from CWD or repo root) if python-dotenv is installed
-# - Composes candidate modules to look for entrypoints: main/run/start
-# - Allows overriding candidates via CANDIDATES env var
-# - Then resolves and calls the first available entrypoint
-
+import importlib
 import os
 import sys
-from importlib import import_module
-from typing import Iterable, Tuple
+from pathlib import Path
 
-
-# ---------- helpers: repo root & dotenv ----------
-
-def _find_repo_root(start: str, max_up: int = 6) -> str | None:
+def _load_dotenv_safe():
     """
-    Walk up to `max_up` levels looking for a directory that contains
-    both '.git' and 'requirements.txt' — treat it as the repo root.
+    Ленивая подгрузка .env, чтобы поведение оставалось как раньше:
+    при наличии .env в корне — загрузить и написать, откуда загрузили.
+    Не добавляем зависимостей; если python-dotenv не установлен — просто пропускаем.
     """
-    cur = os.path.abspath(start)
-    for _ in range(max_up):
-        git_dir = os.path.join(cur, ".git")
-        req_file = os.path.join(cur, "requirements.txt")
-        if os.path.isdir(git_dir) and os.path.isfile(req_file):
-            return cur
-        parent = os.path.dirname(cur)
-        if parent == cur:
-            break
-        cur = parent
+    env_path = Path(__file__).parent / ".env"
+    if env_path.exists():
+        try:
+            from dotenv import load_dotenv
+            load_dotenv(env_path)
+            print(f"[ebot] .env loaded from: {env_path}")
+        except Exception:
+            # Безопасно замалчиваем — старое поведение было «мягким»
+            print(f"[ebot] .env present but python-dotenv not available (skipped): {env_path}")
+
+def _try_call(func):
+    if callable(func):
+        return func()
     return None
 
-
-# Add repo root to sys.path if we can detect it (supports running from a subfolder)
-_REPO_ROOT = _find_repo_root(os.getcwd())
-if _REPO_ROOT and _REPO_ROOT not in sys.path:
-    sys.path.insert(0, _REPO_ROOT)
-
-# Try to load .env (from current dir or repo root), if python-dotenv is available
-try:
-    from dotenv import load_dotenv, find_dotenv  # type: ignore
-    _env_path = find_dotenv(usecwd=True) or os.path.join(_REPO_ROOT or os.getcwd(), ".env")
-    if _env_path and os.path.isfile(_env_path):
-        load_dotenv(_env_path)
-        print(f"[ebot] .env loaded from: {_env_path}")
-except Exception:
-    # dotenv is optional; environment variables may already be present
-    pass
-
-
-# ---------- candidates configuration ----------
-
-DEFAULT_ENTRY_NAMES: Tuple[str, ...] = ("main", "run", "start")
-
-def _compose_candidates() -> Iterable[Tuple[str, Tuple[str, ...]]]:
+def _resolve_and_run():
     """
-    Compose a list of (module_name, entry_names) to probe for an entrypoint.
-    Order:
-      1) Modules listed in env var CANDIDATES (comma-separated),
-      2) Project defaults (with and without 'emailbot.' prefix).
+    Универсальный «старый» запуск:
+    пытаемся найти в известных модулях одну из функций: main / run / start / cli
+    и вызвать её без аргументов.
+    Можно переопределить через CLI:
+      python email_bot.py --module emailbot.messaging --func main
     """
-    env_candidates: Iterable[str] = ()
-    env_val = os.getenv("CANDIDATES", "").strip()
-    if env_val:
-        env_candidates = [m.strip() for m in env_val.split(",") if m.strip()]
+    # Быстрый ручной оверрайд через флаги
+    mod_override = None
+    func_override = None
+    if "--module" in sys.argv:
+        i = sys.argv.index("--module")
+        if i + 1 < len(sys.argv):
+            mod_override = sys.argv[i+1]
+    if "--func" in sys.argv:
+        i = sys.argv.index("--func")
+        if i + 1 < len(sys.argv):
+            func_override = sys.argv[i+1]
 
-    defaults = [
-        # canonical project modules
-        "emailbot.messaging_utils",
+    # Набор вероятных модулей из проекта (упорядочены по приоритету)
+    candidates_modules = [
+        "emailbot.app",
+        "emailbot.bot",
         "emailbot.messaging",
-        "emailbot.bot.__main__",
-        # fallbacks without prefix (for historical subfolder launches)
-        "bot.__main__",
-        "messaging",
-        "bot",
+        "emailbot.runner",
+        "emailbot.main",
+        "emailbot.core",
+        "emailbot.cli",
     ]
+    # Наиболее типовые имена точек входа
+    candidate_funcs = ["main", "run", "start", "cli"]
 
-    seen = set()
-    ordered: list[Tuple[str, Tuple[str, ...]]] = []
-    for name in list(env_candidates) + defaults:
-        if name not in seen:
-            seen.add(name)
-            ordered.append((name, DEFAULT_ENTRY_NAMES))
-    return ordered
+    if mod_override:
+        modules = [mod_override]
+    else:
+        modules = candidates_modules
 
+    if func_override:
+        funcs = [func_override]
+    else:
+        funcs = candidate_funcs
 
-CANDIDATES: Iterable[Tuple[str, Tuple[str, ...]]] = _compose_candidates()
-
-
-# ---------- entrypoint resolution ----------
-
-def resolve_entrypoint():
-    """
-    Try importing each candidate module and look for a callable named
-    'main' or 'run' or 'start'. Return the first one found.
-    """
-    for mod_name, names in CANDIDATES:
+    last_err = None
+    for m in modules:
         try:
-            mod = import_module(mod_name)
-        except Exception:
+            mod = importlib.import_module(m)
+        except Exception as e:
+            last_err = e
             continue
-        for name in names:
-            fn = getattr(mod, name, None)
+        for f in funcs:
+            fn = getattr(mod, f, None)
             if callable(fn):
-                return fn
-    raise SystemExit(
-        "Не найдено ни одной точки входа (main/run/start). "
-        "Уточните, в каком модуле она находится, и задайте переменную окружения CANDIDATES, "
-        "например: CANDIDATES=emailbot.messaging,emailbot.messaging_utils"
+                return _try_call(fn)
+    # Если ничего не нашли — даем понятное сообщение (как раньше, но без CANDIDATES)
+    raise RuntimeError(
+        "Не найдена точка входа. "
+        "Проверьте, что в одном из модулей пакета emailbot есть функция main/run/start/cli.\n"
+        "Можно указать явно: python email_bot.py --module emailbot.X --func main"
+        + (f"\nПоследняя ошибка импорта: {last_err}" if last_err else "")
     )
 
-
 def main():
-    entry = resolve_entrypoint()
-    return entry()
-
+    _load_dotenv_safe()
+    # На всякий случай гасим влияние новой переменной, если она осталась в окружении
+    os.environ.pop("CANDIDATES", None)
+    return _resolve_and_run()
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main() or 0)

--- a/emailbot/__main__.py
+++ b/emailbot/__main__.py
@@ -1,0 +1,14 @@
+# Позволяет запускать: python -m email_bot
+from pathlib import Path
+import runpy
+import sys
+
+def _run_legacy_entry():
+    # Запускаем корневой email_bot.py как скрипт — это сохраняет «старую» семантику.
+    root = Path(__file__).resolve().parent.parent / "email_bot.py"
+    if not root.exists():
+        raise SystemExit("email_bot.py не найден в корне репозитория.")
+    runpy.run_path(str(root), run_name="__main__")
+
+if __name__ == "__main__":
+    _run_legacy_entry()


### PR DESCRIPTION
## Summary
- replace the legacy launcher script with a simplified entrypoint lookup without the CANDIDATES env override
- add a module-level __main__ so `python -m email_bot` reuses the legacy script behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e01265b640832693286e289e7df02c