### PR TITLE
Disable inline email editor flow by default

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -8,6 +8,8 @@ from typing import Dict, Sequence
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
 
+from emailbot.config import ENABLE_INLINE_EMAIL_EDITOR
+
 
 groups_map = {
     "sport": "⚽ Спорт",
@@ -74,19 +76,21 @@ def build_parse_mode_kb(
 
 
 def build_post_parse_extra_actions_kb() -> InlineKeyboardMarkup:
-    """
-    Дополнительные действия после завершения парсинга.
+    """Дополнительные действия после завершения парсинга."""
 
-    Используется в паре с основным выводом результатов, отправляется отдельным
-    сообщением и не ломает текущую клавиатуру.
-    """
-
-    return InlineKeyboardMarkup(
-        [
-            [InlineKeyboardButton("📥 Экспорт адресов в Excel", callback_data="bulk:xls:export")],
-            [InlineKeyboardButton("✏️ Отправить правки текстом", callback_data="bulk:txt:start")],
-        ]
-    )
+    rows = [
+        [InlineKeyboardButton("📥 Экспорт адресов в Excel", callback_data="bulk:xls:export")],
+        [InlineKeyboardButton("✏️ Отправить правки текстом", callback_data="bulk:txt:start")],
+    ]
+    if ENABLE_INLINE_EMAIL_EDITOR:
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    "✏️ Исправить адреса (встроенно)", callback_data="bulk:edit:start"
+                )
+            ]
+        )
+    return InlineKeyboardMarkup(rows)
 
 
 def build_sections_suggest_kb(

--- a/email_bot.py
+++ b/email_bot.py
@@ -20,6 +20,7 @@ from telegram.ext import (
 )
 
 from emailbot import bot_handlers, messaging
+from emailbot.config import ENABLE_INLINE_EMAIL_EDITOR
 from emailbot.messaging_utils import SecretFilter
 from emailbot.utils import load_env
 
@@ -201,26 +202,31 @@ def main() -> None:
             bot_handlers.ask_include_numeric, pattern="^ask_include_numeric$"
         )
     )
-    app.add_handler(
-        CallbackQueryHandler(bot_handlers.bulk_edit_start, pattern="^bulk:edit:start$")
-    )
-    app.add_handler(
-        CallbackQueryHandler(bot_handlers.bulk_edit_add_prompt, pattern="^bulk:edit:add$")
-    )
-    app.add_handler(
-        CallbackQueryHandler(
-            bot_handlers.bulk_edit_replace_prompt, pattern="^bulk:edit:replace$"
+    if ENABLE_INLINE_EMAIL_EDITOR:
+        app.add_handler(
+            CallbackQueryHandler(bot_handlers.bulk_edit_start, pattern="^bulk:edit:start$")
         )
-    )
-    app.add_handler(
-        CallbackQueryHandler(bot_handlers.bulk_edit_delete, pattern=r"^bulk:edit:del:")
-    )
-    app.add_handler(
-        CallbackQueryHandler(bot_handlers.bulk_edit_page, pattern=r"^bulk:edit:page:")
-    )
-    app.add_handler(
-        CallbackQueryHandler(bot_handlers.bulk_edit_done, pattern="^bulk:edit:done$")
-    )
+        app.add_handler(
+            CallbackQueryHandler(bot_handlers.bulk_edit_add_prompt, pattern="^bulk:edit:add$")
+        )
+        app.add_handler(
+            CallbackQueryHandler(
+                bot_handlers.bulk_edit_replace_prompt, pattern="^bulk:edit:replace$"
+            )
+        )
+        app.add_handler(
+            CallbackQueryHandler(
+                bot_handlers.bulk_edit_delete, pattern=r"^bulk:edit:del:"
+            )
+        )
+        app.add_handler(
+            CallbackQueryHandler(
+                bot_handlers.bulk_edit_page, pattern=r"^bulk:edit:page:"
+            )
+        )
+        app.add_handler(
+            CallbackQueryHandler(bot_handlers.bulk_edit_done, pattern="^bulk:edit:done$")
+        )
     app.add_handler(
         CallbackQueryHandler(bot_handlers.prompt_mass_send, pattern="^bulk:send:start$")
     )

--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -34,6 +34,8 @@ from bot.keyboards import (
     groups_map,
 )
 
+from emailbot.config import ENABLE_INLINE_EMAIL_EDITOR
+
 from . import messaging
 from . import messaging_utils as mu
 from . import extraction as _extraction
@@ -1091,13 +1093,14 @@ async def handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 )
             ]
         )
-    extra_buttons.append(
-        [
-            InlineKeyboardButton(
-                "✏️ Исправить адреса", callback_data="bulk:edit:start"
-            )
-        ]
-    )
+    if ENABLE_INLINE_EMAIL_EDITOR:
+        extra_buttons.append(
+            [
+                InlineKeyboardButton(
+                    "✏️ Исправить адреса", callback_data="bulk:edit:start"
+                )
+            ]
+        )
     extra_buttons.append(
         [
             InlineKeyboardButton(
@@ -1161,6 +1164,13 @@ async def bulk_edit_start(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 
     query = update.callback_query
     await query.answer()
+    if not ENABLE_INLINE_EMAIL_EDITOR:
+        await query.message.reply_text(
+            "Редактор в чате отключён. Используйте:\n"
+            "• 📥 Экспорт адресов в Excel\n"
+            "• ✏️ Отправить правки текстом (в одном сообщении: «старый -> новый» на строку)\n"
+        )
+        return
 
     previous = context.user_data.get("bulk_edit_message")
     if previous:
@@ -1192,6 +1202,9 @@ async def bulk_edit_add_prompt(
     """Ask the user to provide additional e-mail addresses."""
 
     query = update.callback_query
+    if not ENABLE_INLINE_EMAIL_EDITOR:
+        await query.answer()
+        return
     await query.answer()
     context.user_data["bulk_edit_mode"] = "add"
     context.user_data.pop("bulk_edit_replace_old", None)
@@ -1204,6 +1217,9 @@ async def bulk_edit_replace_prompt(
     """Ask for the address that should be replaced."""
 
     query = update.callback_query
+    if not ENABLE_INLINE_EMAIL_EDITOR:
+        await query.answer()
+        return
     await query.answer()
     context.user_data["bulk_edit_mode"] = "replace_wait_old"
     context.user_data.pop("bulk_edit_replace_old", None)
@@ -1214,6 +1230,9 @@ async def bulk_edit_delete(update: Update, context: ContextTypes.DEFAULT_TYPE) -
     """Remove a single e-mail from the working list."""
 
     query = update.callback_query
+    if not ENABLE_INLINE_EMAIL_EDITOR:
+        await query.answer()
+        return
     await query.answer("Удалено")
     target = query.data.split("bulk:edit:del:", 1)[-1]
     working = [
@@ -1233,6 +1252,9 @@ async def bulk_edit_page(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     """Switch between pages in the bulk edit keyboard."""
 
     query = update.callback_query
+    if not ENABLE_INLINE_EMAIL_EDITOR:
+        await query.answer()
+        return
     await query.answer()
     raw_page = query.data.rsplit(":", 1)[-1]
     try:
@@ -1247,6 +1269,9 @@ async def bulk_edit_done(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
     """Finalize the edited list and return to group selection."""
 
     query = update.callback_query
+    if not ENABLE_INLINE_EMAIL_EDITOR:
+        await query.answer()
+        return
     await query.answer()
 
     working = list(context.user_data.get("bulk_edit_working", []))
@@ -1322,8 +1347,10 @@ async def bulk_xls_export(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             document=fh,
             filename=path.name,
             caption=(
-                "Отредактируйте список локально. Затем пришлите одним сообщением пары "
-                "правок в формате «старый -> новый» (можно много строк)."
+                "Отредактируйте список локально (Excel).\n"
+                "⚠️ Файл загружать обратно НЕ нужно.\n\n"
+                "Пришлите одним сообщением пары правок в формате «старый -> новый» "
+                "(несколько строк в одном сообщении допустимы)."
             ),
         )
 
@@ -1836,13 +1863,14 @@ async def handle_text(update: Update, context: ContextTypes.DEFAULT_TYPE) -> Non
                     )
                 ]
             )
-        extra_buttons.append(
-            [
-                InlineKeyboardButton(
-                    "✏️ Исправить адреса", callback_data="bulk:edit:start"
-                )
-            ]
-        )
+        if ENABLE_INLINE_EMAIL_EDITOR:
+            extra_buttons.append(
+                [
+                    InlineKeyboardButton(
+                        "✏️ Исправить адреса", callback_data="bulk:edit:start"
+                    )
+                ]
+            )
         extra_buttons.append(
             [
                 InlineKeyboardButton(

--- a/emailbot/config.py
+++ b/emailbot/config.py
@@ -15,3 +15,6 @@ CRAWL_HTTP2 = os.getenv("CRAWL_HTTP2", "1") == "1"
 
 # UX: разрешать редактирование сразу после предпросмотра?
 ALLOW_EDIT_AT_PREVIEW = os.getenv("ALLOW_EDIT_AT_PREVIEW", "0") == "1"
+
+# Отключение встроенного (инлайн) редактора e-mail в боте
+ENABLE_INLINE_EMAIL_EDITOR = os.getenv("ENABLE_INLINE_EMAIL_EDITOR", "0") == "1"


### PR DESCRIPTION
## Summary
- add a configuration flag to control access to the inline email editor
- hide inline editor entry points and short-circuit handlers when the flag is disabled
- update export messaging to direct users toward the text corrections flow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2befd65788326bfbeb517141f0666