### PR TITLE
Add bulk edit workflow and new mailing groups

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -3,10 +3,21 @@ from __future__ import annotations
 import json
 from collections import OrderedDict
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Sequence
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
+
+
+groups_map = {
+    "sport": "⚽ Спорт",
+    "tourism": "🧭 Туризм",
+    "medicine": "🩺 Медицина",
+    "bioinformatics": "🧬 Биоинформатика",
+    "geography": "🗺️ География",
+    "psychology": "🧠 Психология",
+    "beauty": "💄 Индустрия красоты",
+}
 
 
 def build_parse_mode_kb(
@@ -200,3 +211,49 @@ def send_flow_keyboard() -> InlineKeyboardMarkup:
             ],
         ]
     )
+
+
+def build_bulk_edit_kb(
+    emails: Sequence[str], page: int = 0, page_size: int = 10
+) -> InlineKeyboardMarkup:
+    """Keyboard for bulk address editing actions."""
+
+    total = len(emails)
+    if page_size <= 0:
+        page_size = 10
+    max_page = max((total - 1) // page_size, 0) if total else 0
+    page = max(0, min(page, max_page))
+    start = page * page_size
+    end = start + page_size
+    visible = emails[start:end]
+
+    rows: list[list[InlineKeyboardButton]] = [
+        [
+            InlineKeyboardButton("➕ Добавить", callback_data="bulk:edit:add"),
+            InlineKeyboardButton("🔁 Заменить", callback_data="bulk:edit:replace"),
+        ]
+    ]
+
+    for email in visible:
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    f"🗑 {email}", callback_data=f"bulk:edit:del:{email}"
+                )
+            ]
+        )
+
+    nav: list[InlineKeyboardButton] = []
+    if page > 0:
+        nav.append(
+            InlineKeyboardButton("⬅️", callback_data=f"bulk:edit:page:{page - 1}")
+        )
+    if end < total:
+        nav.append(
+            InlineKeyboardButton("➡️", callback_data=f"bulk:edit:page:{page + 1}")
+        )
+    if nav:
+        rows.append(nav)
+
+    rows.append([InlineKeyboardButton("✅ Готово", callback_data="bulk:edit:done")])
+    return InlineKeyboardMarkup(rows)

--- a/email_bot.py
+++ b/email_bot.py
@@ -197,6 +197,26 @@ def main() -> None:
         )
     )
     app.add_handler(
+        CallbackQueryHandler(bot_handlers.bulk_edit_start, pattern="^bulk:edit:start$")
+    )
+    app.add_handler(
+        CallbackQueryHandler(bot_handlers.bulk_edit_add_prompt, pattern="^bulk:edit:add$")
+    )
+    app.add_handler(
+        CallbackQueryHandler(
+            bot_handlers.bulk_edit_replace_prompt, pattern="^bulk:edit:replace$"
+        )
+    )
+    app.add_handler(
+        CallbackQueryHandler(bot_handlers.bulk_edit_delete, pattern=r"^bulk:edit:del:")
+    )
+    app.add_handler(
+        CallbackQueryHandler(bot_handlers.bulk_edit_page, pattern=r"^bulk:edit:page:")
+    )
+    app.add_handler(
+        CallbackQueryHandler(bot_handlers.bulk_edit_done, pattern="^bulk:edit:done$")
+    )
+    app.add_handler(
         CallbackQueryHandler(
             bot_handlers.include_numeric_emails, pattern="^confirm_include_numeric$"
         )

--- a/emailbot/messaging.py
+++ b/emailbot/messaging.py
@@ -51,9 +51,13 @@ MAX_EMAILS_PER_DAY = int(os.getenv("MAX_EMAILS_PER_DAY", "300"))
 # HTML templates are stored at the root-level ``templates`` directory.
 TEMPLATES_DIR = str(SCRIPT_DIR / "templates")
 TEMPLATE_MAP = {
-    "спорт": os.path.join(TEMPLATES_DIR, "sport.htm"),
-    "туризм": os.path.join(TEMPLATES_DIR, "tourism.htm"),
-    "медицина": os.path.join(TEMPLATES_DIR, "medicine.htm"),
+    "sport": os.path.join(TEMPLATES_DIR, "sport.html"),
+    "tourism": os.path.join(TEMPLATES_DIR, "tourism.html"),
+    "medicine": os.path.join(TEMPLATES_DIR, "medicine.html"),
+    "bioinformatics": os.path.join(TEMPLATES_DIR, "bioinformatics.html"),
+    "geography": os.path.join(TEMPLATES_DIR, "geography.html"),
+    "psychology": os.path.join(TEMPLATES_DIR, "psychology.html"),
+    "beauty": os.path.join(TEMPLATES_DIR, "beauty.html"),
 }
 
 # Text of the signature without styling. The surrounding block and


### PR DESCRIPTION
## Summary
- extend the mailing group mapping and template map to cover the new categories
- add an inline bulk editing flow that supports adding, replacing, deleting, and paging through addresses
- update keyboards and callbacks to reuse the shared group map and surface the editor entry point after parsing

## Testing
- pytest *(fails: missing aiohttp dependency in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1740e2d58832687899f8ee077e5a5