### PR TITLE
Show skipped examples on demand and hide hidden-error notice

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -101,7 +101,7 @@ def build_after_parse_combined_kb(
     """
 
     rows: list[list[InlineKeyboardButton]] = [
-        [InlineKeyboardButton("👀 Показать ещё примеры", callback_data="refresh_preview")],
+        [InlineKeyboardButton("👀 Показать примеры", callback_data="refresh_preview")],
         [InlineKeyboardButton("🧭 Перейти к выбору направления", callback_data="proceed_group")],
         [InlineKeyboardButton("✏️ Отправить правки текстом", callback_data="bulk:txt:start")],
     ]
@@ -116,6 +116,14 @@ def build_after_parse_combined_kb(
     if extra_rows:
         rows.extend(extra_rows)
     return InlineKeyboardMarkup(rows)
+
+
+def build_skipped_preview_entry_kb() -> InlineKeyboardMarkup:
+    """Keyboard with a single entry button for skipped-address examples."""
+
+    return InlineKeyboardMarkup(
+        [[InlineKeyboardButton("👀 Показать примеры", callback_data="skipped_menu")]]
+    )
 
 
 def build_sections_suggest_kb(

--- a/email_bot.py
+++ b/email_bot.py
@@ -271,6 +271,9 @@ def main() -> None:
         CallbackQueryHandler(bot_handlers.refresh_preview, pattern="^refresh_preview$")
     )
     app.add_handler(
+        CallbackQueryHandler(bot_handlers.show_skipped_menu, pattern="^skipped_menu$")
+    )
+    app.add_handler(
         CallbackQueryHandler(bot_handlers.show_skipped_examples, pattern="^skipped:")
     )
     app.add_handler(

--- a/emailbot/ui/messages.py
+++ b/emailbot/ui/messages.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
-import re
-from collections import Counter
+
 from typing import Iterable, Mapping
 
 # Старый «приятный» стиль сообщений под Telegram (эмодзи + плотные подпункты).
 # Никакого HTML – чистый текст/Markdown-safe (aiogram parse_mode="HTML"/"MarkdownV2" на твой выбор).
+
 
 def format_parse_summary(s: Mapping[str, int], examples: Iterable[str] = ()) -> str:
     """
@@ -22,12 +22,6 @@ def format_parse_summary(s: Mapping[str, int], examples: Iterable[str] = ()) -> 
     lines.append(f"📄 Пропущено страниц: {s.get('pages_skipped', 0)}")
     lines.append(f"♻️ Возможные сносочные дубликаты удалены: {s.get('footnote_dupes_removed', 0)}")
     lines.append("")
-    ex = list(examples)
-    if ex:
-        lines.append("📝 Примеры:")
-        for e in ex[:10]:
-            lines.append(f"• {e}")
-        lines.append("")
     return "\n".join(lines)
 
 
@@ -104,35 +98,7 @@ def format_dispatch_result(
         lines.append(f"🔁 Дубликаты за 24 ч: {duplicates}")
     lines.append(f"ℹ️ Осталось без изменений: {left}")
     return "\n".join(lines)
-
-
-_EMAIL_RE = re.compile(r"(?i)[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}")
-
-
 def format_error_details(details: Iterable[str]) -> str:
-    """Format a summary of error reasons without exposing e-mail addresses."""
+    """Return an empty string to avoid sending hidden error summaries."""
 
-    sanitized: list[str] = []
-    for item in details:
-        text = str(item).strip()
-        if not text:
-            continue
-        sanitized.append(_EMAIL_RE.sub("[скрыто]", text))
-
-    if not sanitized:
-        return ""
-
-    counts = Counter(sanitized)
-    lines = ["Ошибки (адреса скрыты):"]
-    for reason, count in counts.most_common():
-        if not reason:
-            continue
-        if count > 1:
-            lines.append(f"• {reason} ×{count}")
-        else:
-            lines.append(f"• {reason}")
-
-    if len(lines) == 1:
-        lines.append(f"• Всего ошибок: {len(sanitized)}")
-
-    return "\n".join(lines)
+    return ""


### PR DESCRIPTION
## Summary
- stop including the “Примеры” block in the parse summary and rename the preview button to “Показать примеры”
- add an entry keyboard for skipped-address examples so the full filter set only appears after pressing “Показать примеры”
- suppress the “Ошибки (адреса скрыты)” follow-up message everywhere

## Testing
- pytest -q *(fails: missing optional dependencies and legacy modules during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68e62949085883269d0b08b7230c7aa5