### PR TITLE
Handle BOM in send stats reader

### DIFF
--- a/emailbot/reporting.py
+++ b/emailbot/reporting.py
@@ -432,8 +432,9 @@ def _iter_send_events(path: str | Path | None = None) -> Iterable[Mapping[str, o
 
     # Определяем вложенную функцию-генератор для ленивой обработки строк файла.
     def _gen() -> Iterable[Mapping[str, object]]:
-        # Открываем файл в кодировке UTF-8 для корректного чтения русских символов.
-        with stats_path.open("r", encoding="utf-8") as file_obj:
+        # Открываем файл в кодировке UTF-8 с поддержкой BOM, чтобы корректно
+        # обрабатывать как файлы без BOM, так и с BOM (utf-8-sig).
+        with stats_path.open("r", encoding="utf-8-sig") as file_obj:
             for line in file_obj:
                 # Удаляем перевод строки и пропускаем пустые строки.
                 stripped = line.strip()


### PR DESCRIPTION
## Summary
- adjust send stats reading to handle UTF-8 files that include a BOM

## Testing
- python -m py_compile emailbot/reporting.py
- python - <<'PY'
from pathlib import Path
from emailbot.reporting import _iter_send_events

# Создаем временный файл с BOM и одной записью JSON Lines.
tmp_path = Path('send_stats_test.jsonl')
tmp_content = '\ufeff{"key": "value"}\n{}\n\n'
tmp_path.write_text(tmp_content, encoding='utf-8-sig')

# Считываем события и выводим результат для проверки корректности декодирования.
print(list(_iter_send_events(tmp_path)))

# Удаляем временный файл после проверки.
tmp_path.unlink()
PY

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69283ef7c62483269cdf8b918846e138)