### PR TITLE
Handle missing group prefix safely

### DIFF
--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -1639,7 +1639,7 @@ async def select_group(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
     query = update.callback_query
     data = (query.data or "").strip()
-    group_code = data.removeprefix("group_").strip()
+    group_code = (data[len("group_"):] if data.startswith("group_") else data).strip()
     if not group_code:
         await query.answer(
             cache_time=0,


### PR DESCRIPTION
## Summary
- guard the group selection handler to strip the `group_` prefix only when present

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e38cf479b88326ba945c003b30ad10