### PR TITLE
Fix pre-3.9 compatibility for group code parsing

### DIFF
--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -1639,6 +1639,7 @@ async def select_group(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
     query = update.callback_query
     data = (query.data or "").strip()
+    # безопасно для Python < 3.9
     group_code = (data[len("group_"):] if data.startswith("group_") else data).strip()
     if not group_code:
         await query.answer(
@@ -2131,7 +2132,12 @@ async def send_manual_email(update: Update, context: ContextTypes.DEFAULT_TYPE) 
 
     async def long_job() -> None:
         chat_id = query.message.chat.id
-        group_code = query.data.removeprefix("manual_group_")
+        # безопасно для Python < 3.9
+        group_code = (
+            query.data[len("manual_group_") :]
+            if (query.data or "").startswith("manual_group_")
+            else (query.data or "")
+        )
         template_path = TEMPLATE_MAP[group_code]
 
         # manual отправка не учитывает супресс-лист


### PR DESCRIPTION
## Summary
- replace usage of `removeprefix` when parsing group callback data to support older Python versions
- apply the same safe prefix removal for manual group callbacks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e393cadf9c83269bf951b696ac3630