### PR TITLE
Improve batch send reporting and diagnostics

### DIFF
--- a/emailbot/ui/messages.py
+++ b/emailbot/ui/messages.py
@@ -53,6 +53,39 @@ def format_dispatch_preview(stats: Mapping[str, int], xlsx_name: str) -> str:
     )
 
 
+def format_dispatch_start(
+    planned: int,
+    unique: int,
+    to_send: int,
+    *,
+    deferred: int = 0,
+    suppressed: int = 0,
+    foreign: int = 0,
+    duplicates: int = 0,
+    limited_from: int | None = None,
+) -> str:
+    lines = [
+        "✉️ Рассылка начата.",
+        f"Запрошено: {planned}",
+        f"Уникальных: {unique}",
+    ]
+    if limited_from is not None and limited_from > to_send:
+        lines.append(
+            f"К отправке (после фильтров и лимитов): {to_send} из {limited_from}"
+        )
+    else:
+        lines.append(f"К отправке (после фильтров): {to_send}")
+    if deferred:
+        lines.append(f"Отложено по правилу 180 дней: {deferred}")
+    if suppressed:
+        lines.append(f"Исключено (супресс/блок-лист): {suppressed}")
+    if foreign:
+        lines.append(f"Отложено (иностранные домены): {foreign}")
+    if duplicates:
+        lines.append(f"Дубликаты в пачке: {duplicates}")
+    return "\n".join(lines)
+
+
 def format_dispatch_result(
     total: int,
     sent: int,


### PR DESCRIPTION
## Summary
- initialise and persist duplicate tracking in bulk send while announcing filtered counts via the new formatted start message
- warn in selfcheck when SMTP_HOST looks like an IMAP host and default to smtp.mail.ru
- limit the day report to the current REPORT_TZ date and show the timezone in the response

## Testing
- pytest tests/test_smtp_client_env.py

------
https://chatgpt.com/codex/tasks/task_e_68e6132a62d88326aff8a95254bfcdf5