### PR TITLE
Improve error handling and email selection robustness

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -8,7 +8,7 @@ from typing import Dict, Sequence
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import ContextTypes
 
-from emailbot.config import ENABLE_INLINE_EMAIL_EDITOR
+from emailbot.config import ENABLE_INLINE_EMAIL_EDITOR, EXPORT_XLS_ADMIN_ONLY
 
 
 groups_map = {
@@ -75,13 +75,20 @@ def build_parse_mode_kb(
     return InlineKeyboardMarkup(rows)
 
 
-def build_post_parse_extra_actions_kb() -> InlineKeyboardMarkup:
+def build_post_parse_extra_actions_kb(*, is_admin: bool = True) -> InlineKeyboardMarkup:
     """Дополнительные действия после завершения парсинга."""
 
-    rows = [
-        [InlineKeyboardButton("📥 Экспорт адресов в Excel", callback_data="bulk:xls:export")],
-        [InlineKeyboardButton("✏️ Отправить правки текстом", callback_data="bulk:txt:start")],
-    ]
+    rows = [[InlineKeyboardButton("✏️ Отправить правки текстом", callback_data="bulk:txt:start")]]
+    if not EXPORT_XLS_ADMIN_ONLY or is_admin:
+        rows.insert(
+            0,
+            [
+                InlineKeyboardButton(
+                    "📥 Скачать Excel с адресами (для ручной проверки)",
+                    callback_data="bulk:xls:export",
+                )
+            ],
+        )
     if ENABLE_INLINE_EMAIL_EDITOR:
         rows.append(
             [
@@ -95,6 +102,8 @@ def build_post_parse_extra_actions_kb() -> InlineKeyboardMarkup:
 
 def build_after_parse_combined_kb(
     extra_rows: Sequence[Sequence[InlineKeyboardButton]] | None = None,
+    *,
+    is_admin: bool = True,
 ) -> InlineKeyboardMarkup:
     """
     Клавиатура, объединяющая действия после парсинга под единым сообщением
@@ -105,8 +114,16 @@ def build_after_parse_combined_kb(
         [InlineKeyboardButton("👀 Показать ещё примеры", callback_data="refresh_preview")],
         [InlineKeyboardButton("🧭 Перейти к выбору направления", callback_data="proceed_group")],
         [InlineKeyboardButton("✏️ Отправить правки текстом", callback_data="bulk:txt:start")],
-        [InlineKeyboardButton("📥 Экспорт адресов в Excel", callback_data="bulk:xls:export")],
     ]
+    if not EXPORT_XLS_ADMIN_ONLY or is_admin:
+        rows.append(
+            [
+                InlineKeyboardButton(
+                    "📥 Скачать Excel с адресами (для ручной проверки)",
+                    callback_data="bulk:xls:export",
+                )
+            ]
+        )
     if ENABLE_INLINE_EMAIL_EDITOR:
         rows.append(
             [

--- a/emailbot/config.py
+++ b/emailbot/config.py
@@ -18,3 +18,4 @@ ALLOW_EDIT_AT_PREVIEW = os.getenv("ALLOW_EDIT_AT_PREVIEW", "0") == "1"
 
 # Отключение встроенного (инлайн) редактора e-mail в боте
 ENABLE_INLINE_EMAIL_EDITOR = os.getenv("ENABLE_INLINE_EMAIL_EDITOR", "0") == "1"
+EXPORT_XLS_ADMIN_ONLY = os.getenv("EXPORT_XLS_ADMIN_ONLY", "0") == "1"


### PR DESCRIPTION
## Summary
- add a PTB application-wide error handler that logs exceptions with chat metadata
- guard group selection against empty recipient lists by reusing cached parses and surfacing a user-facing warning
- clarify the Excel export button label, optionally hide it for non-admins via an env flag, and harden email normalization against footnote prefixes

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68e2d4633a7c83269c52218a246b09a5