### PR TITLE
Add manual message routing and shared email parser

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -214,6 +214,13 @@ def main() -> None:
     app.add_handler(MessageHandler(filters.Document.ALL, bot_handlers.handle_document))
     app.add_handler(
         MessageHandler(
+            filters.TEXT & ~filters.COMMAND,
+            bot_handlers.route_text_message,
+        ),
+        group=5,
+    )
+    app.add_handler(
+        MessageHandler(
             filters.TEXT & (~filters.COMMAND), bot_handlers.corrections_text_handler
         )
     )
@@ -222,7 +229,13 @@ def main() -> None:
     )
 
     app.add_handler(
-        CallbackQueryHandler(bot_handlers.send_manual_email, pattern="^manual_group_")
+        CallbackQueryHandler(bot_handlers.manual_start, pattern="^manual$"), group=0
+    )
+    app.add_handler(
+        CallbackQueryHandler(
+            bot_handlers.manual_select_group, pattern="^manual_group_"
+        ),
+        group=0,
     )
     app.add_handler(
         CallbackQueryHandler(bot_handlers.proceed_to_group, pattern="^proceed_group$")

--- a/emailbot/messaging.py
+++ b/emailbot/messaging.py
@@ -41,6 +41,31 @@ from .messaging_utils import (
 
 logger = logging.getLogger(__name__)
 
+EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+
+
+def parse_emails_from_text(text: str) -> list[str]:
+    """Extract e-mail addresses from arbitrary text.
+
+    The parser accepts comma, semicolon, whitespace and newline separators, trims
+    surrounding punctuation, normalizes case and removes duplicates while
+    preserving order of first appearance.
+    """
+
+    if not text:
+        return []
+
+    found = EMAIL_RE.findall(text)
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for raw in found:
+        normalized = raw.strip().strip(",;").lower()
+        if not normalized or normalized in seen:
+            continue
+        cleaned.append(normalized)
+        seen.add(normalized)
+    return cleaned
+
 # Resolve the project root (one level above this file) and use shared
 # directories located at the repository root.
 from utils.paths import expand_path
@@ -916,6 +941,7 @@ __all__ = [
     "clear_recent_sent_cache",
     "get_sent_today",
     "count_sent_today",
+    "parse_emails_from_text",
     "prepare_mass_mailing",
     "sync_log_with_imap",
     "periodic_unsubscribe_check",


### PR DESCRIPTION
## Summary
- register manual inline callbacks and a text router so manual input goes through a dedicated flow
- add a reusable email parser in messaging utilities and wire manual selection through the shared filtering pipeline
- reuse a resilient batch sender for manual deliveries and reset manual session flags when finished

## Testing
- pytest tests/test_manual_flow_no_filters.py *(fails: ModuleNotFoundError: No module named 'aiohttp')*


------
https://chatgpt.com/codex/tasks/task_e_68e3bb3ab2f48326a45a0201fb8ea239