### PR TITLE
Centralize cooldown decisions on SQLite

### DIFF
--- a/email_bot.py
+++ b/email_bot.py
@@ -23,7 +23,7 @@ from telegram.ext import (
     filters,
 )
 
-from emailbot import bot_handlers, messaging
+from emailbot import bot_handlers, messaging, history_service
 from emailbot.config import ENABLE_INLINE_EMAIL_EDITOR
 from emailbot.messaging_utils import SecretFilter
 from emailbot.utils import load_env
@@ -130,6 +130,11 @@ async def error_handler(update: object, context: ContextTypes.DEFAULT_TYPE) -> N
 
 def main() -> None:
     load_env(SCRIPT_DIR)
+
+    try:
+        history_service.ensure_initialized()
+    except Exception:
+        logging.getLogger(__name__).debug("history init failed", exc_info=True)
 
     token = os.getenv("TELEGRAM_BOT_TOKEN", "")
     messaging.EMAIL_ADDRESS = os.getenv("EMAIL_ADDRESS", "")


### PR DESCRIPTION
## Summary
- rely exclusively on the SQLite history registry for cooldown checks and write every send via the cooldown cache into the shared history store
- record successful sends into the history service from both legacy messaging flows and the aiogram port while initializing the database on startup
- refactor cooldown tests to seed SQLite data directly instead of relying on send_stats exports

## Testing
- pytest tests/test_cooldown.py
- pytest tests/test_messaging.py *(fails: ModuleNotFoundError: No module named 'aiohttp')*

------
https://chatgpt.com/codex/tasks/task_e_68e58097e790832698cb0f324392e109