### PR TITLE
Handle glued emails after letters and symbols

### DIFF
--- a/emailbot/text_normalize.py
+++ b/emailbot/text_normalize.py
@@ -24,13 +24,32 @@ def normalize_text_for_emails(text: str) -> str:
     # Остальные переносы превращаем в пробелы.
     text = re.sub(r"\s*\n\s*", " ", text)
 
-    # 2) Вставить пробел перед e-mail, если слева слово-символ вне ASCII-набора local-part.
-    text = re.sub(
-        r"(?:(?<=\w)(?<![A-Za-z0-9._%+\-]))(" + EMAIL_TOKEN + r")",
-        r" \1",
-        text,
-        flags=re.UNICODE,
-    )
+    # 2) Вставить пробел перед e-mail, если слева буква/цифра/закрывающий знак.
+    # Покрываем латиницу+кириллицу+цифры и частые «закрывающие» (скобки/кавычки/двоеточие/равно):
+    #   "Россияnik@site.ru"      → "Россия nik@site.ru"
+    #   ")ivanov@site.ru"        → ") ivanov@site.ru"
+    #   "E-mail:ivanov@site.ru"  → "E-mail: ivanov@site.ru"
+    closing_chars = {")", "]", "»", "”", "'", '"', ":", "="}
+    insert_positions = []
+    for match in re.finditer(EMAIL_TOKEN, text):
+        start = match.start()
+        if start == 0:
+            continue
+        prev_char = text[start - 1]
+        if prev_char.isspace():
+            continue
+        if prev_char.isalpha() or prev_char.isdigit() or prev_char in closing_chars:
+            insert_positions.append(start)
+
+    if insert_positions:
+        parts = []
+        last_idx = 0
+        for insert_idx in insert_positions:
+            parts.append(text[last_idx:insert_idx])
+            parts.append(" ")
+            last_idx = insert_idx
+        parts.append(text[last_idx:])
+        text = "".join(parts)
 
     # 3) Сжать множественные пробелы.
     text = re.sub(r"[ \t]{2,}", " ", text)

--- a/tests/test_text_normalize.py
+++ b/tests/test_text_normalize.py
@@ -14,3 +14,13 @@ def test_normalize_replaces_newlines_with_spaces():
 def test_normalize_inserts_space_before_email_token():
     raw = "Россияnik@example.com"
     assert normalize_text_for_emails(raw) == "Россия nik@example.com"
+
+
+def test_normalize_inserts_space_after_closing_symbols():
+    raw = ")ivanov@example.com"
+    assert normalize_text_for_emails(raw) == ") ivanov@example.com"
+
+
+def test_normalize_inserts_space_after_email_label():
+    raw = "E-mail:ivanov@example.com"
+    assert normalize_text_for_emails(raw) == "E-mail: ivanov@example.com"


### PR DESCRIPTION
## Summary
- insert spaces before email tokens when glued to letters, digits, or closing punctuation
- add unit tests that cover glued parentheses and label scenarios

## Testing
- pytest tests/test_text_normalize.py

------
https://chatgpt.com/codex/tasks/task_e_68e65109a0dc83268b9c89b10fbc87aa