### PR TITLE
Handle sent log timezone and per-send entries

### DIFF
--- a/emailbot/handlers/manual_send.py
+++ b/emailbot/handlers/manual_send.py
@@ -493,7 +493,7 @@ async def send_all(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                     break
                 email_addr = to_send.pop(0)
                 try:
-                    outcome, token = send_email_with_sessions(
+                    outcome, token, log_key = send_email_with_sessions(
                         smtp,
                         imap,
                         sent_folder,
@@ -512,6 +512,7 @@ async def send_all(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                             chat_id,
                             template_path,
                             unsubscribe_token=token,
+                            key=log_key,
                         )
                         sent_ok.append(email_addr)
                         _audit(email_addr, "sent")

--- a/emailbot/settings.py
+++ b/emailbot/settings.py
@@ -22,6 +22,8 @@ EXTERNAL_SOURCES: dict[str, dict[str, dict[str, str]]] = {}
 # UI helpers
 SKIPPED_PREVIEW_LIMIT: int = int(os.getenv("SKIPPED_PREVIEW_LIMIT", "10"))
 LAST_SUMMARY_DIR: str = os.getenv("LAST_SUMMARY_DIR", "var/last_summaries")
+# Отчётная временная зона (используется в логах/отчётах)
+REPORT_TZ: str = (os.getenv("REPORT_TZ") or "Europe/Moscow").strip() or "Europe/Moscow"
 
 # Краулер: бюджеты и кэш
 CRAWL_MAX_PAGES_PER_DOMAIN = int(os.getenv("CRAWL_MAX_PAGES_PER_DOMAIN", "50"))
@@ -119,6 +121,7 @@ __all__ = [
     "EXTERNAL_SOURCES",
     "SKIPPED_PREVIEW_LIMIT",
     "LAST_SUMMARY_DIR",
+    "REPORT_TZ",
     "CRAWL_MAX_PAGES_PER_DOMAIN",
     "CRAWL_TIME_BUDGET_SECONDS",
     "ROBOTS_CACHE_PATH",

--- a/tests/test_bot_handlers.py
+++ b/tests/test_bot_handlers.py
@@ -435,7 +435,7 @@ def test_send_manual_email_uses_html_template(monkeypatch, tmp_path):
 
     def fake_send(client, imap, folder, addr, path, *a, **kw):
         sent_paths.append(path)
-        return SendOutcome.SENT, "tok"
+        return SendOutcome.SENT, "tok", "log"
 
     class DummyImap:
         def login(self, *a, **k):
@@ -568,7 +568,7 @@ async def test_manual_send_override_sets_flag(monkeypatch, tmp_path):
 
     def fake_send(client, imap, folder, addr, path, *a, **kw):
         overrides.append(kw.get("override_180d"))
-        return SendOutcome.SENT, "tok"
+        return SendOutcome.SENT, "tok", "log"
 
     class DummyImap:
         def login(self, *a, **k):
@@ -711,7 +711,7 @@ async def test_manual_send_selective_override(monkeypatch, tmp_path):
 
     def fake_send(client, imap, folder, addr, path, *a, **kw):
         overrides[addr] = kw.get("override_180d")
-        return SendOutcome.SENT, "tok"
+        return SendOutcome.SENT, "tok", f"key-{addr}"
 
     class DummyImap:
         def login(self, *a, **k):

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -3,6 +3,7 @@ import csv
 import logging
 import smtplib
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 from pathlib import Path
 
 import aiohttp
@@ -13,6 +14,7 @@ from emailbot import messaging
 from emailbot import unsubscribe
 from emailbot import messaging_utils as mu
 from emailbot.reporting import build_mass_report_text
+from emailbot.settings import REPORT_TZ
 
 
 @pytest.fixture(autouse=True)
@@ -97,10 +99,10 @@ def test_log_sent_email_records_entries(temp_files):
     assert len(rows) == 1
     row = rows[0]
     ts = datetime.fromisoformat(row["last_sent_at"])
-    now = datetime.now(timezone.utc)
-    if ts.tzinfo is None:
-        ts = ts.replace(tzinfo=timezone.utc)
-    assert abs((now - ts).total_seconds()) < 5
+    assert ts.tzinfo is not None
+    tz = ZoneInfo(REPORT_TZ)
+    now = datetime.now(tz)
+    assert abs((now.astimezone(timezone.utc) - ts.astimezone(timezone.utc)).total_seconds()) < 5
     assert row["email"] == "user@example.com"
     assert row["source"] == "group1"
     assert row["status"] == "ok"

--- a/tests/test_messaging_utils.py
+++ b/tests/test_messaging_utils.py
@@ -91,13 +91,15 @@ def test_schema_migration_from_legacy_headers(tmp_path):
 def test_upsert_idempotent(tmp_path):
     path = tmp_path / "sent_log.csv"
     ts = datetime(2023, 1, 1)
-    ins, upd = mu.upsert_sent_log(path, "Test@Example.com", ts, "src")
+    ins, upd = mu.upsert_sent_log(path, "Test@Example.com", ts, "src", key="k1")
     assert (ins, upd) == (True, False)
-    ins2, upd2 = mu.upsert_sent_log(path, "test@example.com", ts, "src")
-    assert (ins2, upd2) == (False, False)
+    ins2, upd2 = mu.upsert_sent_log(path, "test@example.com", ts, "src", key="k1")
+    assert (ins2, upd2) == (False, True)
+    ins3, upd3 = mu.upsert_sent_log(path, "test@example.com", ts, "src", key="k2")
+    assert (ins3, upd3) == (True, False)
     with path.open() as f:
         rows = list(csv.DictReader(f))
-    assert len(rows) == 1
+    assert len(rows) == 2
 
 
 def test_classify_tld():


### PR DESCRIPTION
## Summary
- add a `REPORT_TZ` setting and use it when computing Telegram bot report windows
- rewrite sent-log helpers to store timezone-aware timestamps, append unique entries, and dedupe only by explicit keys
- ensure session-based sends log each success and propagate the log key through handlers and updated tests

## Testing
- pytest tests/test_messaging.py tests/test_messaging_utils.py tests/test_bot_handlers.py *(fails: requires aiohttp dependency unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e52d569a088326ad586219104da5a3