### PR TITLE
Handle unresolved placeholders in email templates

### DIFF
--- a/emailbot/bot_handlers.py
+++ b/emailbot/bot_handlers.py
@@ -2252,6 +2252,22 @@ async def send_manual_email(update: Update, context: ContextTypes.DEFAULT_TYPE) 
                             )
                             sent_count += 1
                             await asyncio.sleep(1.5)
+                        except ValueError as e:
+                            if "Unresolved placeholders" in str(e):
+                                await context.bot.send_message(
+                                    chat_id=query.message.chat.id,
+                                    text=(
+                                        "⚠️ Шаблон содержит неподставленные плейсхолдеры "
+                                        "(например, {{BODY}} или {BODY}). "
+                                        "Исправьте шаблон и повторите отправку."
+                                    ),
+                                )
+                                try:
+                                    imap.logout()
+                                except Exception:
+                                    pass
+                                return
+                            errors.append(f"{email_addr} — {e}")
                         except Exception as e:
                             errors.append(f"{email_addr} — {e}")
                             code, msg = None, None
@@ -2475,6 +2491,22 @@ async def send_all(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                     )
                     sent_ok.append(email_addr)
                     await asyncio.sleep(1.5)
+                except ValueError as e:
+                    if "Unresolved placeholders" in str(e):
+                        await context.bot.send_message(
+                            chat_id=query.message.chat.id,
+                            text=(
+                                "⚠️ Шаблон содержит неподставленные плейсхолдеры "
+                                "(например, {{BODY}} или {BODY}). "
+                                "Исправьте шаблон и повторите отправку."
+                            ),
+                        )
+                        try:
+                            imap.logout()
+                        except Exception:
+                            pass
+                        return
+                    errors.append(f"{email_addr} — {e}")
                 except Exception as e:
                     errors.append(f"{email_addr} — {e}")
                     code, msg = None, None


### PR DESCRIPTION
## Summary
- add placeholder rendering helpers for text templates with a safe SIGNATURE default
- render SIGNATURE placeholders inside HTML templates and raise on unresolved tokens to avoid bad sends
- stop bulk sends and notify the operator when unresolved placeholders are detected during delivery

## Testing
- pytest tests/test_messaging.py::test_build_message_adds_signature_and_unsubscribe *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68e3b0d3ec208326bcb4c7ef9a978ae7