### PR TITLE
Implement provider-specific email canonicalization and adaptive throttling

### DIFF
--- a/emailbot/bounce_detail.py
+++ b/emailbot/bounce_detail.py
@@ -1,0 +1,103 @@
+"""Bounce detail extraction and persistence utilities."""
+
+from __future__ import annotations
+
+import csv
+import os
+from datetime import datetime
+from email import message_from_bytes
+from email.message import Message
+from email.utils import getaddresses, parsedate_to_datetime
+from typing import Optional, Tuple
+from zoneinfo import ZoneInfo
+
+from .settings import REPORT_TZ, BOUNCE_DETAIL_PATH
+
+FIELDS = [
+    "ts_local",
+    "email",
+    "dsn_status",
+    "dsn_action",
+    "diagnostic",
+    "subject",
+    "message_id",
+]
+
+
+def ensure_bounce_detail_schema() -> None:
+    """Create CSV with header if it does not yet exist."""
+
+    if os.path.exists(BOUNCE_DETAIL_PATH):
+        return
+    with open(BOUNCE_DETAIL_PATH, "w", encoding="utf-8", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(FIELDS)
+
+
+def _extract_dsn_part(msg: Message) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    """Return ``(status, action, diagnostic)`` from DSN payload if available."""
+
+    if msg.get_content_type() == "message/delivery-status":
+        status = msg.get("Status")
+        action = msg.get("Action")
+        diagnostic = msg.get("Diagnostic-Code") or msg.get("X-Postfix-Sender-Notes")
+        return status, action, diagnostic
+    if msg.is_multipart():
+        for part in msg.get_payload():
+            status, action, diagnostic = _extract_dsn_part(part)
+            if status or action or diagnostic:
+                return status, action, diagnostic
+    return None, None, None
+
+
+def _first_to_address(msg: Message) -> Optional[str]:
+    candidates = msg.get_all("Final-Recipient") or msg.get_all("Original-Recipient")
+    if not candidates:
+        candidates = msg.get_all("To")
+    if not candidates:
+        return None
+    addresses = [addr for _, addr in getaddresses(candidates) if addr]
+    if not addresses:
+        return None
+    return addresses[0].lower()
+
+
+def parse_and_write_bounce_detail(raw_bytes: bytes) -> None:
+    """Parse DSN payload and append details to ``BOUNCE_DETAIL_PATH``."""
+
+    ensure_bounce_detail_schema()
+    tz = ZoneInfo(REPORT_TZ)
+    try:
+        msg = message_from_bytes(raw_bytes)
+    except Exception:
+        return
+    subject = (msg.get("Subject") or "").strip()
+    message_id = (msg.get("Message-Id") or "").strip()
+    ts_local = datetime.now(tz)
+    date_header = msg.get("Date")
+    if date_header:
+        try:
+            parsed = parsedate_to_datetime(date_header)
+            ts_local = parsed.replace(tzinfo=tz) if parsed.tzinfo is None else parsed.astimezone(tz)
+        except Exception:
+            pass
+    status, action, diagnostic = _extract_dsn_part(msg)
+    address = _first_to_address(msg) or ""
+    row = [
+        ts_local.isoformat(timespec="seconds"),
+        address,
+        (status or "").strip(),
+        (action or "").strip(),
+        (diagnostic or "").strip()[:500],
+        subject[:200],
+        message_id,
+    ]
+    try:
+        with open(BOUNCE_DETAIL_PATH, "a", encoding="utf-8", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(row)
+    except Exception:
+        pass
+
+
+__all__ = ["parse_and_write_bounce_detail", "ensure_bounce_detail_schema"]

--- a/emailbot/settings.py
+++ b/emailbot/settings.py
@@ -25,6 +25,21 @@ LAST_SUMMARY_DIR: str = os.getenv("LAST_SUMMARY_DIR", "var/last_summaries")
 # Отчётная временная зона (используется в логах/отчётах)
 REPORT_TZ: str = (os.getenv("REPORT_TZ") or "Europe/Moscow").strip() or "Europe/Moscow"
 
+# ---- Canonical e-mail rules ----
+ENABLE_PROVIDER_CANON: int = int(os.getenv("ENABLE_PROVIDER_CANON", "1"))
+CANON_GMAIL_DOTS: int = int(os.getenv("CANON_GMAIL_DOTS", "1"))
+CANON_GMAIL_PLUS: int = int(os.getenv("CANON_GMAIL_PLUS", "1"))
+CANON_OTHER_PLUS: int = int(os.getenv("CANON_OTHER_PLUS", "1"))
+
+# ---- Bounce details ----
+BOUNCE_DETAIL_PATH: str = os.getenv("BOUNCE_DETAIL_PATH", "var/bounce_detail.csv")
+
+# ---- Adaptive per-domain throttling ----
+BASE_DOMAIN_DELAY: float = float(os.getenv("BASE_DOMAIN_DELAY", "1.0"))
+BACKOFF_STEP_SECONDS: float = float(os.getenv("BACKOFF_STEP_SECONDS", "1.5"))
+BACKOFF_MAX_SECONDS: float = float(os.getenv("BACKOFF_MAX_SECONDS", "15.0"))
+BACKOFF_DECAY_SUCCESS: float = float(os.getenv("BACKOFF_DECAY_SUCCESS", "0.5"))
+
 # ---- Reconcile (IMAP vs CSV) ----
 RECONCILE_SINCE_DAYS: int = int(os.getenv("RECONCILE_SINCE_DAYS", "7"))
 
@@ -125,6 +140,15 @@ __all__ = [
     "SKIPPED_PREVIEW_LIMIT",
     "LAST_SUMMARY_DIR",
     "REPORT_TZ",
+    "ENABLE_PROVIDER_CANON",
+    "CANON_GMAIL_DOTS",
+    "CANON_GMAIL_PLUS",
+    "CANON_OTHER_PLUS",
+    "BOUNCE_DETAIL_PATH",
+    "BASE_DOMAIN_DELAY",
+    "BACKOFF_STEP_SECONDS",
+    "BACKOFF_MAX_SECONDS",
+    "BACKOFF_DECAY_SUCCESS",
     "RECONCILE_SINCE_DAYS",
     "CRAWL_MAX_PAGES_PER_DOMAIN",
     "CRAWL_TIME_BUDGET_SECONDS",

--- a/utils/email_canonical.py
+++ b/utils/email_canonical.py
@@ -1,0 +1,84 @@
+"""Utilities for provider-specific e-mail canonicalisation."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from email.utils import parseaddr
+from typing import Tuple
+
+import idna
+
+GMAIL_HOSTS = {"gmail.com", "googlemail.com"}
+YAHOO_HOSTS = {
+    "yahoo.com",
+    "yahoo.co.uk",
+    "yahoo.co.jp",
+    "ymail.com",
+    "rocketmail.com",
+}
+OUTLOOK_HOSTS = {
+    "outlook.com",
+    "hotmail.com",
+    "live.com",
+    "msn.com",
+    "outlook.co.uk",
+}
+
+_PLUS_TAG_RE = re.compile(r"\+[^@]+$")
+
+
+def _split(email: str) -> Tuple[str, str]:
+    """Return ``(local, domain)`` extracted from ``email``."""
+
+    _, addr = parseaddr(email or "")
+    addr = unicodedata.normalize("NFKC", (addr or "").strip().lower())
+    if "@" not in addr:
+        return addr, ""
+    local, domain = addr.split("@", 1)
+    try:
+        domain_ascii = idna.encode(domain).decode("ascii")
+    except Exception:
+        domain_ascii = domain
+    return local, domain_ascii
+
+
+def canonicalize_email(
+    email: str,
+    *,
+    gmail_dots: bool = True,
+    gmail_plus: bool = True,
+    other_plus: bool = True,
+) -> str:
+    """Return canonical representation suitable for deduplication.
+
+    Provider-specific rules supported:
+    * Gmail – optional removal of dots in the local part and ``+tag`` suffixes.
+    * Yahoo/Outlook – optional removal of ``+tag`` suffixes.
+    * Other domains – returned as-is with optional ``+tag`` stripping when
+      ``other_plus`` is ``True``.
+    """
+
+    if not email:
+        return ""
+    local, domain = _split(email)
+    if not domain:
+        return local
+
+    if domain in GMAIL_HOSTS:
+        if gmail_plus:
+            local = _PLUS_TAG_RE.sub("", local)
+        if gmail_dots:
+            local = local.replace(".", "")
+        domain = "gmail.com"
+    elif domain in YAHOO_HOSTS or domain in OUTLOOK_HOSTS:
+        if other_plus:
+            local = _PLUS_TAG_RE.sub("", local)
+    else:
+        if other_plus:
+            local = _PLUS_TAG_RE.sub("", local)
+
+    return unicodedata.normalize("NFKC", f"{local}@{domain}")
+
+
+__all__ = ["canonicalize_email"]


### PR DESCRIPTION
## Summary
- add configuration flags and utilities for provider-specific email canonicalization and bounce detail logging
- normalise send-history lookups with canonical keys and report-zone timestamps for daily and 180-day checks
- record bounce details and apply adaptive per-domain SMTP throttling with configurable backoff values

## Testing
- pytest tests/test_messaging.py::test_get_sent_today *(fails: ModuleNotFoundError: No module named 'aiohttp')*


------
https://chatgpt.com/codex/tasks/task_e_68e556c7e158832684abb93bdb2446d7