### PR TITLE
Add Telegram API IP override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -179,4 +179,7 @@ DEBUG_EMAIL_PARSE_LOG=0
 #########################################
 TEMPLATES_NEW_SIGNATURE=bioinformatics,geography,psychology
 
+# Optional: pin the Telegram Bot API to a working address when VPN DNS returns
+# an unreachable endpoint. TLS is still verified for api.telegram.org.
+# TELEGRAM_API_IP=149.154.167.220
 

--- a/email_bot.py
+++ b/email_bot.py
@@ -39,6 +39,8 @@ PROJECT_ROOT = Path(__file__).resolve().parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+from emailbot.telegram_network import configure_telegram_api_ip
+
 
 def _selfcheck_email_clean_exports() -> None:
     if os.getenv("EMAILBOT_SKIP_EMAIL_CLEAN_SELFTEST", "0") == "1":
@@ -284,6 +286,17 @@ def main() -> None:
         _die("Selfcheck failed:\n - " + "\n - ".join(errs))
 
     load_env(SCRIPT_DIR)
+
+    telegram_api_ip = os.getenv("TELEGRAM_API_IP", "").strip()
+    if telegram_api_ip:
+        try:
+            configured_ip = configure_telegram_api_ip(telegram_api_ip)
+        except ValueError:
+            _die("TELEGRAM_API_IP must contain one valid IP address.")
+        logging.getLogger(__name__).info(
+            "[BOOT] Telegram API DNS override enabled: api.telegram.org -> %s",
+            configured_ip,
+        )
 
     try:
         history_service.ensure_initialized()

--- a/emailbot/telegram_network.py
+++ b/emailbot/telegram_network.py
@@ -1,0 +1,68 @@
+"""Network workarounds for reaching the Telegram Bot API."""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+import threading
+from typing import Any
+
+TELEGRAM_API_HOST = "api.telegram.org"
+
+_ORIGINAL_GETADDRINFO = socket.getaddrinfo
+_LOCK = threading.Lock()
+_override_ip: str | None = None
+_installed = False
+
+
+def _normalized_host(host: Any) -> str:
+    if isinstance(host, bytes):
+        try:
+            host = host.decode("ascii")
+        except UnicodeDecodeError:
+            return ""
+    return str(host).rstrip(".").lower()
+
+
+def _telegram_getaddrinfo(
+    host: Any,
+    port: Any,
+    family: int = 0,
+    type: int = 0,
+    proto: int = 0,
+    flags: int = 0,
+):
+    forced_ip = _override_ip
+    if forced_ip and _normalized_host(host) == TELEGRAM_API_HOST:
+        return _ORIGINAL_GETADDRINFO(
+            forced_ip,
+            port,
+            family,
+            type,
+            proto,
+            flags,
+        )
+    return _ORIGINAL_GETADDRINFO(host, port, family, type, proto, flags)
+
+
+def configure_telegram_api_ip(value: str | None) -> str | None:
+    """Force only ``api.telegram.org`` to a configured IP address.
+
+    The request URL and TLS server name remain ``api.telegram.org``. Only the
+    DNS result used by this Python process is replaced.
+    """
+
+    raw = (value or "").strip()
+    if not raw:
+        return None
+
+    forced_ip = str(ipaddress.ip_address(raw))
+
+    global _installed, _override_ip
+    with _LOCK:
+        _override_ip = forced_ip
+        if not _installed:
+            socket.getaddrinfo = _telegram_getaddrinfo
+            _installed = True
+
+    return forced_ip

--- a/tests/test_telegram_network.py
+++ b/tests/test_telegram_network.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from emailbot import telegram_network
+
+
+def test_configure_telegram_api_ip_overrides_only_telegram(monkeypatch):
+    calls = []
+
+    def fake_getaddrinfo(host, port, family=0, type=0, proto=0, flags=0):
+        calls.append((host, port, family, type, proto, flags))
+        return [(family, type, proto, "", (str(host), port))]
+
+    monkeypatch.setattr(telegram_network, "_ORIGINAL_GETADDRINFO", fake_getaddrinfo)
+    monkeypatch.setattr(telegram_network, "_override_ip", None)
+    monkeypatch.setattr(telegram_network, "_installed", False)
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+    configured = telegram_network.configure_telegram_api_ip("149.154.167.220")
+
+    assert configured == "149.154.167.220"
+    socket.getaddrinfo("api.telegram.org", 443, socket.AF_INET)
+    socket.getaddrinfo("example.com", 443, socket.AF_INET)
+    assert calls[0][0] == "149.154.167.220"
+    assert calls[1][0] == "example.com"
+
+
+def test_configure_telegram_api_ip_rejects_invalid_address():
+    with pytest.raises(ValueError):
+        telegram_network.configure_telegram_api_ip("not-an-ip")


### PR DESCRIPTION
## What changed

- Added an optional `TELEGRAM_API_IP` setting for the Telegram Bot API.
- Kept the request hostname and TLS verification on `api.telegram.org` while overriding only DNS resolution inside the bot process.
- Added configuration documentation and focused unit tests.

## Why

With VLESS split tunneling enabled, the system DNS resolved `api.telegram.org` to `149.154.166.110`. The route entered the VPN tunnel, but TLS to that endpoint timed out. A different Telegram endpoint (`149.154.167.220`) was reachable and passed a real Bot API `getMe` request.

## Impact

The bot can pin a reachable Telegram API endpoint without modifying the Windows hosts file, disabling split tunneling, or weakening TLS certificate validation. Other applications and hostnames are unaffected.

The real `.env` remains local and is not included in this PR.

## Validation

- `pytest tests/test_telegram_network.py -q` — 2 passed.
- Real Telegram Bot API `getMe` request — succeeded (`TELEGRAM_GET_ME_OK`).
- Diff validation — exactly 4 files, 117 insertions, no whitespace errors.