### PR TITLE
Enforce 180-day cooldown in manual mailings

### DIFF
--- a/emailbot/handlers/manual_send.py
+++ b/emailbot/handlers/manual_send.py
@@ -501,6 +501,7 @@ async def send_all(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                         fixed_from=fixed_map.get(email_addr),
                         group_title=template_label,
                         group_key=group_code,
+                        override_180d=(context.chat_data.get("manual_send_mode") == "all"),
                     )
                     if outcome == SendOutcome.SENT:
                         log_sent_email(

--- a/emailbot/services/cooldown.py
+++ b/emailbot/services/cooldown.py
@@ -29,7 +29,7 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
-COOLDOWN_DAYS = _env_int("COOLDOWN_DAYS", 180)
+COOLDOWN_DAYS = _env_int("COOLDOWN_DAYS", _env_int("SEND_COOLDOWN_DAYS", 180))
 _DEFAULT_SEND_STATS_PATH = expand_path("var/send_stats.jsonl")
 SEND_STATS_PATH = os.getenv("SEND_STATS_PATH", str(_DEFAULT_SEND_STATS_PATH))
 APPEND_TO_SENT = os.getenv("APPEND_TO_SENT", "1") == "1"
@@ -153,7 +153,14 @@ def mark_sent(email: str, *, sent_at: Optional[datetime] = None) -> None:
 def _cooldown_days(days: Optional[int]) -> int:
     if days is not None:
         return days
-    return _env_int("COOLDOWN_DAYS", COOLDOWN_DAYS)
+    # приоритет COOLDOWN_DAYS, но поддерживаем SEND_COOLDOWN_DAYS для совместимости
+    val = os.getenv("COOLDOWN_DAYS")
+    if val is not None and str(val).strip():
+        try:
+            return int(str(val).strip())
+        except Exception:
+            pass
+    return _env_int("SEND_COOLDOWN_DAYS", COOLDOWN_DAYS)
 
 
 def _append_to_sent_enabled() -> bool:

--- a/mailer/smtp_sender.py
+++ b/mailer/smtp_sender.py
@@ -12,7 +12,7 @@ from email.utils import getaddresses
 from smtplib import SMTPResponseException
 
 from emailbot.audit import write_audit_drop
-from emailbot.services.cooldown import COOLDOWN_DAYS, should_skip_by_cooldown
+from emailbot.services.cooldown import COOLDOWN_DAYS, should_skip_by_cooldown, mark_sent as cooldown_mark_sent
 from emailbot.history_service import (
     cancel_send_attempt,
     mark_sent,
@@ -219,6 +219,10 @@ def send_messages(messages: Iterable[EmailMessage], user: str, password: str, ho
                         run_id=run_id,
                         smtp_result="ok",
                     )
+                    try:
+                        cooldown_mark_sent(addr_norm)
+                    except Exception:
+                        logger.debug("cooldown mark_sent failed (non-fatal)", exc_info=True)
             except Exception:
                 logger.warning("history_registry_record_failed", exc_info=True)
 


### PR DESCRIPTION
## Summary
- add a shared SendOutcome enum and make the messaging helpers return structured status information with cooldown checks
- wire the manual sending flows to pass the override flag, surface cooldown/blocked outcomes, and persist cooldown state to the cache
- allow SEND_COOLDOWN_DAYS as an environment fallback for the cooldown service

## Testing
- pytest tests/test_messaging.py::test_send_email_batch_dedup *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68e3f0bb27bc83268b0185ad5fc6f14f