### PR TITLE
Fix cross-platform sent log path

### DIFF
--- a/emailbot/messaging.py
+++ b/emailbot/messaging.py
@@ -42,9 +42,11 @@ logger = logging.getLogger(__name__)
 
 # Resolve the project root (one level above this file) and use shared
 # directories located at the repository root.
+from utils.paths import expand_path
 SCRIPT_DIR = Path(__file__).resolve().parent.parent
 DOWNLOAD_DIR = str(SCRIPT_DIR / "downloads")
-LOG_FILE = str(Path("/mnt/data") / "sent_log.csv")
+# Был жёсткий путь /mnt/data/sent_log.csv → падало на Windows/Linux без /mnt.
+LOG_FILE = str(expand_path(os.getenv("SENT_LOG_PATH", "var/sent_log.csv")))
 BLOCKED_FILE = str(SCRIPT_DIR / "blocked_emails.txt")
 MAX_EMAILS_PER_DAY = int(os.getenv("MAX_EMAILS_PER_DAY", "300"))
 


### PR DESCRIPTION
## Summary
- use the shared path helper to resolve the sent log location
- default the sent log to var/sent_log.csv while allowing override via SENT_LOG_PATH

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3a363042483268590feb489ad1ff8